### PR TITLE
Non aligned parallel iterators

### DIFF
--- a/polars/src/chunked_array/iterator/mod.rs
+++ b/polars/src/chunked_array/iterator/mod.rs
@@ -560,7 +560,7 @@ where
 ///
 /// # Input
 ///
-/// ca_type: The chunked array for which the which the single chunks iterator is implemented.
+/// ca_type: The chunked array for which the single chunks iterator is implemented.
 /// arrow_array: The arrow type of the chunked array chunks.
 /// iterator_name: The name of the iterator struct to be implemented for a `SingleChunk` iterator.
 /// iter_item: The iterator `Item`, the type which is going to be returned by the iterator.

--- a/polars/src/chunked_array/iterator/par/boolean.rs
+++ b/polars/src/chunked_array/iterator/par/boolean.rs
@@ -8,7 +8,7 @@ use rayon::iter::plumbing::*;
 use rayon::iter::plumbing::{Consumer, ProducerCallback};
 use rayon::prelude::*;
 
-// Implement the parallel iterators for Utf8. It also implement the trait `IntoParallelIterator`
+// Implement the parallel iterators for Boolean. It also implement the trait `IntoParallelIterator`
 // for `&'a BooleanChunked` and `NoNull<&'a BooleanChunked>`, which use static dispatcher to use
 // the best implementation of parallel iterators depending on the number of chunks and the
 // existence of null values.
@@ -48,3 +48,373 @@ impl_all_parallel_iterators!(
     // Lifetime.
     lifetime = 'a
 );
