### PR TITLE
Simplify parsing in infer field schema, remove lazy static dependency

### DIFF
--- a/polars/Cargo.toml
+++ b/polars/Cargo.toml
@@ -38,7 +38,6 @@ regex = {version = "1.4" }
 anyhow = "1.0"
 ahash = "0.5"
 csv = "1.1"
-lazy_static = "1.4"
 crossbeam = "0.8"
 serde_json = "1.0"
 

--- a/polars/src/frame/ser/fork/csv.rs
+++ b/polars/src/frame/ser/fork/csv.rs
@@ -46,7 +46,7 @@ fn infer_field_schema(string: &str) -> ArrowDataType {
         return ArrowDataType::Utf8;
     }
     // match regex in a particular order
-    let lower = string.to_lowercase();
+    let lower = string.to_ascii_lowercase();
     if lower == "true" || lower == "false" {
         return ArrowDataType::Boolean;
     }

--- a/polars/src/frame/ser/fork/csv.rs
+++ b/polars/src/frame/ser/fork/csv.rs
@@ -50,10 +50,10 @@ fn infer_field_schema(string: &str) -> ArrowDataType {
     if lower == "true" || lower == "false" {
         return ArrowDataType::Boolean;
     }
-    let mut d = string.split('.');
-    let (x, y) = (d.next(), d.next());
-    let left_is_number = x.map_or(false, all_numeric);
-    let right_is_number = y.map_or(false, all_numeric);
+    let mut parts = string.split('.');
+    let (left, right) = (parts.next(), parts.next());
+    let left_is_number = left.map_or(false, all_numeric);
+    let right_is_number = right.map_or(false, all_numeric);
     if left_is_number && right_is_number {
         return ArrowDataType::Float64;
     } else if left_is_number {

--- a/polars/src/frame/ser/fork/csv.rs
+++ b/polars/src/frame/ser/fork/csv.rs
@@ -50,7 +50,9 @@ fn infer_field_schema(string: &str) -> ArrowDataType {
     if lower == "true" || lower == "false" {
         return ArrowDataType::Boolean;
     }
-    let mut parts = string.split('.');
+    let skip_minus = if string.starts_with('-') { 1 } else { 0 };
+
+    let mut parts = string[skip_minus..].split('.');
     let (left, right) = (parts.next(), parts.next());
     let left_is_number = left.map_or(false, all_digit);
     if left_is_number && right.map_or(false, all_digit) {

--- a/polars/src/frame/ser/fork/csv.rs
+++ b/polars/src/frame/ser/fork/csv.rs
@@ -53,8 +53,7 @@ fn infer_field_schema(string: &str) -> ArrowDataType {
     let mut parts = string.split('.');
     let (left, right) = (parts.next(), parts.next());
     let left_is_number = left.map_or(false, all_numeric);
-    let right_is_number = right.map_or(false, all_numeric);
-    if left_is_number && right_is_number {
+    if left_is_number && right.map_or(false, all_numeric) {
         return ArrowDataType::Float64;
     } else if left_is_number {
         return ArrowDataType::Int64;

--- a/polars/src/frame/ser/fork/csv.rs
+++ b/polars/src/frame/ser/fork/csv.rs
@@ -58,7 +58,7 @@ fn infer_field_schema(string: &str) -> ArrowDataType {
     } else if left_is_number {
         return ArrowDataType::Int64;
     }
-    return ArrowDataType::Utf8;
+    ArrowDataType::Utf8
 }
 
 /// Infer the schema of a CSV file by reading through the first n records of the file,

--- a/polars/src/frame/ser/fork/csv.rs
+++ b/polars/src/frame/ser/fork/csv.rs
@@ -35,8 +35,8 @@ use std::sync::Arc;
 /// Is multiplied with batch_size to determine capacity of builders
 const CAPACITY_MULTIPLIER: usize = 512;
 
-fn all_numeric(string: &str) -> bool {
-    string.chars().all(char::is_numeric)
+fn all_digit(string: &str) -> bool {
+    string.chars().all(|c| c.is_ascii_digit())
 }
 /// Infer the data type of a record
 fn infer_field_schema(string: &str) -> ArrowDataType {
@@ -52,8 +52,8 @@ fn infer_field_schema(string: &str) -> ArrowDataType {
     }
     let mut parts = string.split('.');
     let (left, right) = (parts.next(), parts.next());
-    let left_is_number = left.map_or(false, all_numeric);
-    if left_is_number && right.map_or(false, all_numeric) {
+    let left_is_number = left.map_or(false, all_digit);
+    if left_is_number && right.map_or(false, all_digit) {
         return ArrowDataType::Float64;
     } else if left_is_number {
         return ArrowDataType::Int64;


### PR DESCRIPTION
Makes parsing manually instead of relying on (probably slower, is there a benchmark?) regexes.

Also can remove lazy_static as direct dependency.