### PR TITLE
Rename `from_` methods to `read_` methods

### DIFF
--- a/py-polars/pypolars/frame.py
+++ b/py-polars/pypolars/frame.py
@@ -34,7 +34,7 @@ class DataFrame:
         return self
 
     @staticmethod
-    def from_csv(
+    def read_csv(
         file: Union[str, TextIO],
         infer_schema_length: int = 100,
         batch_size: int = 100000,
@@ -62,13 +62,13 @@ class DataFrame:
         DataFrame
         """
         self = DataFrame.__new__(DataFrame)
-        self._df = PyDataFrame.from_csv(
+        self._df = PyDataFrame.read_csv(
             file, infer_schema_length, batch_size, has_headers, ignore_errors
         )
         return self
 
     @staticmethod
-    def from_parquet(
+    def read_parquet(
         file: Union[str, BinaryIO], batch_size: int = 250000,
     ) -> DataFrame:
         """
@@ -86,11 +86,11 @@ class DataFrame:
         DataFrame
         """
         self = DataFrame.__new__(DataFrame)
-        self._df = PyDataFrame.from_parquet(file, batch_size)
+        self._df = PyDataFrame.read_parquet(file, batch_size)
         return self
 
     @staticmethod
-    def from_ipc(file: Union[str, BinaryIO]) -> DataFrame:
+    def read_ipc(file: Union[str, BinaryIO]) -> DataFrame:
         """
         Read into a DataFrame from Arrow IPC stream format. This is also called the feather format.
 
@@ -104,11 +104,11 @@ class DataFrame:
         DataFrame
         """
         self = DataFrame.__new__(DataFrame)
-        self._df = PyDataFrame.from_ipc(file)
+        self._df = PyDataFrame.read_ipc(file)
         return self
 
     @staticmethod
-    def from_feather(file: Union[str, BinaryIO]) -> DataFrame:
+    def read_feather(file: Union[str, BinaryIO]) -> DataFrame:
         """
         Read into a DataFrame from Arrow IPC stream format. This is also called the feather format.
 
@@ -121,7 +121,7 @@ class DataFrame:
         -------
         DataFrame
         """
-        return DataFrame.from_ipc(file)
+        return DataFrame.read_ipc(file)
 
     def to_csv(
         self,

--- a/py-polars/src/dataframe.rs
+++ b/py-polars/src/dataframe.rs
@@ -30,7 +30,7 @@ impl PyDataFrame {
     }
 
     #[staticmethod]
-    pub fn from_csv(
+    pub fn read_csv(
         py_f: PyObject,
         infer_schema_length: usize,
         batch_size: usize,
@@ -53,7 +53,7 @@ impl PyDataFrame {
     }
 
     #[staticmethod]
-    pub fn from_parquet(py_f: PyObject, batch_size: usize) -> PyResult<Self> {
+    pub fn read_parquet(py_f: PyObject, batch_size: usize) -> PyResult<Self> {
         use EitherRustPythonFile::*;
         let result = match get_either_file(py_f, false)? {
             Py(f) => ParquetReader::new(f).with_batch_size(batch_size).finish(),
@@ -64,7 +64,7 @@ impl PyDataFrame {
     }
 
     #[staticmethod]
-    pub fn from_ipc(py_f: PyObject) -> PyResult<Self> {
+    pub fn read_ipc(py_f: PyObject) -> PyResult<Self> {
         let file = get_file_like(py_f, false)?;
         let df = IPCReader::new(file).finish().map_err(PyPolarsEr::from)?;
         Ok(PyDataFrame::new(df))

--- a/py-polars/tests/test_df.py
+++ b/py-polars/tests/test_df.py
@@ -163,13 +163,13 @@ def test_file_buffer():
     f = BytesIO()
     f.write(b"1,2,3,4,5,6\n1,2,3,4,5,6")
     f.seek(0)
-    df = DataFrame.from_csv(f, has_headers=False)
+    df = DataFrame.read_csv(f, has_headers=False)
     assert df.shape == (2, 6)
     f.seek(0)
 
     # check if not fails on TryClone and Length impl in file.rs
     with pytest.raises(RuntimeError) as e:
-        df.from_parquet(f)
+        df.read_parquet(f)
     assert "Invalid Parquet file" in str(e.value)
 
 


### PR DESCRIPTION
In Pandas, the `from_` methods are used to create a series/dataframe based on an in-memory data structure like `from_dict()`. `read_` methods are used to create a series/dataframe based on a file. Therefore I suggest to rename the `from_csv`, `from_parquet`, ... to `read_csv` etc.