### PR TITLE
Optimizer: Separate recursion & matching, run until reaching fixed point

### DIFF
--- a/polars/src/lazy/logical_plan/optimizer/simplify_expr.rs
+++ b/polars/src/lazy/logical_plan/optimizer/simplify_expr.rs
@@ -112,8 +112,7 @@ impl SimplifyOptimizer {
                         plans.push(input);
                         exprs.extend(e2);
                     }
-                    CsvScan { .. } => {}
-                    DataFrameScan { .. } => {}
+                    CsvScan { .. } | DataFrameScan { .. } => {}
                 }
 
                 while let Some(expr) = exprs.pop() {
@@ -181,7 +180,6 @@ impl SimplifyOptimizer {
                         Shift { input, .. } => {
                             exprs.push(input);
                         }
-                        Column { .. } => {}
                         Ternary {
                             predicate,
                             truthy,
@@ -194,8 +192,7 @@ impl SimplifyOptimizer {
                         Apply { input, .. } => {
                             exprs.push(input);
                         }
-                        Literal { .. } => {}
-                        Wildcard { .. } => {}
+                        Literal { .. } | Column { .. } | Wildcard => {}
                     }
                 }
             }

--- a/polars/src/lazy/logical_plan/optimizer/simplify_expr.rs
+++ b/polars/src/lazy/logical_plan/optimizer/simplify_expr.rs
@@ -71,7 +71,8 @@ impl SimplifyOptimizer {
 
         // run loop until reaching fixed point
         while changed {
-            // recurse into sub plans and expressions and applies rule
+            // recurse into sub plans and expressions and apply rules
+            
             let mut plans = vec![&mut *logical_plan];
             let mut exprs = vec![];
 

--- a/polars/src/lazy/logical_plan/optimizer/simplify_expr.rs
+++ b/polars/src/lazy/logical_plan/optimizer/simplify_expr.rs
@@ -84,12 +84,10 @@ impl SimplifyOptimizer {
 
                 match plan {
                     Selection { input, predicate } => {
-                        //let predicate = self.rewrite_expr(predicate)?;
                         plans.push(input);
                         exprs.push(predicate);
                     }
                     Projection { expr, input, .. } => {
-                        //let expr = self.rewrite_expressions(expr)?;
                         plans.push(input);
                         exprs.extend(expr);
                     }
@@ -97,7 +95,6 @@ impl SimplifyOptimizer {
                         plans.push(input);
                     }
                     Aggregate { input, aggs, .. } => {
-                        //let aggs = self.rewrite_expressions(aggs)?;
                         plans.push(input);
                         exprs.extend(aggs);
                     }

--- a/polars/src/lazy/logical_plan/optimizer/simplify_expr.rs
+++ b/polars/src/lazy/logical_plan/optimizer/simplify_expr.rs
@@ -72,7 +72,7 @@ impl SimplifyOptimizer {
         // run loop until reaching fixed point
         while changed {
             // recurse into sub plans and expressions and apply rules
-            
+
             let mut plans = vec![&mut *logical_plan];
             let mut exprs = vec![];
 


### PR DESCRIPTION
This shows the concept of the "optimization framework" as described here https://github.com/ritchie46/polars/issues/145

Some notes:

* Matching & recursion are separated. So easy to add additional rules on expression / logical plan level, as they often have to match only on one or a couple of cases.
* Runs until reaching fixed point
* Additional rules could be iterated over in inner loop
* Uses local stack
* If traits are changed to take in a &mut , no clone will be needed.
* SimplifyExprRule is an example rule, a trait can be made to "generalize" it