+
+#[cfg(test)]
+mod test {
+    use crate::prelude::*;
+    use rayon::prelude::{IntoParallelIterator, ParallelIterator};
+
+    /// The size of the chunked array used in tests.
+    const BOOLEAN_CHUNKED_ARRAY_SIZE: usize = 1_000_000;
+
+    /// Generates a `Vec` of `bool`, with even indexes are true, and odd indexes are false.
+    fn generate_boolean_vec(size: usize) -> Vec<bool> {
+        (0..size).map(|n| n % 2 == 0).collect()
+    }
+
+    /// Generate a `Vec` of `Option<bool>`, where:
+    /// - If the index is divisible by 3, then, the value is `None`.
+    /// - If the index is not divisible by 3 and it is even, then, the value is `Some(true)`.
+    /// - Otherwise, the value is `Some(false)`.
+    fn generate_opt_boolean_vec(size: usize) -> Vec<Option<bool>> {
+        (0..size)
+            .map(|n| {
+                if n % 3 == 0 {
+                    None
+                } else {
+                    Some(n % 2 == 0)
+                }
+            })
+            .collect()
+    }
+
+    /// Implement a test which performs a map over a `ParallelIterator` and over its correspondant `Iterator`,
+    /// and compares that the result of both iterators is the same. It performs over iterators which return
+    /// Option<bool>.
+    ///
+    /// # Input
+    ///
+    /// test_name: The name of the test to implement, it is a function name so it shall be unique.
+    /// ca_init_block: The block which initialize the chunked array. It shall return the chunked array.
+    macro_rules! impl_par_iter_return_option_map_test {
+        ($test_name:ident, $ca_init_block:block) => {
+            #[test]
+            fn $test_name() {
+                let a = $ca_init_block;
+
+                // Perform a parallel maping.
+                let par_result = a
+                    .into_par_iter()
+                    .map(|opt_b| opt_b.map(|b| !b))
+                    .collect::<Vec<_>>();
+
+                // Perform a sequetial maping.
+                let seq_result = a
+                    .into_iter()
+                    .map(|opt_b| opt_b.map(|b| !b))
+                    .collect::<Vec<_>>();
+
+                // Check sequetial and parallel results are equal.
+                assert_eq!(par_result, seq_result);
+            }
+        };
+    }
+
+    /// Implement a test which performs a filter over a `ParallelIterator` and over its correspondant `Iterator`,
+    /// and compares that the result of both iterators is the same. It performs over iterators which return
+    /// Option<bool>.
+    ///
+    /// # Input
+    ///
+    /// test_name: The name of the test to implement, it is a function name so it shall be unique.
+    /// ca_init_block: The block which initialize the chunked array. It shall return the chunked array.
+    macro_rules! impl_par_iter_return_option_filter_test {
+        ($test_name:ident, $ca_init_block:block) => {
+            #[test]
+            fn $test_name() {
+                let a = $ca_init_block;
+
+                // Perform a parallel filter.
+                let par_result = a
+                    .into_par_iter()
+                    .filter(|opt_b| opt_b.unwrap_or(false))
+                    .collect::<Vec<_>>();
+
+                // Perform a sequetial filter.
+                let seq_result = a
+                    .into_iter()
+                    .filter(|opt_b| opt_b.unwrap_or(false))
+                    .collect::<Vec<_>>();
+
+                // Check sequetial and parallel results are equal.
+                assert_eq!(par_result, seq_result);
+            }
+        };
+    }
+
+    /// Implement a test which performs a fold over a `ParallelIterator` and over its correspondant `Iterator`,
+    /// and compares that the result of both iterators is the same. It performs over iterators which return
+    /// Option<bool>.
+    ///
+    /// # Input
+    ///
+    /// test_name: The name of the test to implement, it is a function name so it shall be unique.
+    /// ca_init_block: The block which initialize the chunked array. It shall return the chunked array.
+    macro_rules! impl_par_iter_return_option_fold_test {
+        ($test_name:ident, $ca_init_block:block) => {
+            #[test]
+            fn $test_name() {
+                let a = $ca_init_block;
+
+                // Perform a parallel sum of length.
+                let par_result = a
+                    .into_par_iter()
+                    .fold(
+                        || 0u64,
+                        |acc, opt_b| {
+                            let opt_u = opt_b.map(|b| if b { 1 } else { 2 });
+
+                            let val = opt_u.unwrap_or(0);
+                            acc + val
+                        },
+                    )
+                    .reduce(|| 0u64, |left, right| left + right);
+
+                // Perform a sequential sum of length.
+                let seq_result = a.into_iter().fold(0u64, |acc, opt_b| {
+                    let opt_u = opt_b.map(|b| if b { 1 } else { 2 });
+
+                    let val = opt_u.unwrap_or(0);
+                    acc + val
+                });
+
+                // Check sequetial and parallel results are equal.
+                assert_eq!(par_result, seq_result);
+            }
+        };
+    }
+
+    // Single Chunk Parallel Iterator Tests.
+    impl_par_iter_return_option_map_test!(boolean_par_iter_single_chunk_return_option_map, {
+        BooleanChunked::new_from_slice("a", &generate_boolean_vec(BOOLEAN_CHUNKED_ARRAY_SIZE))
+    });
+
+    impl_par_iter_return_option_filter_test!(boolean_par_iter_single_chunk_return_option_filter, {
+        BooleanChunked::new_from_slice("a", &generate_boolean_vec(BOOLEAN_CHUNKED_ARRAY_SIZE))
+    });
+
+    impl_par_iter_return_option_fold_test!(boolean_par_iter_single_chunk_return_option_fold, {
+        BooleanChunked::new_from_slice("a", &generate_boolean_vec(BOOLEAN_CHUNKED_ARRAY_SIZE))
+    });
+
+    // Single Chunk Null Check Parallel Iterator Tests.
+    impl_par_iter_return_option_map_test!(
+        boolean_par_iter_single_chunk_null_check_return_option_map,
+        { BooleanChunked::new_from_opt_slice("a", &generate_opt_boolean_vec(BOOLEAN_CHUNKED_ARRAY_SIZE)) }
+    );
+
+    impl_par_iter_return_option_filter_test!(
+        boolean_par_iter_single_chunk_null_check_return_option_filter,
+        { BooleanChunked::new_from_opt_slice("a", &generate_opt_boolean_vec(BOOLEAN_CHUNKED_ARRAY_SIZE)) }
+    );
+
+    impl_par_iter_return_option_fold_test!(
+        boolean_par_iter_single_chunk_null_check_return_option_fold,
+        { BooleanChunked::new_from_opt_slice("a", &generate_opt_boolean_vec(BOOLEAN_CHUNKED_ARRAY_SIZE)) }
+    );
+
+    // Many Chunk Parallel Iterator Tests.
+    impl_par_iter_return_option_map_test!(boolean_par_iter_many_chunk_return_option_map, {
+        let mut a = BooleanChunked::new_from_slice("a", &generate_boolean_vec(BOOLEAN_CHUNKED_ARRAY_SIZE));
+        let a_b = BooleanChunked::new_from_slice("a", &generate_boolean_vec(BOOLEAN_CHUNKED_ARRAY_SIZE));
+        a.append(&a_b);
+        a
+    });
+
+    impl_par_iter_return_option_filter_test!(boolean_par_iter_many_chunk_return_option_filter, {
+        let mut a = BooleanChunked::new_from_slice("a", &generate_boolean_vec(BOOLEAN_CHUNKED_ARRAY_SIZE));
+        let a_b = BooleanChunked::new_from_slice("a", &generate_boolean_vec(BOOLEAN_CHUNKED_ARRAY_SIZE));
+        a.append(&a_b);
+        a
+    });
+
+    impl_par_iter_return_option_fold_test!(boolean_par_iter_many_chunk_return_option_fold, {
+        let mut a = BooleanChunked::new_from_slice("a", &generate_boolean_vec(BOOLEAN_CHUNKED_ARRAY_SIZE));
+        let a_b = BooleanChunked::new_from_slice("a", &generate_boolean_vec(BOOLEAN_CHUNKED_ARRAY_SIZE));
+        a.append(&a_b);
+        a
+    });
+
+    // Many Chunk Null Check Parallel Iterator Tests.
+    impl_par_iter_return_option_map_test!(boolean_par_iter_many_chunk_null_check_return_option_map, {
+        let mut a =
+            BooleanChunked::new_from_opt_slice("a", &generate_opt_boolean_vec(BOOLEAN_CHUNKED_ARRAY_SIZE));
+        let a_b =
+            BooleanChunked::new_from_opt_slice("a", &generate_opt_boolean_vec(BOOLEAN_CHUNKED_ARRAY_SIZE));
+        a.append(&a_b);
+        a
+    });
+
+    impl_par_iter_return_option_filter_test!(
+        boolean_par_iter_many_chunk_null_check_return_option_filter,
+        {
+            let mut a = BooleanChunked::new_from_opt_slice(
+                "a",
+                &generate_opt_boolean_vec(BOOLEAN_CHUNKED_ARRAY_SIZE),
+            );
+            let a_b = BooleanChunked::new_from_opt_slice(
+                "a",
+                &generate_opt_boolean_vec(BOOLEAN_CHUNKED_ARRAY_SIZE),
+            );
+            a.append(&a_b);
+            a
+        }
+    );
+
+    impl_par_iter_return_option_fold_test!(
+        boolean_par_iter_many_chunk_null_check_return_option_fold,
+        {
+            let mut a = BooleanChunked::new_from_opt_slice(
+                "a",
+                &generate_opt_boolean_vec(BOOLEAN_CHUNKED_ARRAY_SIZE),
+            );
+            let a_b = BooleanChunked::new_from_opt_slice(
+                "a",
+                &generate_opt_boolean_vec(BOOLEAN_CHUNKED_ARRAY_SIZE),
+            );
+            a.append(&a_b);
+            a
+        }
+    );
+
+    /// Implement a test which performs a map over a `ParallelIterator` and over its correspondant `Iterator`,
+    /// and compares that the result of both iterators is the same. It performs over iterators which return
+    /// &str.
+    ///
+    /// # Input
+    ///
+    /// test_name: The name of the test to implement, it is a function name so it shall be unique.
+    /// ca_init_block: The block which initialize the chunked array. It shall return the chunked array.
+    macro_rules! impl_par_iter_return_unwrapped_map_test {
+        ($test_name:ident, $ca_init_block:block) => {
+            #[test]
+            fn $test_name() {
+                let a = $ca_init_block;
+
+                // Perform a parallel maping.
+                let par_result = NoNull(&a)
+                    .into_par_iter()
+                    .map(|b| !b)
+                    .collect::<Vec<_>>();
+
+                // Perform a sequetial maping.
+                let seq_result = a
+                    .into_no_null_iter()
+                    .map(|b| !b)
+                    .collect::<Vec<_>>();
+
+                // Check sequetial and parallel results are equal.
+                assert_eq!(par_result, seq_result);
+            }
+        };
+    }
+
+    /// Implement a test which performs a filter over a `ParallelIterator` and over its correspondant `Iterator`,
+    /// and compares that the result of both iterators is the same. It performs over iterators which return
+    /// &str.
+    ///
+    /// # Input
+    ///
+    /// test_name: The name of the test to implement, it is a function name so it shall be unique.
+    /// ca_init_block: The block which initialize the chunked array. It shall return the chunked array.
+    macro_rules! impl_par_iter_return_unwrapped_filter_test {
+        ($test_name:ident, $ca_init_block:block) => {
+            #[test]
+            fn $test_name() {
+                let a = $ca_init_block;
+
+                // Perform a parallel filter.
+                let par_result = NoNull(&a)
+                    .into_par_iter()
+                    .filter(|&b| b)
+                    .collect::<Vec<_>>();
+
+                // Perform a sequetial filter.
+                let seq_result = a
+                    .into_no_null_iter()
+                    .filter(|&b| b)
+                    .collect::<Vec<_>>();
+
+                // Check sequetial and parallel results are equal.
+                assert_eq!(par_result, seq_result);
+            }
+        };
+    }
+
+    /// Implement a test which performs a fold over a `ParallelIterator` and over its correspondant `Iterator`,
+    /// and compares that the result of both iterators is the same. It performs over iterators which return
+    /// &str.
+    ///
+    /// # Input
+    ///
+    /// test_name: The name of the test to implement, it is a function name so it shall be unique.
+    /// ca_init_block: The block which initialize the chunked array. It shall return the chunked array.
+    macro_rules! impl_par_iter_return_unwrapped_fold_test {
+        ($test_name:ident, $ca_init_block:block) => {
+            #[test]
+            fn $test_name() {
+                let a = $ca_init_block;
+
+                // Perform a parallel sum of length.
+                let par_result = NoNull(&a)
+                    .into_par_iter()
+                    .fold(|| 0u64, |acc, b| {
+                        let val = if b { 1 } else { 2 };
+                        acc + val
+                    })
+                    .reduce(|| 0u64, |left, right| left + right);
+
+                // Perform a sequential sum of length.
+                let seq_result = a
+                    .into_no_null_iter()
+                    .fold(0u64, |acc, b| {
+                        let val = if b { 1 } else { 2 };
+                        acc + val
+                    });
+
+                // Check sequetial and parallel results are equal.
+                assert_eq!(par_result, seq_result);
+            }
+        };
+    }
+
+    // Single Chunk Return Unwrapped
+    impl_par_iter_return_unwrapped_map_test!(boolean_par_iter_single_chunk_return_unwrapped_map, {
+        BooleanChunked::new_from_slice("a", &generate_boolean_vec(BOOLEAN_CHUNKED_ARRAY_SIZE))
+    });
+
+    impl_par_iter_return_unwrapped_filter_test!(
+        boolean_par_iter_single_chunk_return_unwrapped_filter,
+        { BooleanChunked::new_from_slice("a", &generate_boolean_vec(BOOLEAN_CHUNKED_ARRAY_SIZE)) }
+    );
+
+    impl_par_iter_return_unwrapped_fold_test!(boolean_par_iter_single_chunk_return_unwrapped_fold, {
+        BooleanChunked::new_from_slice("a", &generate_boolean_vec(BOOLEAN_CHUNKED_ARRAY_SIZE))
+    });
+
+    // Many Chunk Return Unwrapped
+    impl_par_iter_return_unwrapped_map_test!(boolean_par_iter_many_chunk_return_unwrapped_map, {
+        let mut a = BooleanChunked::new_from_slice("a", &generate_boolean_vec(BOOLEAN_CHUNKED_ARRAY_SIZE));
+        let a_b = BooleanChunked::new_from_slice("a", &generate_boolean_vec(BOOLEAN_CHUNKED_ARRAY_SIZE));
+        a.append(&a_b);
+        a
+    });
+
+    impl_par_iter_return_unwrapped_filter_test!(
+        boolean_par_iter_many_chunk_return_unwrapped_filter,
+        {
+            let mut a =
+                BooleanChunked::new_from_slice("a", &generate_boolean_vec(BOOLEAN_CHUNKED_ARRAY_SIZE));
+            let a_b = BooleanChunked::new_from_slice("a", &generate_boolean_vec(BOOLEAN_CHUNKED_ARRAY_SIZE));
+            a.append(&a_b);
+            a
+        }
+    );
+
+    impl_par_iter_return_unwrapped_fold_test!(boolean_par_iter_many_chunk_return_unwrapped_fold, {
+        let mut a = BooleanChunked::new_from_slice("a", &generate_boolean_vec(BOOLEAN_CHUNKED_ARRAY_SIZE));
+        let a_b = BooleanChunked::new_from_slice("a", &generate_boolean_vec(BOOLEAN_CHUNKED_ARRAY_SIZE));
+        a.append(&a_b);
+        a
+    });
+}

