### PR TITLE
Run build & test on every PR/push

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -1,12 +1,9 @@
-name: Build, test and docs
+name: Build and test
 
-on:
-  push:
-    branches:
-      - master
+on: push
 jobs:
   test:
-    name: Build, test and docs
+    name: Build and test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -10,7 +10,7 @@ jobs:
       - name: Install latest Rust nightly
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2020-10-09
+          toolchain: nightly-2020-11-12
           override: true
           components: rustfmt, clippy
       - name: Set up Python

--- a/.github/workflows/create-py-release-test.yaml
+++ b/.github/workflows/create-py-release-test.yaml
@@ -17,7 +17,7 @@ jobs:
         - name: Install latest Rust nightly
           uses: actions-rs/toolchain@v1
           with:
-            toolchain: nightly-2020-10-09
+            toolchain: nightly-2020-11-12
             override: true
             components: rustfmt, clippy
         - name: Set up Python

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -20,6 +20,10 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.7
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pdoc3 ghp-import
       - name: deploy docs
         run: |
           cargo doc --no-deps --all-features --package polars \

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,0 +1,30 @@
+name: Docs
+
+on:
+  push:
+    branches:
+      - master
+jobs:
+  test:
+    name: Docs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install latest Rust nightly
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly-2020-10-09
+          override: true
+          components: rustfmt, clippy
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+      - name: deploy docs
+        run: |
+          cargo doc --no-deps --all-features --package polars \
+          && echo '<meta http-equiv=refresh content=0;url=polars/index.html>' > target/doc/index.html && \
+          pdoc --html py-polars/pypolars/ && \
+          mv html/pypolars target/doc/pypolars && \
+          ghp-import -n target/doc && \
+          git push -qf https://${{ secrets.GITHUB_TOKEN }}@github.com/${GITHUB_REPOSITORY}.git gh-pages

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: Install latest Rust nightly
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2020-10-09
+          toolchain: nightly-2020-11-12
           override: true
           components: rustfmt, clippy
       - name: Set up Python

--- a/.github/workflows/test-windows.yaml
+++ b/.github/workflows/test-windows.yaml
@@ -1,9 +1,6 @@
 name: Windows tests
 
-on:
-  push:
-    branches:
-      - master
+on: push
 jobs:
   test:
     runs-on: windows-latest
@@ -12,7 +9,7 @@ jobs:
       - name: Install latest Rust nightly
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2020-10-09
+          toolchain: nightly-2020-11-12
           override: true
       - name: Run tests
         run: |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Polars
 [![rust docs](https://docs.rs/polars/badge.svg)](https://docs.rs/polars/latest/polars/)
-![Build, test and docs](https://github.com/ritchie46/polars/workflows/Build,%20test%20and%20docs/badge.svg)
+![Build, test and docs](https://github.com/ritchie46/polars/workflows/Build%20and%20test%/badge.svg)
 [![](http://meritbadge.herokuapp.com/polars)](https://crates.io/crates/polars)
 [![Gitter](https://badges.gitter.im/polars-rs/community.svg)](https://gitter.im/polars-rs/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 


### PR DESCRIPTION
So PRs can be checked as well. (currently builds are failing on master?)
Also makes windows test run on every push  and update rust version.

This makes it for easier to start for new contributors and reduce the risk for introducing bugs.

If clippy lint errors are reduced to 0, this could be added as well.