### PR TITLE
Increase take performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,3 +98,4 @@ Want to contribute? Read our [contribution guideline](./CONTRIBUTING.md).
     If the number of columns exceeds this it will run in parallel
 * `POLARS_FMT_MAX_COLS` -> maximum number of columns shown when formatting DataFrames
 * `POLARS_FMT_MAX_ROW` -> maximum number of rows shown when formatting DataFrames
+* `POLARS_TABLE_WIDTH` -> width of the tables used during DataFrame formatting

--- a/polars/src/chunked_array/builder.rs
+++ b/polars/src/chunked_array/builder.rs
@@ -197,9 +197,10 @@ pub(crate) fn set_null_bits(
         }
         None => match null_bit_buffer {
             None => builder.null_count(0),
-            Some(buffer) => builder
-                .null_count(bit_util::count_set_bits(buffer.data()))
-                .null_bit_buffer(buffer),
+            Some(_) => {
+                // this should take account into offset and length
+                unimplemented!()
+            }
         },
     }
 }

--- a/polars/src/chunked_array/kernels/mod.rs
+++ b/polars/src/chunked_array/kernels/mod.rs
@@ -1,4 +1,5 @@
 pub mod set;
+pub(crate) mod take;
 #[cfg(feature = "temporal")]
 #[doc(cfg(feature = "temporal"))]
 pub mod temporal;

--- a/polars/src/chunked_array/kernels/take.rs
+++ b/polars/src/chunked_array/kernels/take.rs
@@ -1,0 +1,101 @@
+use crate::chunked_array::builder::aligned_vec_to_primitive_array;
+use crate::prelude::*;
+use arrow::array::{
+    Array, ArrayData, BooleanArray, PrimitiveArray, PrimitiveArrayOps, StringArray, UInt32Array,
+};
+use arrow::buffer::{Buffer, MutableBuffer};
+use arrow::datatypes::ToByteSlice;
+use arrow::util::bit_util;
+use std::sync::Arc;
+
+/// Forked snippet from Arrow. Remove on Arrow 3.0 release
+pub(crate) fn take_no_null_boolean(arr: &BooleanArray, indices: &UInt32Array) -> Arc<BooleanArray> {
+    assert_eq!(arr.null_count(), 0);
+    let data_len = indices.len();
+    let num_bytes = bit_util::ceil(data_len, 8);
+
+    // fill with false bits
+    let mut val_buf = MutableBuffer::new(num_bytes).with_bitset(num_bytes, false);
+    let val_slice = val_buf.data_mut();
+    (0..data_len).for_each(|i| {
+        let index = indices.value(i) as usize;
+        if arr.value(index) {
+            bit_util::set_bit(val_slice, i)
+        }
+    });
+    let nulls = indices.data_ref().null_buffer().cloned();
+    let data = ArrayData::new(
+        ArrowDataType::Boolean,
+        indices.len(),
+        None,
+        nulls,
+        0,
+        vec![val_buf.freeze()],
+        vec![],
+    );
+    Arc::new(BooleanArray::from(Arc::new(data)))
+}
+
+/// Forked snippet from Arrow. Only does not write to a Vec, but directly to aligned memory.
+pub(crate) fn take_no_null_primitive<T: PolarsNumericType>(
+    arr: &PrimitiveArray<T>,
+    indices: &UInt32Array,
+) -> Arc<PrimitiveArray<T>> {
+    assert_eq!(arr.null_count(), 0);
+
+    let data_len = indices.len();
+    let mut values = AlignedVec::<T::Native>::with_capacity_aligned(data_len);
+    for i in 0..data_len {
+        let index = indices.value(i) as usize;
+        let v = arr.value(index);
+        values.inner.push(v);
+    }
+    let nulls = indices.data_ref().null_buffer().cloned();
+
+    let arr = aligned_vec_to_primitive_array(values, nulls, Some(indices.null_count()));
+    Arc::new(arr)
+}
+
+pub(crate) fn take_no_null_utf8(arr: &StringArray, indices: &UInt32Array) -> Arc<StringArray> {
+    assert_eq!(arr.null_count(), 0);
+    let data_len = indices.len();
+    let mut offsets = Vec::with_capacity(data_len + 1);
+    let mut values = Vec::with_capacity(data_len);
+    let mut length_so_far = 0;
+    offsets.push(length_so_far);
+    let nulls;
+
+    // both 0 nulls
+    if arr.null_count() == indices.null_count() {
+        for i in 0..data_len {
+            let index = indices.value(i) as usize;
+            let s = arr.value(index);
+
+            length_so_far += s.len() as i32;
+            values.extend_from_slice(s.as_bytes());
+            offsets.push(length_so_far)
+        }
+        nulls = None
+    } else {
+        for i in 0..data_len {
+            if indices.is_valid(i) {
+                let index = indices.value(i) as usize;
+
+                let s = arr.value(index);
+                length_so_far += s.len() as i32;
+                values.extend_from_slice(s.as_bytes());
+            }
+            offsets.push(length_so_far);
+        }
+        nulls = indices.data_ref().null_buffer().cloned();
+    }
+
+    let mut data = ArrayData::builder(ArrowDataType::Utf8)
+        .len(data_len)
+        .add_buffer(Buffer::from(offsets.to_byte_slice()))
+        .add_buffer(Buffer::from(&values[..]));
+    if let Some(null_buffer) = nulls {
+        data = data.null_bit_buffer(null_buffer);
+    }
+    Arc::new(StringArray::from(data.build()))
+}

