### PR TITLE
Use `aHash` as faster hash algorithm

### DIFF
--- a/polars/Cargo.toml
+++ b/polars/Cargo.toml
@@ -38,6 +38,7 @@ ndarray = {version = "0.13", optional = true, default_features = false}
 regex = {version = "1.4" }
 anyhow = "1.0"
 seahash = "4.0.1"
+hashbrown = "0.9"
 csv = "1.1"
 lazy_static = "1.4"
 crossbeam = "0.8"

--- a/polars/Cargo.toml
+++ b/polars/Cargo.toml
@@ -37,8 +37,7 @@ rand_distr = {version = "0.3", optional = true}
 ndarray = {version = "0.13", optional = true, default_features = false}
 regex = {version = "1.4" }
 anyhow = "1.0"
-seahash = "4.0.1"
-hashbrown = "0.9"
+ahash = "0.5"
 csv = "1.1"
 lazy_static = "1.4"
 crossbeam = "0.8"

--- a/polars/benches/bench.rs
+++ b/polars/benches/bench.rs
@@ -60,7 +60,12 @@ fn bench_join_2_frames(b: &mut Bencher) {
 
     let df2 = DataFrame::new(vec![s2]).unwrap();
 
+    let mut sum = 0;
+
     b.iter(|| {
-        df1.inner_join(&df2, "id", "id");
+        let df3 = df1.inner_join(&df2, "id", "id").unwrap();
+        sum += df3.shape().1;
     });
+
+    println!("{}", sum)
 }

--- a/polars/benches/bench.rs
+++ b/polars/benches/bench.rs
@@ -50,3 +50,17 @@ fn bench_num_2_chunks(b: &mut Bencher) {
     });
     println!("{}", sum)
 }
+
+#[bench]
+fn bench_join_2_frames(b: &mut Bencher) {
+    let s1: Series = Series::new("id", (0u32..10000).collect::<Vec<u32>>());
+    let s2: Series = Series::new("id", (0u32..10000).collect::<Vec<u32>>());
+
+    let df1 = DataFrame::new(vec![s1]).unwrap();
+
+    let df2 = DataFrame::new(vec![s2]).unwrap();
+
+    b.iter(|| {
+        df1.inner_join(&df2, "id", "id");
+    });
+}

--- a/polars/benches/bench.rs
+++ b/polars/benches/bench.rs
@@ -1,6 +1,7 @@
 #![feature(test)]
 extern crate test;
 use polars::prelude::*;
+use std::iter;
 use test::Bencher;
 
 #[bench]
@@ -68,4 +69,17 @@ fn bench_join_2_frames(b: &mut Bencher) {
     });
 
     println!("{}", sum)
+}
+
+#[bench]
+fn bench_group_by(b: &mut Bencher) {
+    let s1: Series = Series::new("item", (0u32..10000).collect::<Vec<u32>>());
+    let s2: Series = Series::new("group", iter::repeat(0).take(10000).collect::<Vec<u32>>());
+
+
+    let df1 = DataFrame::new(vec![s1, s2]).unwrap();
+
+    b.iter(|| {
+        df1.groupby("group").unwrap().select("item").sum().unwrap();
+    });
 }

