### PR TITLE
increase take performance by directly writing to buffer

### DIFF
--- a/polars/src/chunked_array/kernels/take.rs
+++ b/polars/src/chunked_array/kernels/take.rs
@@ -3,9 +3,10 @@ use crate::prelude::*;
 use arrow::array::{
     Array, ArrayData, BooleanArray, PrimitiveArray, PrimitiveArrayOps, StringArray, UInt32Array,
 };
-use arrow::buffer::{Buffer, MutableBuffer};
-use arrow::datatypes::ToByteSlice;
+use arrow::buffer::MutableBuffer;
 use arrow::util::bit_util;
+use std::io::Write;
+use std::mem;
 use std::sync::Arc;
 
 /// Forked snippet from Arrow. Remove on Arrow 3.0 release
@@ -59,41 +60,73 @@ pub(crate) fn take_no_null_primitive<T: PolarsNumericType>(
 pub(crate) fn take_no_null_utf8(arr: &StringArray, indices: &UInt32Array) -> Arc<StringArray> {
     assert_eq!(arr.null_count(), 0);
     let data_len = indices.len();
-    let mut offsets = Vec::with_capacity(data_len + 1);
-    let mut values = Vec::with_capacity(data_len);
+
+    let offset_len_in_bytes = (data_len + 1) * mem::size_of::<i32>();
+    let mut offset_buf = MutableBuffer::new(offset_len_in_bytes);
+    offset_buf
+        .resize(offset_len_in_bytes)
+        .expect("out of memory");
+    let offset_typed = offset_buf.typed_data_mut();
+
+    // The required size is yet unknown
+    // Allocate 1.5 times the expected size.
+    // where expected size is the length of bytes multiplied by the factor (take_len / current_len)
+    let mut values_capacity =
+        ((arr.value_data().len() as f32 * 1.5) as usize) / arr.len() * indices.len() as usize;
+    let mut values_buf = MutableBuffer::new(values_capacity);
+
     let mut length_so_far = 0;
-    offsets.push(length_so_far);
+    offset_typed[0] = length_so_far;
+
     let nulls;
 
     // both 0 nulls
     if arr.null_count() == indices.null_count() {
-        for i in 0..data_len {
-            let index = indices.value(i) as usize;
-            let s = arr.value(index);
-
-            length_so_far += s.len() as i32;
-            values.extend_from_slice(s.as_bytes());
-            offsets.push(length_so_far)
-        }
-        nulls = None
-    } else {
-        for i in 0..data_len {
-            if indices.is_valid(i) {
-                let index = indices.value(i) as usize;
-
+        offset_typed
+            .iter_mut()
+            .skip(1) // first value is already set
+            .enumerate()
+            .for_each(|(idx, offset)| {
+                let index = indices.value(idx) as usize;
                 let s = arr.value(index);
                 length_so_far += s.len() as i32;
-                values.extend_from_slice(s.as_bytes());
-            }
-            offsets.push(length_so_far);
-        }
+                if length_so_far > values_capacity as i32 {
+                    values_capacity = (values_capacity as f32 * 1.2) as usize;
+                    values_buf.reserve(values_capacity).expect("oom");
+                }
+
+                values_buf.write_all(s.as_bytes()).expect("enough capacity");
+
+                *offset = length_so_far;
+            });
+        nulls = None
+    } else {
+        offset_typed
+            .iter_mut()
+            .skip(1) // first value is already set
+            .enumerate()
+            .for_each(|(idx, offset)| {
+                if indices.is_valid(idx) {
+                    let index = indices.value(idx) as usize;
+                    let s = arr.value(index);
+                    length_so_far += s.len() as i32;
+                    if length_so_far > values_capacity as i32 {
+                        values_capacity = (values_capacity as f32 * 1.2) as usize;
+                        values_buf.reserve(values_capacity).expect("oom");
+                    }
+                    values_buf.write_all(s.as_bytes()).expect("enough capacity");
+                }
+                *offset = length_so_far;
+            });
         nulls = indices.data_ref().null_buffer().cloned();
     }
 
+    // todo! shrink to fit? How to?
+
     let mut data = ArrayData::builder(ArrowDataType::Utf8)
         .len(data_len)
-        .add_buffer(Buffer::from(offsets.to_byte_slice()))
-        .add_buffer(Buffer::from(&values[..]));
+        .add_buffer(offset_buf.freeze())
+        .add_buffer(values_buf.freeze());
     if let Some(null_buffer) = nulls {
         data = data.null_bit_buffer(null_buffer);
     }

--- a/polars/src/chunked_array/ops/take.rs
+++ b/polars/src/chunked_array/ops/take.rs
@@ -7,7 +7,7 @@ use crate::chunked_array::builder::{
     get_list_builder, PrimitiveChunkedBuilder, Utf8ChunkedBuilder,
 };
 use crate::chunked_array::kernels::take::{
-    take_no_null_boolean, take_no_null_primitive, take_no_null_utf8,
+    take_no_null_boolean, take_no_null_primitive, take_utf8,
 };
 use crate::prelude::*;
 use crate::utils::Xob;
@@ -346,14 +346,8 @@ impl ChunkTake for Utf8Chunked {
     fn take_from_single_chunked(&self, idx: &UInt32Chunked) -> Result<Self> {
         if self.chunks.len() == 1 && idx.chunks.len() == 1 {
             let idx_arr = idx.downcast_chunks()[0];
-            let arr = &self.chunks[0];
-
-            let new_arr = if self.null_count() == 0 {
-                let arr = arr.as_any().downcast_ref::<StringArray>().unwrap();
-                take_no_null_utf8(arr, idx_arr) as ArrayRef
-            } else {
-                take(arr, idx_arr, None).unwrap()
-            };
+            let arr = self.downcast_chunks()[0];
+            let new_arr = take_utf8(arr, idx_arr) as ArrayRef;
             Ok(Self::new_from_chunks(self.name(), vec![new_arr]))
         } else {
             Err(PolarsError::NoSlice)

--- a/py-polars/Cargo.toml
+++ b/py-polars/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "py-polars"
-version = "0.0.21"
+version = "0.0.22"
 authors = ["ritchie46 <ritchie46@gmail.com>"]
 edition = "2018"
 


### PR DESCRIPTION
@Dandandan I benchmarked the joins with a take kernel that directly writes to a buffer. Some thoughts:

* Still had to do quite some low-level memory management regarding the capacity of the buffer. Has `MutableBuffer` a utility similar to `Vec::push` that resizes when needed?
* Don't know the required size beforehand. I choose 1.5 times the expected size.
* I think a buffer should be shrunk before freezing?

The benchmarks in #192 improved from:

```
470 ms
477 ms
489 ms
```

to

```
338 ms
338 ms
342 ms
```

I saw that `Arrow::Stringarray::from_vec` also has the `Vec/memcpy` approach so assume this is widely used Arrow. I don't know where we could have this discussion in Arrow, but I'd like some centralized logic for the buffer relocation, instead of checking capacity/ reserving in every kernel where we like to use MutableBuffers directly.