--- a/polars/src/chunked_array/iterator/par/boolean.rs
+++ b/polars/src/chunked_array/iterator/par/boolean.rs
@@ -1,6 +1,6 @@
 use crate::chunked_array::iterator::{
-    SomeIterator, BooleanIterManyChunk, BooleanIterManyChunkNullCheck, BooleanIterSingleChunk,
-    BooleanIterSingleChunkNullCheck,
+    BooleanIterManyChunk, BooleanIterManyChunkNullCheck, BooleanIterSingleChunk,
+    BooleanIterSingleChunkNullCheck, SomeIterator,
 };
 use crate::prelude::*;
 use arrow::array::Array;
@@ -68,13 +68,7 @@ mod test {
     /// - Otherwise, the value is `Some(false)`.
     fn generate_opt_boolean_vec(size: usize) -> Vec<Option<bool>> {
         (0..size)
-            .map(|n| {
-                if n % 3 == 0 {
-                    None
-                } else {
-                    Some(n % 2 == 0)
-                }
-            })
+            .map(|n| if n % 3 == 0 { None } else { Some(n % 2 == 0) })
             .collect()
     }
 
@@ -200,50 +194,78 @@ mod test {
     // Single Chunk Null Check Parallel Iterator Tests.
     impl_par_iter_return_option_map_test!(
         boolean_par_iter_single_chunk_null_check_return_option_map,
-        { BooleanChunked::new_from_opt_slice("a", &generate_opt_boolean_vec(BOOLEAN_CHUNKED_ARRAY_SIZE)) }
+        {
+            BooleanChunked::new_from_opt_slice(
+                "a",
+                &generate_opt_boolean_vec(BOOLEAN_CHUNKED_ARRAY_SIZE),
+            )
+        }
     );
 
     impl_par_iter_return_option_filter_test!(
         boolean_par_iter_single_chunk_null_check_return_option_filter,
-        { BooleanChunked::new_from_opt_slice("a", &generate_opt_boolean_vec(BOOLEAN_CHUNKED_ARRAY_SIZE)) }
+        {
+            BooleanChunked::new_from_opt_slice(
+                "a",
+                &generate_opt_boolean_vec(BOOLEAN_CHUNKED_ARRAY_SIZE),
+            )
+        }
     );
 
     impl_par_iter_return_option_fold_test!(
         boolean_par_iter_single_chunk_null_check_return_option_fold,
-        { BooleanChunked::new_from_opt_slice("a", &generate_opt_boolean_vec(BOOLEAN_CHUNKED_ARRAY_SIZE)) }
+        {
+            BooleanChunked::new_from_opt_slice(
+                "a",
+                &generate_opt_boolean_vec(BOOLEAN_CHUNKED_ARRAY_SIZE),
+            )
+        }
     );
 
     // Many Chunk Parallel Iterator Tests.
     impl_par_iter_return_option_map_test!(boolean_par_iter_many_chunk_return_option_map, {
-        let mut a = BooleanChunked::new_from_slice("a", &generate_boolean_vec(BOOLEAN_CHUNKED_ARRAY_SIZE));
-        let a_b = BooleanChunked::new_from_slice("a", &generate_boolean_vec(BOOLEAN_CHUNKED_ARRAY_SIZE));
+        let mut a =
+            BooleanChunked::new_from_slice("a", &generate_boolean_vec(BOOLEAN_CHUNKED_ARRAY_SIZE));
+        let a_b =
+            BooleanChunked::new_from_slice("a", &generate_boolean_vec(BOOLEAN_CHUNKED_ARRAY_SIZE));
         a.append(&a_b);
         a
     });
 
     impl_par_iter_return_option_filter_test!(boolean_par_iter_many_chunk_return_option_filter, {
-        let mut a = BooleanChunked::new_from_slice("a", &generate_boolean_vec(BOOLEAN_CHUNKED_ARRAY_SIZE));
-        let a_b = BooleanChunked::new_from_slice("a", &generate_boolean_vec(BOOLEAN_CHUNKED_ARRAY_SIZE));
+        let mut a =
+            BooleanChunked::new_from_slice("a", &generate_boolean_vec(BOOLEAN_CHUNKED_ARRAY_SIZE));
+        let a_b =
+            BooleanChunked::new_from_slice("a", &generate_boolean_vec(BOOLEAN_CHUNKED_ARRAY_SIZE));
         a.append(&a_b);
         a
     });
 
     impl_par_iter_return_option_fold_test!(boolean_par_iter_many_chunk_return_option_fold, {
-        let mut a = BooleanChunked::new_from_slice("a", &generate_boolean_vec(BOOLEAN_CHUNKED_ARRAY_SIZE));
-        let a_b = BooleanChunked::new_from_slice("a", &generate_boolean_vec(BOOLEAN_CHUNKED_ARRAY_SIZE));
+        let mut a =
+            BooleanChunked::new_from_slice("a", &generate_boolean_vec(BOOLEAN_CHUNKED_ARRAY_SIZE));
+        let a_b =
+            BooleanChunked::new_from_slice("a", &generate_boolean_vec(BOOLEAN_CHUNKED_ARRAY_SIZE));
         a.append(&a_b);
         a
     });
 
     // Many Chunk Null Check Parallel Iterator Tests.
-    impl_par_iter_return_option_map_test!(boolean_par_iter_many_chunk_null_check_return_option_map, {
-        let mut a =
-            BooleanChunked::new_from_opt_slice("a", &generate_opt_boolean_vec(BOOLEAN_CHUNKED_ARRAY_SIZE));
-        let a_b =
-            BooleanChunked::new_from_opt_slice("a", &generate_opt_boolean_vec(BOOLEAN_CHUNKED_ARRAY_SIZE));
-        a.append(&a_b);
-        a
-    });
+    impl_par_iter_return_option_map_test!(
+        boolean_par_iter_many_chunk_null_check_return_option_map,
+        {
+            let mut a = BooleanChunked::new_from_opt_slice(
+                "a",
+                &generate_opt_boolean_vec(BOOLEAN_CHUNKED_ARRAY_SIZE),
+            );
+            let a_b = BooleanChunked::new_from_opt_slice(
+                "a",
+                &generate_opt_boolean_vec(BOOLEAN_CHUNKED_ARRAY_SIZE),
+            );
+            a.append(&a_b);
+            a
+        }
+    );
 
     impl_par_iter_return_option_filter_test!(
         boolean_par_iter_many_chunk_null_check_return_option_filter,
@@ -292,16 +314,10 @@ mod test {
                 let a = $ca_init_block;
 
                 // Perform a parallel maping.
-                let par_result = NoNull(&a)
-                    .into_par_iter()
-                    .map(|b| !b)
-                    .collect::<Vec<_>>();
+                let par_result = NoNull(&a).into_par_iter().map(|b| !b).collect::<Vec<_>>();
 
                 // Perform a sequetial maping.
-                let seq_result = a
-                    .into_no_null_iter()
-                    .map(|b| !b)
-                    .collect::<Vec<_>>();
+                let seq_result = a.into_no_null_iter().map(|b| !b).collect::<Vec<_>>();
 
                 // Check sequetial and parallel results are equal.
                 assert_eq!(par_result, seq_result);
@@ -330,10 +346,7 @@ mod test {
                     .collect::<Vec<_>>();
 
                 // Perform a sequetial filter.
-                let seq_result = a
-                    .into_no_null_iter()
-                    .filter(|&b| b)
-                    .collect::<Vec<_>>();
+                let seq_result = a.into_no_null_iter().filter(|&b| b).collect::<Vec<_>>();
 
                 // Check sequetial and parallel results are equal.
                 assert_eq!(par_result, seq_result);
@@ -358,19 +371,20 @@ mod test {
                 // Perform a parallel sum of length.
                 let par_result = NoNull(&a)
                     .into_par_iter()
-                    .fold(|| 0u64, |acc, b| {
-                        let val = if b { 1 } else { 2 };
-                        acc + val
-                    })
+                    .fold(
+                        || 0u64,
+                        |acc, b| {
+                            let val = if b { 1 } else { 2 };
+                            acc + val
+                        },
+                    )
                     .reduce(|| 0u64, |left, right| left + right);
 
                 // Perform a sequential sum of length.
-                let seq_result = a
-                    .into_no_null_iter()
-                    .fold(0u64, |acc, b| {
-                        let val = if b { 1 } else { 2 };
-                        acc + val
-                    });
+                let seq_result = a.into_no_null_iter().fold(0u64, |acc, b| {
+                    let val = if b { 1 } else { 2 };
+                    acc + val
+                });
 
                 // Check sequetial and parallel results are equal.
                 assert_eq!(par_result, seq_result);
@@ -388,14 +402,17 @@ mod test {
         { BooleanChunked::new_from_slice("a", &generate_boolean_vec(BOOLEAN_CHUNKED_ARRAY_SIZE)) }
     );
 
-    impl_par_iter_return_unwrapped_fold_test!(boolean_par_iter_single_chunk_return_unwrapped_fold, {
-        BooleanChunked::new_from_slice("a", &generate_boolean_vec(BOOLEAN_CHUNKED_ARRAY_SIZE))
-    });
+    impl_par_iter_return_unwrapped_fold_test!(
+        boolean_par_iter_single_chunk_return_unwrapped_fold,
+        { BooleanChunked::new_from_slice("a", &generate_boolean_vec(BOOLEAN_CHUNKED_ARRAY_SIZE)) }
+    );
 
     // Many Chunk Return Unwrapped
     impl_par_iter_return_unwrapped_map_test!(boolean_par_iter_many_chunk_return_unwrapped_map, {
-        let mut a = BooleanChunked::new_from_slice("a", &generate_boolean_vec(BOOLEAN_CHUNKED_ARRAY_SIZE));
-        let a_b = BooleanChunked::new_from_slice("a", &generate_boolean_vec(BOOLEAN_CHUNKED_ARRAY_SIZE));
+        let mut a =
+            BooleanChunked::new_from_slice("a", &generate_boolean_vec(BOOLEAN_CHUNKED_ARRAY_SIZE));
+        let a_b =
+            BooleanChunked::new_from_slice("a", &generate_boolean_vec(BOOLEAN_CHUNKED_ARRAY_SIZE));
         a.append(&a_b);
         a
     });
@@ -403,17 +420,24 @@ mod test {
     impl_par_iter_return_unwrapped_filter_test!(
         boolean_par_iter_many_chunk_return_unwrapped_filter,
         {
-            let mut a =
-                BooleanChunked::new_from_slice("a", &generate_boolean_vec(BOOLEAN_CHUNKED_ARRAY_SIZE));
-            let a_b = BooleanChunked::new_from_slice("a", &generate_boolean_vec(BOOLEAN_CHUNKED_ARRAY_SIZE));
+            let mut a = BooleanChunked::new_from_slice(
+                "a",
+                &generate_boolean_vec(BOOLEAN_CHUNKED_ARRAY_SIZE),
+            );
+            let a_b = BooleanChunked::new_from_slice(
+                "a",
+                &generate_boolean_vec(BOOLEAN_CHUNKED_ARRAY_SIZE),
+            );
             a.append(&a_b);
             a
         }
     );
 
     impl_par_iter_return_unwrapped_fold_test!(boolean_par_iter_many_chunk_return_unwrapped_fold, {
-        let mut a = BooleanChunked::new_from_slice("a", &generate_boolean_vec(BOOLEAN_CHUNKED_ARRAY_SIZE));
-        let a_b = BooleanChunked::new_from_slice("a", &generate_boolean_vec(BOOLEAN_CHUNKED_ARRAY_SIZE));
+        let mut a =
+            BooleanChunked::new_from_slice("a", &generate_boolean_vec(BOOLEAN_CHUNKED_ARRAY_SIZE));
+        let a_b =
+            BooleanChunked::new_from_slice("a", &generate_boolean_vec(BOOLEAN_CHUNKED_ARRAY_SIZE));
         a.append(&a_b);
         a
     });

--- a/polars/src/chunked_array/iterator/par/boolean.rs
+++ b/polars/src/chunked_array/iterator/par/boolean.rs
@@ -1,0 +1,50 @@
+use crate::chunked_array::iterator::{
+    SomeIterator, BooleanIterManyChunk, BooleanIterManyChunkNullCheck, BooleanIterSingleChunk,
+    BooleanIterSingleChunkNullCheck,
+};
+use crate::prelude::*;
+use arrow::array::Array;
+use rayon::iter::plumbing::*;
+use rayon::iter::plumbing::{Consumer, ProducerCallback};
+use rayon::prelude::*;
+
+// Implement the parallel iterators for Utf8. It also implement the trait `IntoParallelIterator`
+// for `&'a BooleanChunked` and `NoNull<&'a BooleanChunked>`, which use static dispatcher to use
+// the best implementation of parallel iterators depending on the number of chunks and the
+// existence of null values.
+impl_all_parallel_iterators!(
+    // Chunked array.
+    &'a BooleanChunked,
+
+    // Sequential iterators.
+    BooleanIterSingleChunk<'a>,
+    BooleanIterSingleChunkNullCheck<'a>,
+    BooleanIterManyChunk<'a>,
+    BooleanIterManyChunkNullCheck<'a>,
+
+    // Parallel iterators.
+    BooleanParIterSingleChunkReturnOption,
+    BooleanParIterSingleChunkNullCheckReturnOption,
+    BooleanParIterManyChunkReturnOption,
+    BooleanParIterManyChunkNullCheckReturnOption,
+    BooleanParIterSingleChunkReturnUnwrapped,
+    BooleanParIterManyChunkReturnUnwrapped,
+
+    // Producers.
+    BooleanProducerSingleChunkReturnOption,
+    BooleanProducerSingleChunkNullCheckReturnOption,
+    BooleanProducerManyChunkReturnOption,
+    BooleanProducerManyChunkNullCheckReturnOption,
+    BooleanProducerSingleChunkReturnUnwrapped,
+    BooleanProducerManyChunkReturnUnwrapped,
+
+    // Dispatchers.
+    BooleanParIterDispatcher,
+    BooleanNoNullParIterDispatcher,
+
+    // Iter item.
+    bool,
+
+    // Lifetime.
+    lifetime = 'a
+);

--- a/polars/src/chunked_array/iterator/par/list.rs
+++ b/polars/src/chunked_array/iterator/par/list.rs
@@ -1,0 +1,50 @@
+use crate::chunked_array::iterator::{
+    SomeIterator, ListIterManyChunk, ListIterManyChunkNullCheck, ListIterSingleChunk,
+    ListIterSingleChunkNullCheck,
+};
+use crate::prelude::*;
+use arrow::array::Array;
+use rayon::iter::plumbing::*;
+use rayon::iter::plumbing::{Consumer, ProducerCallback};
+use rayon::prelude::*;
+
+// Implement the parallel iterators for Utf8. It also implement the trait `IntoParallelIterator`
+// for `&'a ListChunked` and `NoNull<&'a ListChunked>`, which use static dispatcher to use
+// the best implementation of parallel iterators depending on the number of chunks and the
+// existence of null values.
+impl_all_parallel_iterators!(
+    // Chunked array.
+    &'a ListChunked,
+
+    // Sequential iterators.
+    ListIterSingleChunk<'a>,
+    ListIterSingleChunkNullCheck<'a>,
+    ListIterManyChunk<'a>,
+    ListIterManyChunkNullCheck<'a>,
+
+    // Parallel iterators.
+    ListParIterSingleChunkReturnOption,
+    ListParIterSingleChunkNullCheckReturnOption,
+    ListParIterManyChunkReturnOption,
+    ListParIterManyChunkNullCheckReturnOption,
+    ListParIterSingleChunkReturnUnwrapped,
+    ListParIterManyChunkReturnUnwrapped,
+
+    // Producers.
+    ListProducerSingleChunkReturnOption,
+    ListProducerSingleChunkNullCheckReturnOption,
+    ListProducerManyChunkReturnOption,
+    ListProducerManyChunkNullCheckReturnOption,
+    ListProducerSingleChunkReturnUnwrapped,
+    ListProducerManyChunkReturnUnwrapped,
+
+    // Dispatchers.
+    ListParIterDispatcher,
+    ListNoNullParIterDispatcher,
+
+    // Iter item.
+    Series,
+
+    // Lifetime.
+    lifetime = 'a
+);

--- a/polars/src/chunked_array/iterator/par/list.rs
+++ b/polars/src/chunked_array/iterator/par/list.rs
@@ -1,6 +1,6 @@
 use crate::chunked_array::iterator::{
-    SomeIterator, ListIterManyChunk, ListIterManyChunkNullCheck, ListIterSingleChunk,
-    ListIterSingleChunkNullCheck,
+    ListIterManyChunk, ListIterManyChunkNullCheck, ListIterSingleChunk,
+    ListIterSingleChunkNullCheck, SomeIterator,
 };
 use crate::prelude::*;
 use arrow::array::Array;
@@ -8,7 +8,7 @@ use rayon::iter::plumbing::*;
 use rayon::iter::plumbing::{Consumer, ProducerCallback};
 use rayon::prelude::*;
 
-// Implement the parallel iterators for Utf8. It also implement the trait `IntoParallelIterator`
+// Implement the parallel iterators for Seriesº. It also implement the trait `IntoParallelIterator`
 // for `&'a ListChunked` and `NoNull<&'a ListChunked>`, which use static dispatcher to use
 // the best implementation of parallel iterators depending on the number of chunks and the
 // existence of null values.

--- a/polars/src/chunked_array/iterator/par/macros.rs
+++ b/polars/src/chunked_array/iterator/par/macros.rs
@@ -16,11 +16,11 @@
 ///
 /// seq_iter_single_chunk: The sequential iterator type for a chunked array with one chunk and without null values.
 ///   It is a type, so it MUST exist and its lifetime, if any, shall be included.
-/// seq_iter_single_chunk_null_check: The sequential iterator type for a chunked array with one chunk and with 
+/// seq_iter_single_chunk_null_check: The sequential iterator type for a chunked array with one chunk and with
 ///   null values. It is a type, so it MUST exist and its lifetime, if any, shall be included.
 /// seq_iter_many_chunk: The sequential iterator type for a chunked array with many chunks and without null values.
 ///   It is a type, so it MUST exist and its lifetime, if any, shall be included.
-/// seq_iter_many_chunk_null_check: The sequential iterator type for a chunked array with many chunks and with 
+/// seq_iter_many_chunk_null_check: The sequential iterator type for a chunked array with many chunks and with
 ///   null values. It is a type, so it MUST exist and its lifetime, if any, shall be included.
 ///
 /// par_iter_single_chunk_return_option: The parallel iterator for chunked arrays with one chunk and no null values.
@@ -98,7 +98,7 @@ macro_rules! impl_all_parallel_iterators {
                 let current_array = chunks[0];
                 let idx_left = offset;
                 let idx_right = offset + len;
-        
+
                 Self {
                     current_array,
                     idx_left,
@@ -106,7 +106,7 @@ macro_rules! impl_all_parallel_iterators {
                 }
             }
         }
-        
+
         impl<$( $lifetime )?> $seq_iter_many_chunk {
             fn from_parts(ca: $ca_type, offset: usize, len: usize) -> Self {
                 let ca = ca;
@@ -118,7 +118,7 @@ macro_rules! impl_all_parallel_iterators {
                 let (chunk_idx_right, current_array_idx_right) = ca.right_index_to_chunked_index(idx_right);
                 let current_array_right = chunks[chunk_idx_right];
                 let current_array_left_len = current_array_left.len();
-        
+
                 Self {
                     ca,
                     chunks,
@@ -134,7 +134,7 @@ macro_rules! impl_all_parallel_iterators {
                 }
             }
         }
-        
+
         /// Parallel Iterator for chunked arrays with just one chunk.
         /// It does NOT perform null check, then, it is appropriated for chunks whose contents are never null.
         ///
@@ -143,15 +143,15 @@ macro_rules! impl_all_parallel_iterators {
         pub struct $par_iter_single_chunk_return_option<$( $lifetime )?> {
             ca: $ca_type,
         }
-        
+
         impl<$( $lifetime )?> $par_iter_single_chunk_return_option<$( $lifetime )?> {
             fn new(ca: $ca_type) -> Self {
                 Self { ca }
             }
         }
-        
+
         impl<$( $lifetime )?> From<$producer_single_chunk_return_option<$( $lifetime )?>>
-            for SomeIterator<$seq_iter_single_chunk> 
+            for SomeIterator<$seq_iter_single_chunk>
         {
             fn from(prod: $producer_single_chunk_return_option<$( $lifetime )?>) -> Self {
                 SomeIterator(<$seq_iter_single_chunk>::from_parts(
@@ -161,7 +161,7 @@ macro_rules! impl_all_parallel_iterators {
                 ))
             }
         }
-        
+
         impl_parallel_iterator!(
             $ca_type,
             $par_iter_single_chunk_return_option<$( $lifetime )?>,
@@ -170,7 +170,7 @@ macro_rules! impl_all_parallel_iterators {
             Option<$iter_item>
             $(, lifetime =  $lifetime )?
         );
-        
+
         /// Parallel Iterator for chunked arrays with just one chunk.
         /// It DOES perform null check, then, it is appropriated for chunks whose contents can be null.
         ///
@@ -179,13 +179,13 @@ macro_rules! impl_all_parallel_iterators {
         pub struct $par_iter_single_chunk_null_check_return_option<$( $lifetime )?> {
             ca: $ca_type,
         }
-        
+
         impl<$( $lifetime )?> $par_iter_single_chunk_null_check_return_option<$( $lifetime )?> {
             fn new(ca: $ca_type) -> Self {
                 Self { ca }
             }
         }
-        
+
         impl<$( $lifetime )?> From<$producer_single_chunk_null_check_return_option<$( $lifetime )?>>
             for $seq_iter_single_chunk_null_check
         {
@@ -195,7 +195,7 @@ macro_rules! impl_all_parallel_iterators {
                 let current_data = current_array.data();
                 let idx_left = prod.offset;
                 let idx_right = prod.offset + prod.len;
-        
+
                 Self {
                     current_data,
                     current_array,
@@ -204,7 +204,7 @@ macro_rules! impl_all_parallel_iterators {
                 }
             }
         }
-        
+
         impl_parallel_iterator!(
             $ca_type,
             $par_iter_single_chunk_null_check_return_option<$( $lifetime )?>,
@@ -213,7 +213,7 @@ macro_rules! impl_all_parallel_iterators {
             Option<$iter_item>
             $(, lifetime =  $lifetime )?
         );
-        
+
         /// Parallel Iterator for chunked arrays with more than one chunk.
         /// It does NOT perform null check, then, it is appropriated for chunks whose contents are never null.
         ///
@@ -222,15 +222,15 @@ macro_rules! impl_all_parallel_iterators {
         pub struct $par_iter_many_chunk_return_option<$( $lifetime )?> {
             ca: $ca_type,
         }
-        
+
         impl<$( $lifetime )?> $par_iter_many_chunk_return_option<$( $lifetime )?> {
             fn new(ca: $ca_type) -> Self {
                 Self { ca }
             }
         }
-        
-        impl<$( $lifetime )?> From<$producer_many_chunk_return_option<$( $lifetime )?>> 
-            for SomeIterator<$seq_iter_many_chunk> 
+
+        impl<$( $lifetime )?> From<$producer_many_chunk_return_option<$( $lifetime )?>>
+            for SomeIterator<$seq_iter_many_chunk>
         {
             fn from(prod: $producer_many_chunk_return_option<$( $lifetime )?>) -> Self {
                 SomeIterator(<$seq_iter_many_chunk>::from_parts(
@@ -240,7 +240,7 @@ macro_rules! impl_all_parallel_iterators {
                 ))
             }
         }
-        
+
         impl_parallel_iterator!(
             $ca_type,
             $par_iter_many_chunk_return_option<$( $lifetime )?>,
@@ -249,7 +249,7 @@ macro_rules! impl_all_parallel_iterators {
             Option<$iter_item>
             $(, lifetime =  $lifetime )?
         );
-        
+
         /// Parallel Iterator for chunked arrays with more than one chunk.
         /// It DOES perform null check, then, it is appropriated for chunks whose contents can be null.
         ///
@@ -258,33 +258,33 @@ macro_rules! impl_all_parallel_iterators {
         pub struct $par_iter_many_chunk_null_check_return_option<$( $lifetime )?> {
             ca: $ca_type,
         }
-        
+
         impl<$( $lifetime )?> $par_iter_many_chunk_null_check_return_option<$( $lifetime )?> {
             fn new(ca: $ca_type) -> Self {
                 Self { ca }
             }
         }
-        
+
         impl<$( $lifetime )?> From<$producer_many_chunk_null_check_return_option<$( $lifetime )?>>
             for $seq_iter_many_chunk_null_check
         {
             fn from(prod: $producer_many_chunk_null_check_return_option<$( $lifetime )?>) -> Self {
                 let ca = prod.ca;
                 let chunks = ca.downcast_chunks();
-        
+
                 // Compute left chunk indexes.
                 let idx_left = prod.offset;
                 let (chunk_idx_left, current_array_idx_left) = ca.index_to_chunked_index(idx_left);
                 let current_array_left = chunks[chunk_idx_left];
                 let current_data_left = current_array_left.data();
                 let current_array_left_len = current_array_left.len();
-        
+
                 // Compute right chunk indexes.
                 let idx_right = prod.offset + prod.len;
                 let (chunk_idx_right, current_array_idx_right) = ca.right_index_to_chunked_index(idx_right);
                 let current_array_right = chunks[chunk_idx_right];
                 let current_data_right = current_array_right.data();
-        
+
                 Self {
                     ca,
                     chunks,
@@ -302,7 +302,7 @@ macro_rules! impl_all_parallel_iterators {
                 }
             }
         }
-        
+
         impl_parallel_iterator!(
             $ca_type,
             $par_iter_many_chunk_null_check_return_option<$( $lifetime )?>,
@@ -311,7 +311,7 @@ macro_rules! impl_all_parallel_iterators {
             Option<$iter_item>
             $(, lifetime =  $lifetime )?
         );
-        
+
         /// Parallel Iterator for chunked arrays with just one chunk.
         /// The chunks cannot have null values so it does NOT perform null checks.
         ///
@@ -321,21 +321,21 @@ macro_rules! impl_all_parallel_iterators {
         pub struct $par_iter_single_chunk_return_unwrapped<$( $lifetime )?> {
             ca: $ca_type,
         }
-        
+
         impl<$( $lifetime )?> $par_iter_single_chunk_return_unwrapped<$( $lifetime )?> {
             fn new(ca: $ca_type) -> Self {
                 Self { ca }
             }
         }
-        
+
         impl<$( $lifetime )?> From<$producer_single_chunk_return_unwrapped<$( $lifetime )?>>
-            for $seq_iter_single_chunk 
+            for $seq_iter_single_chunk
         {
             fn from(prod: $producer_single_chunk_return_unwrapped<$( $lifetime )?>) -> Self {
                 Self::from_parts(prod.ca, prod.offset, prod.len)
             }
         }
-        
+
         impl_parallel_iterator!(
             $ca_type,
             $par_iter_single_chunk_return_unwrapped<$( $lifetime )?>,
@@ -344,7 +344,7 @@ macro_rules! impl_all_parallel_iterators {
             $iter_item
             $(, lifetime =  $lifetime )?
         );
-        
+
         /// Parallel Iterator for chunked arrays with many chunk.
         /// The chunks cannot have null values so it does NOT perform null checks.
         ///
@@ -354,13 +354,13 @@ macro_rules! impl_all_parallel_iterators {
         pub struct $par_iter_many_chunk_return_unwrapped<$( $lifetime )?> {
             ca: $ca_type,
         }
-        
+
         impl<$( $lifetime )?> $par_iter_many_chunk_return_unwrapped<$( $lifetime )?> {
             fn new(ca: $ca_type) -> Self {
                 Self { ca }
             }
         }
-        
+
         impl<$( $lifetime )?> From<$producer_many_chunk_return_unwrapped<$( $lifetime )?>>
             for $seq_iter_many_chunk
         {
@@ -368,7 +368,7 @@ macro_rules! impl_all_parallel_iterators {
                 Self::from_parts(prod.ca, prod.offset, prod.len)
             }
         }
-        
+
         impl_parallel_iterator!(
             $ca_type,
             $par_iter_many_chunk_return_unwrapped<$( $lifetime )?>,
@@ -377,7 +377,7 @@ macro_rules! impl_all_parallel_iterators {
             $iter_item
             $(, lifetime =  $lifetime )?
         );
-        
+
         // Implement into parallel iterator and into no null parallel iterator for $ca_type.
         // In both implementation it creates a static dispatcher which chooses the best implementation
         // of the parallel iterator, depending of the state of the chunked array.
@@ -391,7 +391,7 @@ macro_rules! impl_all_parallel_iterators {
             $iter_item
             $(, lifetime =  $lifetime )?
         );
-        
+
         impl_into_no_null_par_iter!(
             $ca_type,
             $into_no_null_par_iter_dispatcher,
@@ -425,7 +425,7 @@ macro_rules! impl_parallel_iterator {
     (
         $ca_type:ty,
         $par_iter:ty ,
-        $producer:ident, 
+        $producer:ident,
         $seq_iter:ty,
         $iter_item:ty
         $(, lifetime = $lifetime:lifetime )?

--- a/polars/src/chunked_array/iterator/par/macros.rs
+++ b/polars/src/chunked_array/iterator/par/macros.rs
@@ -1,0 +1,343 @@
+//! This module defines the macros used to implement parallel iterators.
+
+/// Generate the code for non-aligned parallel iterators.
+///
+/// # Input
+///
+/// ca_type: The chunked array for which these parallel iterator and producer are implemented.
+/// par_iter: The name of the structure used as parallel iterator. This structure MUST EXIST as
+///   it is not created by this macro. It must consist on a wrapper around a reference to a chunked array.
+/// producer: The name used to create the parallel producer. This structure is created in this macro
+///   and it is compose of three parts:
+///   - ca: a reference to the iterator chunked array.
+///   - offset: the index in the chunked array where to start to process.
+///   - len: the number of items this producer is in charge of processing.
+/// seq_iter: The sequential iterator used to traverse the iterator once the chunked array has been
+///   divided in different producer. This structure MUST EXIST as it is not created by this macro.
+///   This iterator MUST IMPLEMENT the trait `From<producer>`.
+/// iter_item: The iterator `Item`, it represents the iterator return type.
+macro_rules! impl_parallel_iterator {
+    (
+        $ca_type:ty,
+        $par_iter:ty ,
+        $producer:ident $( < $lifetime:lifetime > )?,
+        $seq_iter:ty,
+        $iter_item:ty
+    ) => {
+        impl<$( $lifetime )?> ParallelIterator for $par_iter {
+            type Item = $iter_item;
+
+            fn drive_unindexed<C>(self, consumer: C) -> C::Result
+            where
+                C: UnindexedConsumer<Self::Item>,
+            {
+                bridge(self, consumer)
+            }
+
+            fn opt_len(&self) -> Option<usize> {
+                Some(self.ca.len())
+            }
+        }
+
+        impl<$( $lifetime )?> IndexedParallelIterator for $par_iter {
+            fn len(&self) -> usize {
+                self.ca.len()
+            }
+
+            fn drive<C>(self, consumer: C) -> C::Result
+            where
+                C: Consumer<Self::Item>,
+            {
+                bridge(self, consumer)
+            }
+
+            fn with_producer<CB>(self, callback: CB) -> CB::Output
+            where
+                CB: ProducerCallback<Self::Item>,
+            {
+                callback.callback($producer {
+                    ca: &self.ca,
+                    offset: 0,
+                    len: self.ca.len(),
+                })
+            }
+        }
+
+        struct $producer<$( $lifetime )?> {
+            ca: $ca_type,
+            offset: usize,
+            len: usize,
+        }
+
+        impl<$( $lifetime )?> Producer for $producer<$( $lifetime )?> {
+            type Item = $iter_item;
+            type IntoIter = $seq_iter;
+
+            fn into_iter(self) -> Self::IntoIter {
+                self.into()
+            }
+
+            fn split_at(self, index: usize) -> (Self, Self) {
+                (
+                    $producer {
+                        ca: self.ca,
+                        offset: self.offset,
+                        len: index,
+                    },
+                    $producer {
+                        ca: self.ca,
+                        offset: self.offset + index,
+                        len: self.len - index,
+                    },
+                )
+            }
+        }
+    };
+}
+
+/// Implement the code to convert a chunked array into the best implementation of a parallel iterator.
+/// The implemented parallel iterator uses a static dispatcher, which returns `Option<iter_type>`, to
+/// choose the best implementation of the parallel iterator. The rules to choose the best iterator are:
+/// - If the chunked array has just one chunk and no null values, it will use `single_chunk_return_option`.
+/// - If the chunked array has just one chunk and null values, it will use `single_chunk_null_check_return_option`.
+/// - If the chunked array has many chunks and no null values, it will use `many_chunk_return_option`.
+/// - If the chunked array has many chunks and null values, it will use `many_chunk_null_check_return_option`.
+///
+/// # Input
+///
+/// ca_type: The chunked array for which the `IntoParallelIterator` implemented.
+/// dispatcher: The name of the static dispatcher to be created to implement the `IntoParallelIterator`.
+///   It can contain an optional lifetime.
+/// single_chunk_return_option: A parallel iterator for chunked arrays with just one chunk and no null values.
+/// single_chunk_null_check_return_option: A parallel iterator for chunked arrays with just one chunk and null values.
+/// many_chunk_return_option: A parallel iterator for chunked arrays with many chunks and no null values.
+/// many_chunk_null_check_return_option: A parallel iterator for chunked arrays with many chunks and null values.
+/// iter_item: The iterator `Item`, it represents the iterator return type. It will be wrapped into
+///   an `Option<iter_type>`.
+macro_rules! impl_into_par_iter {
+    (
+        $ca_type:ty,
+        $dispatcher:ident $( < $lifetime:lifetime > )?,
+        $single_chunk_return_option:ty,
+        $single_chunk_null_check_return_option:ty,
+        $many_chunk_return_option:ty,
+        $many_chunk_null_check_return_option:ty,
+        $iter_item:ty
+    ) => {
+        /// Static dispatching structure to allow static polymorphism of chunked parallel iterators.
+        ///
+        /// All the iterators of the dispatcher returns `Option<$iter_item>`.
+        pub enum $dispatcher<$( $lifetime )?> {
+            SingleChunk($single_chunk_return_option),
+            SingleChunkNullCheck($single_chunk_null_check_return_option),
+            ManyChunk($many_chunk_return_option),
+            ManyChunkNullCheck($many_chunk_null_check_return_option),
+        }
+
+        /// Convert `$ca_iter` into a `ParallelIterator` using the most efficient
+        /// `ParallelIterator` implementation for the given `$ca_type`.
+        ///
+        /// - If `$ca_type` has only a chunk and has no null values, it uses `$single_chunk_return_option`.
+        /// - If `$ca_type` has only a chunk and does have null values, it uses `$single_chunk_null_check_return_option`.
+        /// - If `$ca_type` has many chunks and has no null values, it uses `$many_chunk_return_option`.
+        /// - If `$ca_type` has many chunks and does have null values, it uses `$many_chunk_null_check_return_option`.
+        impl<$( $lifetime )?> IntoParallelIterator for $ca_type {
+            type Iter = $dispatcher<$( $lifetime )?>;
+            type Item = Option<$iter_item>;
+
+            fn into_par_iter(self) -> Self::Iter {
+                let chunks = self.downcast_chunks();
+                match chunks.len() {
+                    1 => {
+                        if self.null_count() == 0 {
+                            $dispatcher::SingleChunk(
+                                <$single_chunk_return_option>::new(self),
+                            )
+                        } else {
+                            $dispatcher::SingleChunkNullCheck(
+                                <$single_chunk_null_check_return_option>::new(self),
+                            )
+                        }
+                    }
+                    _ => {
+                        if self.null_count() == 0 {
+                            $dispatcher::ManyChunk(
+                                <$many_chunk_return_option>::new(self),
+                            )
+                        } else {
+                            $dispatcher::ManyChunkNullCheck(
+                                <$many_chunk_null_check_return_option>::new(self),
+                            )
+                        }
+                    }
+                }
+            }
+        }
+
+        impl<$( $lifetime )?> ParallelIterator for $dispatcher<$( $lifetime )?> {
+            type Item = Option<$iter_item>;
+
+            fn drive_unindexed<C>(self, consumer: C) -> C::Result
+            where
+                C: UnindexedConsumer<Self::Item>,
+            {
+                match self {
+                    $dispatcher::SingleChunk(a) => a.drive_unindexed(consumer),
+                    $dispatcher::SingleChunkNullCheck(a) => a.drive_unindexed(consumer),
+                    $dispatcher::ManyChunk(a) => a.drive_unindexed(consumer),
+                    $dispatcher::ManyChunkNullCheck(a) => a.drive_unindexed(consumer),
+                }
+            }
+
+            fn opt_len(&self) -> Option<usize> {
+                match self {
+                    $dispatcher::SingleChunk(a) => a.opt_len(),
+                    $dispatcher::SingleChunkNullCheck(a) => a.opt_len(),
+                    $dispatcher::ManyChunk(a) => a.opt_len(),
+                    $dispatcher::ManyChunkNullCheck(a) => a.opt_len(),
+                }
+            }
+        }
+
+        impl<$( $lifetime )?> IndexedParallelIterator for $dispatcher<$( $lifetime )?> {
+            fn len(&self) -> usize {
+                match self {
+                    $dispatcher::SingleChunk(a) => a.len(),
+                    $dispatcher::SingleChunkNullCheck(a) => a.len(),
+                    $dispatcher::ManyChunk(a) => a.len(),
+                    $dispatcher::ManyChunkNullCheck(a) => a.len(),
+                }
+            }
+
+            fn drive<C>(self, consumer: C) -> C::Result
+            where
+                C: Consumer<Self::Item>,
+            {
+                match self {
+                    $dispatcher::SingleChunk(a) => a.drive(consumer),
+                    $dispatcher::SingleChunkNullCheck(a) => a.drive(consumer),
+                    $dispatcher::ManyChunk(a) => a.drive(consumer),
+                    $dispatcher::ManyChunkNullCheck(a) => a.drive(consumer),
+                }
+            }
+
+            fn with_producer<CB>(self, callback: CB) -> CB::Output
+            where
+                CB: ProducerCallback<Self::Item>,
+            {
+                match self {
+                    $dispatcher::SingleChunk(a) => a.with_producer(callback),
+                    $dispatcher::SingleChunkNullCheck(a) => a.with_producer(callback),
+                    $dispatcher::ManyChunk(a) => a.with_producer(callback),
+                    $dispatcher::ManyChunkNullCheck(a) => a.with_producer(callback),
+                }
+            }
+        }
+    };
+}
+
+/// Implement the code to convert a non-nullable chunked array into the best implementation of a
+/// parallel iterator which cannot contain null values. The implemented parallel iterator uses a static
+/// dispatcher, which returns `iter_type`, to choose the best implementation of the parallel iterator.
+/// The rules to choose the best iterator are:
+/// - If the chunked array has just one chunk and no null values, it will use `single_chunk_return_unwrapped`.
+/// - If the chunked array has many chunks and no null values, it will use `many_chunk_return_unwrapped`.
+///
+/// # Input
+///
+/// ca_type: The chunked array for which the `IntoParallelIterator` implemented.
+/// dispatcher: The name of the static dispatcher to be created to implement the `IntoParallelIterator`.
+///   It can contain an optional lifetime.
+/// single_chunk_return_unwrapped: A parallel iterator for chunked arrays with just one chunk and no null values.
+/// many_chunk_return_unwrapped: A parallel iterator for chunked arrays with many chunks and no null values.
+/// iter_item: The iterator `Item`, it represents the iterator return type.
+macro_rules! impl_into_no_null_par_iter {
+    (
+        $ca_type:ty,
+        $dispatcher:ident $( < $lifetime:lifetime > )?,
+        $single_chunk_return_unwrapped:ty,
+        $many_chunk_return_unwrapped:ty,
+        $iter_item:ty
+    ) => {
+        /// Static dispatching structure to allow static polymorphism of non-nullable chunked parallel iterators.
+        ///
+        /// All the iterators of the dispatcher returns `$iter_item`, as there are no nulls in the chunked array.
+        pub enum $dispatcher<$( $lifetime )?> {
+            SingleChunk($single_chunk_return_unwrapped),
+            ManyChunk($many_chunk_return_unwrapped),
+        }
+
+        /// Convert non-nullable `$ca_type` into a non-nullable `ParallelIterator` using the most
+        /// efficient `ParallelIterator` implementation for the given `$ca_type`.
+        ///
+        /// - If `$ca_type` has only a chunk, it uses `$single_chunk_return_unwrapped`.
+        /// - If `$ca_type` has many chunks, it uses `$many_chunk_return_unwrapped`.
+        impl<$( $lifetime )?> IntoParallelIterator for NoNull<$ca_type> {
+            type Iter = $dispatcher<$( $lifetime )?>;
+            type Item = $iter_item;
+
+            fn into_par_iter(self) -> Self::Iter {
+                let ca = self.0;
+                let chunks = ca.downcast_chunks();
+                match chunks.len() {
+                    1 => $dispatcher::SingleChunk(
+                        <$single_chunk_return_unwrapped>::new(ca),
+                    ),
+                    _ => $dispatcher::ManyChunk(
+                        <$many_chunk_return_unwrapped>::new(ca),
+                    ),
+                }
+            }
+        }
+
+        impl<$( $lifetime )?> ParallelIterator for $dispatcher<$( $lifetime )?> {
+            type Item = $iter_item;
+
+            fn drive_unindexed<C>(self, consumer: C) -> C::Result
+            where
+                C: UnindexedConsumer<Self::Item>,
+            {
+                match self {
+                    $dispatcher::SingleChunk(a) => a.drive_unindexed(consumer),
+                    $dispatcher::ManyChunk(a) => a.drive_unindexed(consumer),
+                }
+            }
+
+            fn opt_len(&self) -> Option<usize> {
+                match self {
+                    $dispatcher::SingleChunk(a) => a.opt_len(),
+                    $dispatcher::ManyChunk(a) => a.opt_len(),
+                }
+            }
+        }
+
+        impl<$( $lifetime )?> IndexedParallelIterator for $dispatcher<$( $lifetime )?> {
+            fn len(&self) -> usize {
+                match self {
+                    $dispatcher::SingleChunk(a) => a.len(),
+                    $dispatcher::ManyChunk(a) => a.len(),
+                }
+            }
+
+            fn drive<C>(self, consumer: C) -> C::Result
+            where
+                C: Consumer<Self::Item>,
+            {
+                match self {
+                    $dispatcher::SingleChunk(a) => a.drive(consumer),
+                    $dispatcher::ManyChunk(a) => a.drive(consumer),
+                }
+            }
+
+            fn with_producer<CB>(self, callback: CB) -> CB::Output
+            where
+                CB: ProducerCallback<Self::Item>,
+            {
+                match self {
+                    $dispatcher::SingleChunk(a) => a.with_producer(callback),
+                    $dispatcher::ManyChunk(a) => a.with_producer(callback),
+                }
+            }
+        }
+    };
+}

--- a/polars/src/chunked_array/iterator/par/mod.rs
+++ b/polars/src/chunked_array/iterator/par/mod.rs
@@ -2,9 +2,9 @@ use crate::chunked_array::ChunkedArray;
 
 #[macro_use]
 mod macros;
-pub mod utf8;
 pub mod boolean;
 pub mod list;
+pub mod utf8;
 
 impl<T> ChunkedArray<T> {
     /// Helper function for parallel iterators. It computes the chunk index and the index inside that chunk, for right

--- a/polars/src/chunked_array/iterator/par/mod.rs
+++ b/polars/src/chunked_array/iterator/par/mod.rs
@@ -3,6 +3,8 @@ use crate::chunked_array::ChunkedArray;
 #[macro_use]
 mod macros;
 pub mod utf8;
+pub mod boolean;
+pub mod list;
 
 impl<T> ChunkedArray<T> {
     /// Helper function for parallel iterators. It computes the chunk index and the index inside that chunk, for right

--- a/polars/src/chunked_array/iterator/par/mod.rs
+++ b/polars/src/chunked_array/iterator/par/mod.rs
@@ -1,5 +1,7 @@
 use crate::chunked_array::ChunkedArray;
 
+#[macro_use]
+mod macros;
 pub mod utf8;
 
 impl<T> ChunkedArray<T> {

--- a/polars/src/chunked_array/iterator/par/utf8.rs
+++ b/polars/src/chunked_array/iterator/par/utf8.rs
@@ -62,7 +62,7 @@ mod test {
         (0..size).map(|n| n.to_string()).collect()
     }
 
-    /// Generate a `Vec` of `Option<String`, where even indexes are `None` and odd indexes are `Some("{idx}")`.
+    /// Generate a `Vec` of `Option<String>`, where even indexes are `None` and odd indexes are `Some("{idx}")`.
     fn generate_opt_utf8_vec(size: usize) -> Vec<Option<String>> {
         (0..size)
             .map(|n| {


### PR DESCRIPTION
This pull request contains the following changes:
1. A `macro` module has been added to the `chunked_array::iterator::par` module. It contains every macro that is common for the different `ParallelIterators` types. The macros are visible just inside the `chunked_array::iterator::par` module and its submodules.
2. Generalized `utf8` module code as a macro. Every module, boolean, utf8 and list, use the same code to generate `ParallelIterator`s, so make sense to generalize its code into a macro, and to use the newly created macro to generate the code for other modules.
3. Implement `Utf8Chunked`, `BooleanChunked` and `ListChunked` parallel iterators by using the newly created macro.
4. Create test for `BooleanChunked` parallel iterators.

NOTE: There are no test for `ListChunked`. This is because right now I couldn't find a method to create a `ListChunked` from slice, or a similar method.