--- a/polars/benches/bench.rs
+++ b/polars/benches/bench.rs
@@ -76,7 +76,6 @@ fn bench_group_by(b: &mut Bencher) {
     let s1: Series = Series::new("item", (0u32..10000).collect::<Vec<u32>>());
     let s2: Series = Series::new("group", iter::repeat(0).take(10000).collect::<Vec<u32>>());
 
-
     let df1 = DataFrame::new(vec![s1, s2]).unwrap();
 
     b.iter(|| {

--- a/polars/src/chunked_array/ops/unique.rs
+++ b/polars/src/chunked_array/ops/unique.rs
@@ -1,10 +1,10 @@
 use crate::prelude::*;
 use crate::utils::{floating_encode_f64, integer_decode_f64};
 use crate::{chunked_array::float::IntegerDecode, frame::group_by::IntoGroupTuples};
+use ahash::RandomState;
 use num::{NumCast, ToPrimitive};
-use ahash::{RandomState};
 use std::collections::{HashMap, HashSet};
-use std::hash::{Hash};
+use std::hash::Hash;
 
 pub(crate) fn is_unique_helper(
     groups: impl Iterator<Item = (usize, Vec<usize>)>,
@@ -66,10 +66,7 @@ impl ChunkUnique<ListType> for ListChunked {
     }
 }
 
-fn fill_set<A>(
-    a: impl Iterator<Item = A>,
-    capacity: usize,
-) -> HashSet<A, RandomState>
+fn fill_set<A>(a: impl Iterator<Item = A>, capacity: usize) -> HashSet<A, RandomState>
 where
     A: Hash + Eq,
 {
@@ -86,8 +83,7 @@ fn arg_unique<T>(a: impl Iterator<Item = T>, capacity: usize) -> Vec<usize>
 where
     T: Hash + Eq,
 {
-    let mut set =
-        HashSet::with_capacity_and_hasher(capacity, RandomState::new());
+    let mut set = HashSet::with_capacity_and_hasher(capacity, RandomState::new());
     let mut unique = Vec::with_capacity(capacity);
     a.enumerate().for_each(|(idx, val)| {
         if set.insert(val) {

--- a/polars/src/chunked_array/ops/unique.rs
+++ b/polars/src/chunked_array/ops/unique.rs
@@ -2,9 +2,9 @@ use crate::prelude::*;
 use crate::utils::{floating_encode_f64, integer_decode_f64};
 use crate::{chunked_array::float::IntegerDecode, frame::group_by::IntoGroupTuples};
 use num::{NumCast, ToPrimitive};
-use seahash::SeaHasher;
+use ahash::{RandomState};
 use std::collections::{HashMap, HashSet};
-use std::hash::{BuildHasherDefault, Hash};
+use std::hash::{Hash};
 
 pub(crate) fn is_unique_helper(
     groups: impl Iterator<Item = (usize, Vec<usize>)>,
@@ -69,11 +69,11 @@ impl ChunkUnique<ListType> for ListChunked {
 fn fill_set<A>(
     a: impl Iterator<Item = A>,
     capacity: usize,
-) -> HashSet<A, BuildHasherDefault<SeaHasher>>
+) -> HashSet<A, RandomState>
 where
     A: Hash + Eq,
 {
-    let mut set = HashSet::with_capacity_and_hasher(capacity, BuildHasherDefault::default());
+    let mut set = HashSet::with_capacity_and_hasher(capacity, RandomState::new());
 
     for val in a {
         set.insert(val);
@@ -87,7 +87,7 @@ where
     T: Hash + Eq,
 {
     let mut set =
-        HashSet::with_capacity_and_hasher(capacity, BuildHasherDefault::<SeaHasher>::default());
+        HashSet::with_capacity_and_hasher(capacity, RandomState::new());
     let mut unique = Vec::with_capacity(capacity);
     a.enumerate().for_each(|(idx, val)| {
         if set.insert(val) {
@@ -273,17 +273,17 @@ pub trait ValueCounts<T>
 where
     T: ArrowPrimitiveType,
 {
-    fn value_counts(&self) -> HashMap<Option<T::Native>, u32, BuildHasherDefault<SeaHasher>>;
+    fn value_counts(&self) -> HashMap<Option<T::Native>, u32, RandomState>;
 }
 
 fn fill_set_value_count<K>(
     a: impl Iterator<Item = K>,
     capacity: usize,
-) -> HashMap<K, u32, BuildHasherDefault<SeaHasher>>
+) -> HashMap<K, u32, RandomState>
 where
     K: Hash + Eq,
 {
-    let mut kv_store = HashMap::with_capacity_and_hasher(capacity, BuildHasherDefault::default());
+    let mut kv_store = HashMap::with_capacity_and_hasher(capacity, RandomState::new());
 
     for key in a {
         let count = kv_store.entry(key).or_insert(0);
@@ -299,7 +299,7 @@ where
     T::Native: Hash + Eq,
     ChunkedArray<T>: ChunkOps,
 {
-    fn value_counts(&self) -> HashMap<Option<T::Native>, u32, BuildHasherDefault<SeaHasher>> {
+    fn value_counts(&self) -> HashMap<Option<T::Native>, u32, RandomState> {
         match self.null_count() {
             0 => fill_set_value_count(self.into_no_null_iter().map(|v| Some(v)), self.len()),
             _ => fill_set_value_count(self.into_iter(), self.len()),

--- a/polars/src/frame/group_by.rs
+++ b/polars/src/frame/group_by.rs
@@ -3,15 +3,13 @@ use crate::chunked_array::{builder::PrimitiveChunkedBuilder, float::IntegerDecod
 use crate::frame::select::Selection;
 use crate::prelude::*;
 use crate::utils::{IntoDynamicZip, Xob};
+use ahash::RandomState;
 use arrow::array::{PrimitiveBuilder, StringBuilder};
 use itertools::Itertools;
 use num::{Num, NumCast, ToPrimitive, Zero};
 use rayon::prelude::*;
-use seahash::SeaHasher;
 use std::collections::{HashMap, HashSet};
-use std::hash::{BuildHasherDefault, Hash};
-
-type SeaBuildHasher = BuildHasherDefault<SeaHasher>;
+use std::hash::Hash;
 
 use std::{
     fmt::{Debug, Formatter},
@@ -582,14 +580,14 @@ macro_rules! impl_agg_n_unique {
             .into_par_iter()
             .map(|(_first, idx)| {
                 if $self.null_count() == 0 {
-                    let mut set = HashSet::with_hasher(SeaBuildHasher::default());
+                    let mut set = HashSet::with_hasher(RandomState::new());
                     for i in idx {
                         let v = unsafe { $self.get_unchecked(*i) };
                         set.insert(v);
                     }
                     set.len() as u32
                 } else {
-                    let mut set = HashSet::with_hasher(SeaBuildHasher::default());
+                    let mut set = HashSet::with_hasher(RandomState::new());
                     for i in idx {
                         let opt_v = $self.get(*i);
                         set.insert(opt_v);
@@ -1219,8 +1217,7 @@ impl<'df, 'selection_str> GroupBy<'df, 'selection_str> {
         Column: AsRef<str>,
     {
         // create a mapping from columns to aggregations on that column
-        let mut map =
-            HashMap::with_capacity_and_hasher(column_to_agg.len(), SeaBuildHasher::default());
+        let mut map = HashMap::with_capacity_and_hasher(column_to_agg.len(), RandomState::new());
         column_to_agg
             .into_iter()
             .for_each(|(column, aggregations)| {
@@ -1501,8 +1498,8 @@ trait ChunkPivot {
 fn create_column_values_map<'a, T>(
     pivot_vec: &'a [Option<Groupable>],
     size: usize,
-) -> HashMap<&'a Groupable<'a>, Vec<Option<T>>, SeaBuildHasher> {
-    let mut columns_agg_map = HashMap::with_capacity_and_hasher(size, SeaBuildHasher::default());
+) -> HashMap<&'a Groupable<'a>, Vec<Option<T>>, RandomState> {
+    let mut columns_agg_map = HashMap::with_capacity_and_hasher(size, RandomState::new());
     for opt_column_name in pivot_vec {
         if let Some(column_name) = opt_column_name {
             columns_agg_map
@@ -1518,13 +1515,13 @@ fn create_column_values_map<'a, T>(
 fn create_new_column_builder_map<'a, T>(
     pivot_vec: &'a [Option<Groupable>],
     groups: &[(usize, Vec<usize>)],
-) -> HashMap<&'a Groupable<'a>, PrimitiveChunkedBuilder<T>, SeaBuildHasher>
+) -> HashMap<&'a Groupable<'a>, PrimitiveChunkedBuilder<T>, RandomState>
 where
     T: PolarsNumericType,
 {
     // create a hash map that will be filled with the results of the aggregation.
     let mut columns_agg_map_main =
-        HashMap::with_capacity_and_hasher(pivot_vec.len(), SeaBuildHasher::default());
+        HashMap::with_capacity_and_hasher(pivot_vec.len(), RandomState::new());
     for opt_column_name in pivot_vec {
         if let Some(column_name) = opt_column_name {
             columns_agg_map_main.entry(column_name).or_insert_with(|| {

--- a/polars/src/frame/hash_join.rs
+++ b/polars/src/frame/hash_join.rs
@@ -1,12 +1,9 @@
 use crate::prelude::*;
 use crate::utils::Xob;
-use hashbrown::HashMap;
-use seahash::SeaHasher;
-use std::collections::HashSet;
-use std::hash::{BuildHasherDefault, Hash};
+use ahash::{RandomState};
+use std::collections::{HashMap, HashSet};
+use std::hash::Hash;
 use unsafe_unwrap::UnsafeUnwrap;
-
-type SeaBuildHasher = BuildHasherDefault<SeaHasher>;
 
 macro_rules! hash_join_inner {
     ($s_right:ident, $ca_left:ident, $type_:ident) => {{
@@ -84,11 +81,14 @@ macro_rules! apply_hash_join_on_series {
     }};
 }
 
-pub(crate) fn prepare_hashed_relation<T>(b: impl Iterator<Item = T>) -> HashMap<T, Vec<usize>>
+pub(crate) fn prepare_hashed_relation<T>(
+    b: impl Iterator<Item = T>,
+) -> HashMap<T, Vec<usize>, RandomState>
 where
     T: Hash + Eq,
 {
-    let mut hash_tbl = HashMap::with_capacity(b.size_hint().0 / 10);
+    let mut hash_tbl: HashMap<T, Vec<usize>, ahash::RandomState> =
+        HashMap::with_capacity_and_hasher(b.size_hint().0 / 10, RandomState::new());
 
     b.enumerate()
         .for_each(|(idx, key)| hash_tbl.entry(key).or_insert_with(Vec::new).push(idx));
@@ -456,7 +456,7 @@ impl DataFrame {
     /// Utility method to finish a join.
     fn finish_join(&self, mut df_left: DataFrame, mut df_right: DataFrame) -> Result<DataFrame> {
         let mut left_names =
-            HashSet::with_capacity_and_hasher(df_left.width(), SeaBuildHasher::default());
+            HashSet::with_capacity_and_hasher(df_left.width(), RandomState::new());
 
         df_left.columns.iter().for_each(|series| {
             left_names.insert(series.name());

--- a/polars/src/frame/hash_join.rs
+++ b/polars/src/frame/hash_join.rs
@@ -1,6 +1,6 @@
 use crate::prelude::*;
 use crate::utils::Xob;
-use ahash::{RandomState};
+use ahash::RandomState;
 use std::collections::{HashMap, HashSet};
 use std::hash::Hash;
 use unsafe_unwrap::UnsafeUnwrap;
@@ -455,8 +455,7 @@ impl_zip_outer_join!(Utf8Chunked);
 impl DataFrame {
     /// Utility method to finish a join.
     fn finish_join(&self, mut df_left: DataFrame, mut df_right: DataFrame) -> Result<DataFrame> {
-        let mut left_names =
-            HashSet::with_capacity_and_hasher(df_left.width(), RandomState::new());
+        let mut left_names = HashSet::with_capacity_and_hasher(df_left.width(), RandomState::new());
 
         df_left.columns.iter().for_each(|series| {
             left_names.insert(series.name());

--- a/polars/src/frame/hash_join.rs
+++ b/polars/src/frame/hash_join.rs
@@ -1,7 +1,8 @@
 use crate::prelude::*;
 use crate::utils::Xob;
+use hashbrown::HashMap;
 use seahash::SeaHasher;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::hash::{BuildHasherDefault, Hash};
 use unsafe_unwrap::UnsafeUnwrap;
 
@@ -83,14 +84,11 @@ macro_rules! apply_hash_join_on_series {
     }};
 }
 
-pub(crate) fn prepare_hashed_relation<T>(
-    b: impl Iterator<Item = T>,
-) -> HashMap<T, Vec<usize>, SeaBuildHasher>
+pub(crate) fn prepare_hashed_relation<T>(b: impl Iterator<Item = T>) -> HashMap<T, Vec<usize>>
 where
     T: Hash + Eq,
 {
-    let mut hash_tbl =
-        HashMap::with_capacity_and_hasher(b.size_hint().0 / 10, BuildHasherDefault::default());
+    let mut hash_tbl = HashMap::with_capacity(b.size_hint().0 / 10);
 
     b.enumerate()
         .for_each(|(idx, key)| hash_tbl.entry(key).or_insert_with(Vec::new).push(idx));

--- a/polars/src/frame/ser/fork/csv.rs
+++ b/polars/src/frame/ser/fork/csv.rs
@@ -17,6 +17,7 @@
 
 use crate::frame::ser::csv::CsvEncoding;
 use crate::prelude::*;
+use ahash::RandomState;
 use arrow::datatypes::SchemaRef;
 use arrow::error::Result as ArrowResult;
 use crossbeam::{channel::bounded, thread};
@@ -24,10 +25,8 @@ use csv::{ByteRecord, ByteRecordsIntoIter};
 use lazy_static::lazy_static;
 use rayon::prelude::*;
 use regex::{Regex, RegexBuilder};
-use seahash::SeaHasher;
 use std::collections::HashSet;
 use std::fmt;
-use std::hash::BuildHasherDefault;
 use std::io::{Read, Seek, SeekFrom};
 use std::sync::Arc;
 
@@ -92,8 +91,8 @@ fn infer_file_schema<R: Read + Seek>(
 
     let header_length = headers.len();
     // keep track of inferred field types
-    let mut column_types: Vec<HashSet<ArrowDataType, BuildHasherDefault<SeaHasher>>> =
-        vec![HashSet::with_hasher(BuildHasherDefault::default()); header_length];
+    let mut column_types: Vec<HashSet<ArrowDataType, RandomState>> =
+        vec![HashSet::with_hasher(RandomState::new()); header_length];
     // keep track of columns with nulls
     let mut nulls: Vec<bool> = vec![false; header_length];
 


### PR DESCRIPTION
This switches the hash join to use https://github.com/rust-lang/hashbrown as hash map.

Added a small benchmark:

Before:

```
test bench_join_2_frames ... bench:   1,722,155 ns/iter (+/- 88,679)
```

After:

```
test bench_join_2_frames ... bench:   1,030,084 ns/iter (+/- 153,604)
```
