### PR TITLE
Replace FnvHashMap with default hashmap + aHash

### DIFF
--- a/polars/Cargo.toml
+++ b/polars/Cargo.toml
@@ -25,7 +25,6 @@ strings = []
 arrow = {version = "2", default_features = false}
 thiserror = "^1.0.16"
 num = "^0.2.1"
-fnv = "^1.0.7"
 itertools = "^0.9.0"
 unsafe_unwrap = "^0.1.0"
 rayon = "1.5"

--- a/polars/src/lazy/logical_plan/mod.rs
+++ b/polars/src/lazy/logical_plan/mod.rs
@@ -5,8 +5,9 @@ use crate::{
     lazy::{prelude::*, utils},
     prelude::*,
 };
+use ahash::RandomState;
 use arrow::datatypes::DataType;
-use fnv::FnvHashSet;
+use std::collections::HashSet;
 use std::sync::Mutex;
 use std::{fmt, sync::Arc};
 
@@ -477,7 +478,7 @@ impl LogicalPlanBuilder {
         let schema_right = other.schema();
 
         // column names of left table
-        let mut names = FnvHashSet::default();
+        let mut names: HashSet<&String, RandomState> = HashSet::default();
         // fields of new schema
         let mut fields = vec![];
 

--- a/polars/src/lazy/logical_plan/optimizer/predicate.rs
+++ b/polars/src/lazy/logical_plan/optimizer/predicate.rs
@@ -2,16 +2,15 @@ use crate::lazy::logical_plan::optimizer::check_down_node;
 use crate::lazy::prelude::*;
 use crate::lazy::utils::{count_downtree_projections, expr_to_root_column, rename_expr_root_name};
 use crate::prelude::*;
-use fnv::{FnvBuildHasher, FnvHashMap};
+use ahash::RandomState;
 use std::collections::HashMap;
 use std::sync::Arc;
-
 // arbitrary constant to reduce reallocation.
 // don't expect more than 100 predicates.
 const HASHMAP_SIZE: usize = 100;
 
-fn init_hashmap<K, V>() -> HashMap<K, V, FnvBuildHasher> {
-    FnvHashMap::with_capacity_and_hasher(HASHMAP_SIZE, FnvBuildHasher::default())
+fn init_hashmap<K, V>() -> HashMap<K, V, RandomState> {
+    HashMap::with_capacity_and_hasher(HASHMAP_SIZE, RandomState::new())
 }
 
 pub struct PredicatePushDown {}
@@ -34,7 +33,7 @@ impl PredicatePushDown {
     fn finish_at_leaf(
         &self,
         lp: LogicalPlan,
-        acc_predicates: FnvHashMap<Arc<String>, Expr>,
+        acc_predicates: HashMap<Arc<String>, Expr, RandomState>,
     ) -> Result<LogicalPlan> {
         match acc_predicates.len() {
             // No filter in the logical plan
@@ -67,7 +66,7 @@ impl PredicatePushDown {
     fn push_down(
         &self,
         logical_plan: LogicalPlan,
-        mut acc_predicates: FnvHashMap<Arc<String>, Expr>,
+        mut acc_predicates: HashMap<Arc<String>, Expr, RandomState>,
     ) -> Result<LogicalPlan> {
         use LogicalPlan::*;
 
@@ -86,10 +85,7 @@ impl PredicatePushDown {
                 if count_downtree_projections(&input, 0) == 0 {
                     let builder = LogicalPlanBuilder::from(self.push_down(
                         *input,
-                        FnvHashMap::with_capacity_and_hasher(
-                            HASHMAP_SIZE,
-                            FnvBuildHasher::default(),
-                        ),
+                        HashMap::with_capacity_and_hasher(HASHMAP_SIZE, RandomState::new()),
                     )?)
                     .project(expr);
                     // todo! write utility that takes hashmap values by value
@@ -213,9 +209,9 @@ impl PredicatePushDown {
     /// Check if a predicate can be pushed down or not. If it cannot remove it from the accumulated predicates.
     fn split_pushdown_and_local(
         &self,
-        mut acc_predicates: FnvHashMap<Arc<String>, Expr>,
+        mut acc_predicates: HashMap<Arc<String>, Expr, RandomState>,
         schema: &Schema,
-    ) -> (Vec<Expr>, FnvHashMap<Arc<String>, Expr>) {
+    ) -> (Vec<Expr>, HashMap<Arc<String>, Expr, RandomState>) {
         let mut local = Vec::with_capacity(acc_predicates.len());
         let mut local_keys = Vec::with_capacity(acc_predicates.len());
         for (key, predicate) in &acc_predicates {
@@ -234,7 +230,7 @@ impl Optimize for PredicatePushDown {
     fn optimize(&self, logical_plan: LogicalPlan) -> Result<LogicalPlan> {
         self.push_down(
             logical_plan,
-            FnvHashMap::with_capacity_and_hasher(HASHMAP_SIZE, FnvBuildHasher::default()),
+            HashMap::with_capacity_and_hasher(HASHMAP_SIZE, RandomState::new()),
         )
     }
 }

--- a/polars/src/lazy/logical_plan/optimizer/projection.rs
+++ b/polars/src/lazy/logical_plan/optimizer/projection.rs
@@ -5,9 +5,9 @@ use crate::lazy::utils::{
     projected_names,
 };
 use crate::prelude::*;
+use ahash::RandomState;
 use arrow::datatypes::Schema;
-use fnv::{FnvBuildHasher, FnvHashSet};
-
+use std::collections::HashSet;
 fn init_vec() -> Vec<Expr> {
     Vec::with_capacity(100)
 }
@@ -161,9 +161,9 @@ impl ProjectionPushDown {
                     // todo! remove aggregations that aren't selected?
                     let root_projections = expressions_to_root_column_exprs(&aggs)?;
 
-                    let mut names = FnvHashSet::with_capacity_and_hasher(
+                    let mut names = HashSet::with_capacity_and_hasher(
                         acc_projections.len(),
-                        FnvBuildHasher::default(),
+                        RandomState::new(),
                     );
                     for proj in &acc_projections {
                         let name = expr_to_root_column(proj)?;


### PR DESCRIPTION
This should likely not have any performance impact I guess (as it is only building the column names), but removes the dependency on `fnv` 