### PR TITLE
Dynamic group by

### DIFF
--- a/polars/src/frame/group_by.rs
+++ b/polars/src/frame/group_by.rs
@@ -163,6 +163,45 @@ impl DataFrame {
     /// }
     /// ```
     pub fn groupby<'g, J, S: Selection<'g, J>>(&self, by: S) -> Result<GroupBy> {
+        macro_rules! static_zip {
+            ($selected_keys:ident, 0) => {
+                $selected_keys[0].as_groupable_iter()?
+            };
+            ($selected_keys:ident, 1) => {
+                static_zip!($selected_keys, 0).zip($selected_keys[1].as_groupable_iter()?)
+            };
+            ($selected_keys:ident, 2) => {
+                static_zip!($selected_keys, 1).zip($selected_keys[2].as_groupable_iter()?)
+            };
+            ($selected_keys:ident, 3) => {
+                static_zip!($selected_keys, 2).zip($selected_keys[3].as_groupable_iter()?)
+            };
+            ($selected_keys:ident, 4) => {
+                static_zip!($selected_keys, 3).zip($selected_keys[4].as_groupable_iter()?)
+            };
+            ($selected_keys:ident, 5) => {
+                static_zip!($selected_keys, 4).zip($selected_keys[5].as_groupable_iter()?)
+            };
+            ($selected_keys:ident, 6) => {
+                static_zip!($selected_keys, 5).zip($selected_keys[6].as_groupable_iter()?)
+            };
+            ($selected_keys:ident, 7) => {
+                static_zip!($selected_keys, 6).zip($selected_keys[7].as_groupable_iter()?)
+            };
+            ($selected_keys:ident, 8) => {
+                static_zip!($selected_keys, 7).zip($selected_keys[8].as_groupable_iter()?)
+            };
+            ($selected_keys:ident, 9) => {
+                static_zip!($selected_keys, 8).zip($selected_keys[9].as_groupable_iter()?)
+            };
+            ($selected_keys:ident, 10) => {
+                static_zip!($selected_keys, 9).zip($selected_keys[10].as_groupable_iter()?)
+            };
+            ($selected_keys:ident, 11) => {
+                static_zip!($selected_keys, 10).zip($selected_keys[11].as_groupable_iter()?)
+            };
+        }
+
         let selected_keys = self.select_series(by)?;
 
         let groups = match selected_keys.len() {
@@ -170,6 +209,17 @@ impl DataFrame {
                 let series = &selected_keys[0];
                 apply_method_all_series!(series, group_tuples,)
             }
+            2 => groupby(static_zip!(selected_keys, 1)),
+            3 => groupby(static_zip!(selected_keys, 2)),
+            4 => groupby(static_zip!(selected_keys, 3)),
+            5 => groupby(static_zip!(selected_keys, 4)),
+            6 => groupby(static_zip!(selected_keys, 5)),
+            7 => groupby(static_zip!(selected_keys, 6)),
+            8 => groupby(static_zip!(selected_keys, 7)),
+            9 => groupby(static_zip!(selected_keys, 8)),
+            10 => groupby(static_zip!(selected_keys, 9)),
+            11 => groupby(static_zip!(selected_keys, 10)),
+            12 => groupby(static_zip!(selected_keys, 11)),
             _ => {
                 let iter = selected_keys
                     .iter()
@@ -1817,7 +1867,7 @@ mod test {
 
         assert_eq!(
             Vec::from(adf.column("G4").unwrap().utf8().unwrap()),
-            &[Some("2"), Some("3"), Some("1"), Some("4")]
+            &[Some("2"), Some("3"), Some("1"), Some("2")]
         );
 
         assert_eq!(

--- a/polars/src/frame/group_by.rs
+++ b/polars/src/frame/group_by.rs
@@ -231,8 +231,6 @@ impl DataFrame {
             }
         };
 
-        println!("GROUPS: {:?}", groups);
-
         Ok(GroupBy {
             df: self,
             selected_keys,

--- a/polars/src/frame/group_by.rs
+++ b/polars/src/frame/group_by.rs
@@ -1776,4 +1776,58 @@ mod test {
             &[None, Some(3), None]
         );
     }
+
+    #[test]
+    fn test_groupby_by_6_columns() {
+        // Build GroupBy DataFrame.
+        let s0 = Series::new("G1", ["A", "A", "B", "B", "C"].as_ref());
+        let s1 = Series::new("N", [1, 2, 2, 4, 2].as_ref());
+        let s2 = Series::new("G2", ["k", "l", "m", "m", "l"].as_ref());
+        let s3 = Series::new("G3", ["a", "b", "c", "c", "d"].as_ref());
+        let s4 = Series::new("G4", ["1", "2", "3", "3", "4"].as_ref());
+        let s5 = Series::new("G5", ["X", "Y", "Z", "Z", "W"].as_ref());
+        let s6 = Series::new("G6", ["aa", "bb", "zz", "zz", "ww"].as_ref());
+        
+        let df = DataFrame::new(vec![s0, s1, s2, s3, s4, s5, s6]).unwrap();
+        println!("{:?}", df);
+
+        let adf = df.groupby(&["G1", "G2", "G3", "G4", "G5", "G6"])
+                .unwrap()
+                .select("N")
+                .sum()
+                .unwrap();
+
+        println!("{:?}", adf);
+
+        // Check that the result is the expected one.
+        assert_eq!(
+            Vec::from(adf.column("G1").unwrap().utf8().unwrap()),
+            &[Some("A"), Some("B"), Some("A"), Some("C")]
+        );
+
+        assert_eq!(
+            Vec::from(adf.column("G2").unwrap().utf8().unwrap()),
+            &[Some("l"), Some("m"), Some("k"), Some("l")]
+        );
+
+        assert_eq!(
+            Vec::from(adf.column("G3").unwrap().utf8().unwrap()),
+            &[Some("b"), Some("c"), Some("a"), Some("d")]
+        );
+
+        assert_eq!(
+            Vec::from(adf.column("G4").unwrap().utf8().unwrap()),
+            &[Some("2"), Some("3"), Some("1"), Some("4")]
+        );
+
+        assert_eq!(
+            Vec::from(adf.column("G5").unwrap().utf8().unwrap()),
+            &[Some("Y"), Some("Z"), Some("X"), Some("W")]
+        );
+
+        assert_eq!(
+            Vec::from(adf.column("G6").unwrap().utf8().unwrap()),
+            &[Some("bb"), Some("zz"), Some("aa"), Some("ww")]
+        );
+    }
 }

--- a/polars/src/frame/hash_join.rs
+++ b/polars/src/frame/hash_join.rs
@@ -103,7 +103,7 @@ pub(crate) fn prepare_hashed_relation<T>(
     b: impl Iterator<Item = T>,
 ) -> HashMap<T, Vec<usize>, FnvBuildHasher>
 where
-    T: Hash + Eq + Copy,
+    T: Hash + Eq,
 {
     let mut hash_tbl = FnvHashMap::default();
 

--- a/polars/src/utils.rs
+++ b/polars/src/utils.rs
@@ -62,6 +62,47 @@ pub fn get_iter_capacity<T, I: Iterator<Item = T>>(iter: &I) -> usize {
     }
 }
 
+/// An iterator that iterates an unknown at compile time number
+/// of iterators simultaneously.
+///
+/// IMPORTANT: It differs from `std::iter::Zip` in the return type
+/// of `next`. It returns a `Vec` instead of a `tuple`, which implies
+/// that the result is non-copiable anymore.
+pub struct DynamicZip<I>
+where
+    I: Iterator,
+{
+    iterators: Vec<I>,
+}
+
+impl<I, T> Iterator for DynamicZip<I>
+where
+    I: Iterator<Item = T>,
+{
+    type Item = Vec<T>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.iterators.iter_mut().map(|iter| iter.next()).collect()
+    }
+}
+
+/// A trait to convert a value to a `DynamicZip`.
+pub trait IntoDynamicZip<I>
+where
+    I: Iterator,
+{
+    fn into_dynamic_zip(self: Self) -> DynamicZip<I>;
+}
+
+impl<I> IntoDynamicZip<I> for Vec<I>
+where
+    I: Iterator,
+{
+    fn into_dynamic_zip(self: Self) -> DynamicZip<I> {
+        DynamicZip { iterators: self }
+    }
+}
+
 #[macro_export]
 macro_rules! match_arrow_data_type_apply_macro {
     ($obj:expr, $macro:ident, $macro_utf8:ident $(, $opt_args:expr)*) => {{


### PR DESCRIPTION
Added group by by an unlimited number of fields.
To achieve this a `DynamicZip` iterator has been added with the aim to let zip an unknown at compile time number of iterators.

WARNING: In contrast with `zip` method which returns a `tuple`, `DynamicZip` returns a `Vec`, that means that the return object is non-copyable. In order, to be able to implement the solution, the `Copy` constraint in `hash_join::prepare_hashed_relation` and `group_by::groupby`, so calls to this functions can incur in a move.

Also added test to check this new functionality, doing a group-by 6 fields and checking the result is the expected one.