--- a/polars/src/chunked_array/ops/mod.rs
+++ b/polars/src/chunked_array/ops/mod.rs
@@ -248,6 +248,19 @@ pub trait ChunkTake {
     ) -> Self
     where
         Self: std::marker::Sized;
+
+    fn take_from_single_chunked(&self, idx: &UInt32Chunked) -> Result<Self>
+    where
+        Self: std::marker::Sized;
+
+    fn take_from_single_chunked_iter(&self, indices: impl Iterator<Item = usize>) -> Result<Self>
+    where
+        Self: std::marker::Sized,
+    {
+        let idx_ca: Xob<UInt32Chunked> = indices.into_iter().map(|idx| idx as u32).collect();
+        let idx_ca = idx_ca.into_inner();
+        self.take_from_single_chunked(&idx_ca)
+    }
 }
 
 /// Create a `ChunkedArray` with new values by index or by boolean mask.

--- a/polars/src/chunked_array/ops/take.rs
+++ b/polars/src/chunked_array/ops/take.rs
@@ -235,10 +235,7 @@ where
 
             let new_arr = if self.null_count() == 0 {
                 let arr = self.downcast_chunks()[0];
-                let arr = take_no_null_primitive(arr, idx_arr) as ArrayRef;
-                dbg!(&arr);
-                dbg!(arr.null_count());
-                arr
+                take_no_null_primitive(arr, idx_arr) as ArrayRef
             } else {
                 let arr = &self.chunks[0];
                 take(arr, idx_arr, None).unwrap()

--- a/polars/src/lazy/logical_plan/mod.rs
+++ b/polars/src/lazy/logical_plan/mod.rs
@@ -372,10 +372,6 @@ fn replace_wildcard_with_column(expr: Expr, column_name: Arc<String>) -> Expr {
 /// In case of single col(*) -> do nothing, no selection is the same as select all
 /// In other cases replace the wildcard with an expression with all columns
 fn rewrite_projections(exprs: Vec<Expr>, schema: &Schema) -> Vec<Expr> {
-    if exprs.len() == 1 && exprs[0] == Expr::Wildcard {
-        // no projection needed
-        return vec![];
-    };
     let mut result = Vec::with_capacity(exprs.len() + schema.fields().len());
     for expr in exprs {
         if let Ok(Expr::Wildcard) = expr_to_root_column_expr(&expr) {

--- a/polars/src/lazy/logical_plan/optimizer/projection.rs
+++ b/polars/src/lazy/logical_plan/optimizer/projection.rs
@@ -302,7 +302,6 @@ impl ProjectionPushDown {
             Aggregate {
                 input, keys, aggs, ..
             } => {
-                dbg!(&aggs);
                 // todo! remove unnecessary vec alloc.
                 let (mut acc_projections, _local_projections, mut names) =
                     self.split_acc_projections(acc_projections, input.schema());

--- a/polars/src/series/mod.rs
+++ b/polars/src/series/mod.rs
@@ -437,6 +437,15 @@ impl Series {
         }
     }
 
+    /// Take by index if ChunkedArray contains a single chunk.
+    ///
+    /// # Safety
+    /// This doesn't check any bounds. Null validity is checked.
+    pub unsafe fn take_from_single_chunked(&self, idx: &UInt32Chunked) -> Result<Self> {
+        let s = apply_method_all_arrow_series_and_return!(self, take_from_single_chunked, [idx], ?);
+        Ok(s)
+    }
+
     /// Take by index from an iterator. This operation clones the data.
     ///
     /// # Safety

--- a/py-polars/Cargo.toml
+++ b/py-polars/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "py-polars"
-version = "0.0.20"
+version = "0.0.21"
 authors = ["ritchie46 <ritchie46@gmail.com>"]
 edition = "2018"
 

--- a/py-polars/Cargo.toml
+++ b/py-polars/Cargo.toml
@@ -11,7 +11,7 @@ polars = {path = "../polars", features = ["parquet", "simd", "lazy", "strings", 
 pyo3 = {version = "0.12", features = ["extension-module"] }
 thiserror = "1.0.20"
 numpy = "0.12"
-ndarray = "0.13.1"
+ndarray = "0.14.0"
 parquet = "2"
 
 

--- a/py-polars/src/npy.rs
+++ b/py-polars/src/npy.rs
@@ -9,12 +9,17 @@ use pyo3::prelude::*;
 use std::{mem, ptr};
 
 /// Create an empty numpy array arrows 64 byte alignment
-pub fn aligned_array<T: Element>(py: Python<'_>, size: usize) -> (&PyArray1<T>, *mut T) {
+///
+/// # Safety
+/// All elements in the array are non initialized
+///
+/// The array is also writable from Python.
+pub unsafe fn aligned_array<T: Element>(py: Python<'_>, size: usize) -> (&PyArray1<T>, *mut T) {
     let t_size = std::mem::size_of::<T>();
     let capacity = size * t_size;
     let ptr = memory::allocate_aligned(capacity) as *mut T;
-    let mut buf = unsafe { Vec::from_raw_parts(ptr, 0, capacity) };
-    unsafe { buf.set_len(size) }
+    let mut buf = Vec::from_raw_parts(ptr, 0, capacity);
+    buf.set_len(size);
     // modified from
     // numpy-0.10.0/src/array.rs:375
 
@@ -23,21 +28,20 @@ pub fn aligned_array<T: Element>(py: Python<'_>, size: usize) -> (&PyArray1<T>, 
 
     let dims = [len].into_dimension();
     let strides = [mem::size_of::<T>() as npy_intp];
-    unsafe {
-        let ptr = PY_ARRAY_API.PyArray_New(
-            PY_ARRAY_API.get_type_object(npyffi::NpyTypes::PyArray_Type),
-            dims.ndim_cint(),
-            dims.as_dims_ptr(),
-            T::npy_type() as i32,
-            strides.as_ptr() as *mut _, // strides
-            buffer_ptr as _,            // data
-            mem::size_of::<T>() as i32, // itemsize
-            flags::NPY_ARRAY_OUT_ARRAY, // flag
-            ptr::null_mut(),            //obj
-        );
-        mem::forget(buf);
-        (PyArray1::from_owned_ptr(py, ptr), buffer_ptr)
-    }
+
+    let ptr = PY_ARRAY_API.PyArray_New(
+        PY_ARRAY_API.get_type_object(npyffi::NpyTypes::PyArray_Type),
+        dims.ndim_cint(),
+        dims.as_dims_ptr(),
+        T::npy_type() as i32,
+        strides.as_ptr() as *mut _, // strides
+        buffer_ptr as _,            // data
+        mem::size_of::<T>() as i32, // itemsize
+        flags::NPY_ARRAY_OUT_ARRAY, // flag
+        ptr::null_mut(),            //obj
+    );
+    mem::forget(buf);
+    (PyArray1::from_owned_ptr(py, ptr), buffer_ptr)
 }
 
 pub unsafe fn vec_from_ptr<T>(ptr: usize, len: usize) -> Vec<T> {

--- a/py-polars/src/series.rs
+++ b/py-polars/src/series.rs
@@ -824,7 +824,7 @@ macro_rules! impl_ufuncs {
                 let gil = Python::acquire_gil();
                 let py = gil.python();
                 let size = self.len();
-                let (out_array, ptr) = aligned_array::<$type>(py, size);
+                let (out_array, ptr) = unsafe { aligned_array::<$type>(py, size) };
 
                 debug_assert_eq!(out_array.get_refcnt(), 1);
                 // inserting it in a tuple increase the reference count by 1.


### PR DESCRIPTION
Noticed that taking DataFrame values by index used almost all operation time of joins when we have more than a few columns.

Some benchmark results

```
# Baseline
609 ms
600 ms
597 ms

## RAYON_NUM_THREADS=1
872 ms
902 ms
910 ms

# Only 1 column
25 ms
25 ms

# NO RAYON JOIN threads from join
590 ms
586 ms
589 ms

# Box<dyn TakeRand> instead of static dispatch per get
583 ms
575 ms
576 ms

# NO par_iter
852 ms
869 ms
873 ms

# Arrow take for UTF8
460 ms
461 ms
470 ms

# Arrow take for Boolean
589 ms
584 ms
578 ms
591 ms

# Arrow take for Primitive
581 ms
588 ms
594 ms


# Results of implements lowering the baseline
470 ms
477 ms
489 ms
```