### PR TITLE
Toggle not very useful datatypes in Series.

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ Additional cargo features:
     - Lazy api
 * `strings`
     - String utilities for `Utf8Chunked`
+* `dtype-interval`
+    - toggle Interval datatype
 
 ## Contribution
 Want to contribute? Read our [contribution guideline](./CONTRIBUTING.md).

--- a/examples/aggregate_multiple_files_in_chunks/src/main.rs
+++ b/examples/aggregate_multiple_files_in_chunks/src/main.rs
@@ -191,7 +191,7 @@ fn right_or_append(mut accumulator: DataFrame, right: DataFrame) -> PolarResult<
     if accumulator.width() == 0 {
         Ok(right)
     } else {
-        accumulator.vstack(&right)?;
+        accumulator.vstack_mut(&right)?;
         Ok(accumulator)
     }
 }

--- a/polars/Cargo.toml
+++ b/polars/Cargo.toml
@@ -20,6 +20,7 @@ lazy = []
 parallel = []
 # extra utilities for Utf8Chunked
 strings = []
+dtype-interval = []
 
 [dependencies]
 arrow = {version = "2", default_features = false}

--- a/polars/src/chunked_array/mod.rs
+++ b/polars/src/chunked_array/mod.rs
@@ -45,11 +45,13 @@ pub mod upstream_traits;
 use crate::chunked_array::object::ObjectArray;
 use arrow::array::{
     Array, ArrayDataRef, Date32Array, DurationMicrosecondArray, DurationMillisecondArray,
-    DurationNanosecondArray, DurationSecondArray, IntervalDayTimeArray, IntervalYearMonthArray,
-    ListArray, Time32MillisecondArray, Time32SecondArray, Time64MicrosecondArray,
-    TimestampMicrosecondArray, TimestampMillisecondArray, TimestampNanosecondArray,
-    TimestampSecondArray,
+    DurationNanosecondArray, DurationSecondArray, ListArray, Time32MillisecondArray,
+    Time32SecondArray, Time64MicrosecondArray, TimestampMicrosecondArray,
+    TimestampMillisecondArray, TimestampNanosecondArray, TimestampSecondArray,
 };
+#[cfg(feature = "dtype-interval")]
+use arrow::array::{IntervalDayTimeArray, IntervalYearMonthArray};
+
 use arrow::util::bit_util::{get_bit, round_upto_power_of_2};
 use std::fmt::Debug;
 use std::mem;
@@ -240,7 +242,9 @@ impl<T> ChunkedArray<T> {
             ArrowDataType::Time32(TimeUnit::Second) => unpack!(Time32Second),
             ArrowDataType::Time64(TimeUnit::Nanosecond) => unpack!(Time64Nanosecond),
             ArrowDataType::Time64(TimeUnit::Microsecond) => unpack!(Time64Microsecond),
+            #[cfg(feature = "dtype-interval")]
             ArrowDataType::Interval(IntervalUnit::DayTime) => unpack!(IntervalDayTime),
+            #[cfg(feature = "dtype-interval")]
             ArrowDataType::Interval(IntervalUnit::YearMonth) => unpack!(IntervalYearMonth),
             ArrowDataType::Duration(TimeUnit::Nanosecond) => unpack!(DurationNanosecond),
             ArrowDataType::Duration(TimeUnit::Microsecond) => unpack!(DurationMicrosecond),
@@ -556,9 +560,11 @@ where
                 let v = downcast!(Time64MicrosecondArray);
                 AnyType::Time64(v, TimeUnit::Microsecond)
             }
+            #[cfg(feature = "dtype-interval")]
             ArrowDataType::Interval(IntervalUnit::DayTime) => {
                 downcast_and_pack!(IntervalDayTimeArray, IntervalDayTime)
             }
+            #[cfg(feature = "dtype-interval")]
             ArrowDataType::Interval(IntervalUnit::YearMonth) => {
                 downcast_and_pack!(IntervalYearMonthArray, IntervalYearMonth)
             }

--- a/polars/src/datatypes.rs
+++ b/polars/src/datatypes.rs
@@ -90,7 +90,9 @@ pub type Time64NanosecondChunked = ChunkedArray<Time64NanosecondType>;
 pub type Time64MicrosecondChunked = ChunkedArray<Time64MicrosecondType>;
 pub type Time32MillisecondChunked = ChunkedArray<Time32MillisecondType>;
 pub type Time32SecondChunked = ChunkedArray<Time32SecondType>;
+#[cfg(feature = "dtype-interval")]
 pub type IntervalDayTimeChunked = ChunkedArray<IntervalDayTimeType>;
+#[cfg(feature = "dtype-interval")]
 pub type IntervalYearMonthChunked = ChunkedArray<IntervalYearMonthType>;
 
 pub type TimestampNanosecondChunked = ChunkedArray<TimestampNanosecondType>;
@@ -120,7 +122,9 @@ impl PolarsPrimitiveType for DurationNanosecondType {}
 impl PolarsPrimitiveType for DurationMicrosecondType {}
 impl PolarsPrimitiveType for DurationMillisecondType {}
 impl PolarsPrimitiveType for DurationSecondType {}
+#[cfg(feature = "dtype-interval")]
 impl PolarsPrimitiveType for IntervalYearMonthType {}
+#[cfg(feature = "dtype-interval")]
 impl PolarsPrimitiveType for IntervalDayTimeType {}
 impl PolarsPrimitiveType for TimestampNanosecondType {}
 impl PolarsPrimitiveType for TimestampMicrosecondType {}
@@ -148,7 +152,9 @@ impl PolarsNumericType for DurationNanosecondType {}
 impl PolarsNumericType for DurationMicrosecondType {}
 impl PolarsNumericType for DurationMillisecondType {}
 impl PolarsNumericType for DurationSecondType {}
+#[cfg(feature = "dtype-interval")]
 impl PolarsNumericType for IntervalYearMonthType {}
+#[cfg(feature = "dtype-interval")]
 impl PolarsNumericType for IntervalDayTimeType {}
 impl PolarsNumericType for TimestampNanosecondType {}
 impl PolarsNumericType for TimestampMicrosecondType {}
@@ -174,7 +180,9 @@ impl PolarsIntegerType for DurationNanosecondType {}
 impl PolarsIntegerType for DurationMicrosecondType {}
 impl PolarsIntegerType for DurationMillisecondType {}
 impl PolarsIntegerType for DurationSecondType {}
+#[cfg(feature = "dtype-interval")]
 impl PolarsIntegerType for IntervalYearMonthType {}
+#[cfg(feature = "dtype-interval")]
 impl PolarsIntegerType for IntervalDayTimeType {}
 impl PolarsIntegerType for TimestampNanosecondType {}
 impl PolarsIntegerType for TimestampMicrosecondType {}
@@ -229,7 +237,9 @@ pub enum AnyType<'a> {
     TimeStamp(i64, TimeUnit),
     /// A "calendar" interval which models types that don't necessarily have a precise duration without the context of a base timestamp
     /// (e.g. days can differ in length during day light savings time transitions).
+    #[cfg(feature = "dtype-interval")]
     IntervalDayTime(i64),
+    #[cfg(feature = "dtype-interval")]
     IntervalYearMonth(i32),
     List(Series),
     /// Use as_any to get a dyn Any
@@ -272,7 +282,9 @@ impl ToStr for ArrowDataType {
             ArrowDataType::Duration(TimeUnit::Microsecond) => "duration(μs)",
             ArrowDataType::Duration(TimeUnit::Millisecond) => "duration(ms)",
             ArrowDataType::Duration(TimeUnit::Second) => "duration(s)",
+            #[cfg(feature = "dtype-interval")]
             ArrowDataType::Interval(IntervalUnit::DayTime) => "interval(daytime)",
+            #[cfg(feature = "dtype-interval")]
             ArrowDataType::Interval(IntervalUnit::YearMonth) => "interval(year-month)",
             ArrowDataType::List(tp) => return format!("list [{}]", tp.to_str()),
             ArrowDataType::Binary => "object",

--- a/polars/src/fmt.rs
+++ b/polars/src/fmt.rs
@@ -216,9 +216,11 @@ impl Debug for Series {
             Series::DurationSecond(a) => {
                 format_array!(limit, f, a, "duration(s)", a.name(), "Series")
             }
+            #[cfg(feature = "dtype-interval")]
             Series::IntervalDayTime(a) => {
                 format_array!(limit, f, a, "interval(daytime)", a.name(), "Series")
             }
+            #[cfg(feature = "dtype-interval")]
             Series::IntervalYearMonth(a) => {
                 format_array!(limit, f, a, "interval(year-month)", a.name(), "Series")
             }
@@ -412,7 +414,9 @@ impl Display for AnyType<'_> {
             AnyType::TimeStamp(v, TimeUnit::Second) => {
                 write!(f, "{}", timestamp_seconds_as_datetime(*v))
             }
+            #[cfg(feature = "dtype-interval")]
             AnyType::IntervalDayTime(v) => write!(f, "{}", v),
+            #[cfg(feature = "dtype-interval")]
             AnyType::IntervalYearMonth(v) => write!(f, "{}", v),
             AnyType::List(s) => write!(f, "{:?}", s.fmt_list()),
             AnyType::Object(_) => write!(f, "object"),

--- a/polars/src/frame/explode.rs
+++ b/polars/src/frame/explode.rs
@@ -211,7 +211,7 @@ impl DataFrame {
             .ok_or_else(|| PolarsError::NoData("No data in melt operation".into()))?;
 
         while let Some(df) = dataframe_chunks.pop_front() {
-            main_df.vstack(&df)?;
+            main_df.vstack_mut(&df)?;
         }
         Ok(main_df)
     }

--- a/polars/src/frame/group_by.rs
+++ b/polars/src/frame/group_by.rs
@@ -199,7 +199,9 @@ impl Series {
             Series::DurationMicrosecond(ca) => as_groupable_iter!(ca, Int64),
             Series::DurationMillisecond(ca) => as_groupable_iter!(ca, Int64),
             Series::DurationSecond(ca) => as_groupable_iter!(ca, Int64),
+            #[cfg(feature = "dtype-interval")]
             Series::IntervalDayTime(ca) => as_groupable_iter!(ca, Int64),
+            #[cfg(feature = "dtype-interval")]
             Series::IntervalYearMonth(ca) => as_groupable_iter!(ca, Int32),
             Series::Utf8(ca) => as_groupable_iter!(ca, Utf8),
             Series::Float32(ca) => Ok(float_to_groupable_iter(ca)),

--- a/polars/src/frame/hash_join.rs
+++ b/polars/src/frame/hash_join.rs
@@ -72,7 +72,9 @@ macro_rules! apply_hash_join_on_series {
             Series::TimestampMicrosecond(ca_left) => {
                 $join_macro!($s_right, ca_left, timestamp_microsecond)
             }
+            #[cfg(feature = "dtype-interval")]
             Series::IntervalDayTime(ca_left) => $join_macro!($s_right, ca_left, interval_daytime),
+            #[cfg(feature = "dtype-interval")]
             Series::IntervalYearMonth(ca_left) => {
                 $join_macro!($s_right, ca_left, interval_year_month)
             }

--- a/polars/src/lib.rs
+++ b/polars/src/lib.rs
@@ -188,11 +188,13 @@
 //! * `ndarray`
 //!     - Convert from `DataFrame` to `ndarray`
 //! * `parallel`
-//!     - Parallel variants of operation
+//!     - Parallel variants of operations
 //! * `lazy`
 //!     - Lazy api
 //! * `strings`
 //!     - String utilities for `Utf8Chunked`
+//! * `dtype-interval`
+//!     - toggle Interval datatype
 #![allow(dead_code)]
 #![feature(iterator_fold_self)]
 #![feature(doc_cfg)]

--- a/polars/src/series/aggregate.rs
+++ b/polars/src/series/aggregate.rs
@@ -81,9 +81,11 @@ macro_rules! apply_agg_fn {
             Series::TimestampSecond(a) => a
                 .$agg()
                 .map(|v| T::from(v).expect("could not cast TimestampSecond to T")),
+            #[cfg(feature = "dtype-interval")]
             Series::IntervalDayTime(a) => a
                 .$agg()
                 .map(|v| T::from(v).expect("could not cast IntervalDayTime to T")),
+            #[cfg(feature = "dtype-interval")]
             Series::IntervalYearMonth(a) => a
                 .$agg()
                 .map(|v| T::from(v).expect("could not cast IntervalYearMonth to T")),

--- a/polars/src/series/comparison.rs
+++ b/polars/src/series/comparison.rs
@@ -58,7 +58,9 @@ macro_rules! impl_compare {
                 compare!(Series::TimestampMillisecond, a, $rhs, $method)
             }
             Series::TimestampSecond(a) => compare!(Series::TimestampSecond, a, $rhs, $method),
+            #[cfg(feature = "dtype-interval")]
             Series::IntervalDayTime(a) => compare!(Series::IntervalDayTime, a, $rhs, $method),
+            #[cfg(feature = "dtype-interval")]
             Series::IntervalYearMonth(a) => compare!(Series::IntervalYearMonth, a, $rhs, $method),
             Series::List(a) => compare!(Series::List, a, $rhs, $method),
             Series::Object(_) => fill_bool(false, $self.len()),

--- a/polars/src/series/mod.rs
+++ b/polars/src/series/mod.rs
@@ -131,7 +131,11 @@ pub enum Series {
     DurationMicrosecond(DurationMicrosecondChunked),
     DurationMillisecond(DurationMillisecondChunked),
     DurationSecond(DurationSecondChunked),
+    #[cfg(feature = "dtype-interval")]
+    #[doc(cfg(feature = "dtype-interval"))]
     IntervalDayTime(IntervalDayTimeChunked),
+    #[cfg(feature = "dtype-interval")]
+    #[doc(cfg(feature = "dtype-interval"))]
     IntervalYearMonth(IntervalYearMonthChunked),
     TimestampNanosecond(TimestampNanosecondChunked),
     TimestampMicrosecond(TimestampMicrosecondChunked),
@@ -356,11 +360,15 @@ impl Series {
     }
 
     /// Unpack to ChunkedArray
+    #[cfg(feature = "dtype-interval")]
+    #[doc(cfg(feature = "dtype-interval"))]
     pub fn interval_daytime(&self) -> Result<&IntervalDayTimeChunked> {
         unpack_series!(self, IntervalDayTime, "intervaldaytime")
     }
 
     /// Unpack to ChunkedArray
+    #[cfg(feature = "dtype-interval")]
+    #[doc(cfg(feature = "dtype-interval"))]
     pub fn interval_year_month(&self) -> Result<&IntervalYearMonthChunked> {
         unpack_series!(self, IntervalYearMonth, "intervalyearmonth")
     }
@@ -571,7 +579,9 @@ impl Series {
             Series::TimestampMicrosecond(arr) => pack_ca_to_series(arr.cast::<N>()?),
             Series::TimestampMillisecond(arr) => pack_ca_to_series(arr.cast::<N>()?),
             Series::TimestampSecond(arr) => pack_ca_to_series(arr.cast::<N>()?),
+            #[cfg(feature = "dtype-interval")]
             Series::IntervalDayTime(arr) => pack_ca_to_series(arr.cast::<N>()?),
+            #[cfg(feature = "dtype-interval")]
             Series::IntervalYearMonth(arr) => pack_ca_to_series(arr.cast::<N>()?),
             Series::List(arr) => pack_ca_to_series(arr.cast::<N>()?),
             Series::Object(_) => return Err(PolarsError::Other("cannot cast object".into())),
@@ -608,7 +618,9 @@ impl Series {
             Timestamp(TimeUnit::Microsecond, _) => self.cast::<TimestampMicrosecondType>(),
             Timestamp(TimeUnit::Millisecond, _) => self.cast::<TimestampMillisecondType>(),
             Timestamp(TimeUnit::Second, _) => self.cast::<TimestampSecondType>(),
+            #[cfg(feature = "dtype-interval")]
             Interval(IntervalUnit::DayTime) => self.cast::<IntervalDayTimeType>(),
+            #[cfg(feature = "dtype-interval")]
             Interval(IntervalUnit::YearMonth) => self.cast::<IntervalYearMonthType>(),
             List(_) => self.cast::<ListType>(),
             dt => Err(PolarsError::Other(
@@ -670,7 +682,9 @@ impl Series {
             Series::TimestampMicrosecond(arr) => unpack_if_match!(arr),
             Series::TimestampMillisecond(arr) => unpack_if_match!(arr),
             Series::TimestampSecond(arr) => unpack_if_match!(arr),
+            #[cfg(feature = "dtype-interval")]
             Series::IntervalDayTime(arr) => unpack_if_match!(arr),
+            #[cfg(feature = "dtype-interval")]
             Series::IntervalYearMonth(arr) => unpack_if_match!(arr),
             Series::List(arr) => unpack_if_match!(arr),
             Series::Object(arr) => unpack_if_match!(arr),
@@ -1093,14 +1107,19 @@ fn pack_ca_to_series<N: PolarsDataType>(ca: ChunkedArray<N>) -> Series {
             ArrowDataType::Timestamp(TimeUnit::Second, _) => {
                 Series::TimestampSecond(mem::transmute(ca))
             }
+            #[cfg(feature = "dtype-interval")]
             ArrowDataType::Interval(IntervalUnit::YearMonth) => {
                 Series::IntervalYearMonth(mem::transmute(ca))
             }
+            #[cfg(feature = "dtype-interval")]
             ArrowDataType::Interval(IntervalUnit::DayTime) => {
                 Series::IntervalDayTime(mem::transmute(ca))
             }
             ArrowDataType::List(_) => Series::List(mem::transmute(ca)),
-            _ => panic!("Not implemented: {:?}", N::get_data_type()),
+            _ => panic!(
+                "Not implemented or feature flag toggled off: {:?}",
+                N::get_data_type()
+            ),
         }
     }
 }
@@ -1207,7 +1226,9 @@ impl_as_ref_ca!(TimestampNanosecondType, TimestampNanosecond);
 impl_as_ref_ca!(TimestampMicrosecondType, TimestampMicrosecond);
 impl_as_ref_ca!(TimestampMillisecondType, TimestampMillisecond);
 impl_as_ref_ca!(TimestampSecondType, TimestampSecond);
+#[cfg(feature = "dtype-interval")]
 impl_as_ref_ca!(IntervalDayTimeType, IntervalDayTime);
+#[cfg(feature = "dtype-interval")]
 impl_as_ref_ca!(IntervalYearMonthType, IntervalYearMonth);
 impl_as_ref_ca!(ListType, List);
 
@@ -1259,7 +1280,9 @@ impl_as_mut_ca!(TimestampNanosecondType, TimestampNanosecond);
 impl_as_mut_ca!(TimestampMicrosecondType, TimestampMicrosecond);
 impl_as_mut_ca!(TimestampMillisecondType, TimestampMillisecond);
 impl_as_mut_ca!(TimestampSecondType, TimestampSecond);
+#[cfg(feature = "dtype-interval")]
 impl_as_mut_ca!(IntervalDayTimeType, IntervalDayTime);
+#[cfg(feature = "dtype-interval")]
 impl_as_mut_ca!(IntervalYearMonthType, IntervalYearMonth);
 impl_as_mut_ca!(ListType, List);
 
@@ -1301,7 +1324,9 @@ from_series_to_ca!(TimestampMillisecond, TimestampMillisecondChunked);
 from_series_to_ca!(TimestampSecond, TimestampSecondChunked);
 from_series_to_ca!(TimestampMicrosecond, TimestampMicrosecondChunked);
 from_series_to_ca!(TimestampNanosecond, TimestampNanosecondChunked);
+#[cfg(feature = "dtype-interval")]
 from_series_to_ca!(IntervalDayTime, IntervalDayTimeChunked);
+#[cfg(feature = "dtype-interval")]
 from_series_to_ca!(IntervalYearMonth, IntervalYearMonthChunked);
 from_series_to_ca!(List, ListChunked);
 
@@ -1341,9 +1366,11 @@ impl From<(&str, ArrayRef)> for Series {
             ArrowDataType::Time64(TimeUnit::Microsecond) => {
                 Time64MicrosecondChunked::new_from_chunks(name, chunk).into_series()
             }
+            #[cfg(feature = "dtype-interval")]
             ArrowDataType::Interval(IntervalUnit::DayTime) => {
                 IntervalDayTimeChunked::new_from_chunks(name, chunk).into_series()
             }
+            #[cfg(feature = "dtype-interval")]
             ArrowDataType::Interval(IntervalUnit::YearMonth) => {
                 IntervalYearMonthChunked::new_from_chunks(name, chunk).into_series()
             }

--- a/polars/src/utils.rs
+++ b/polars/src/utils.rs
@@ -568,7 +568,7 @@ pub fn accumulate_dataframes_vertical(dfs: Vec<DataFrame>) -> Result<DataFrame> 
     let mut iter = dfs.into_iter();
     let mut acc_df = iter.next().unwrap();
     for df in iter {
-        acc_df.vstack(&df)?;
+        acc_df.vstack_mut(&df)?;
     }
     Ok(acc_df)
 }

--- a/polars/src/utils.rs
+++ b/polars/src/utils.rs
@@ -175,7 +175,9 @@ macro_rules! match_arrow_data_type_apply_macro {
             ArrowDataType::Time32(TimeUnit::Second) => $macro!(Time32SecondType $(, $opt_args)*),
             ArrowDataType::Time64(TimeUnit::Nanosecond) => $macro!(Time64NanosecondType $(, $opt_args)*),
             ArrowDataType::Time64(TimeUnit::Microsecond) => $macro!(Time64MicrosecondType $(, $opt_args)*),
+            #[cfg(feature = "dtype-interval")]
             ArrowDataType::Interval(IntervalUnit::DayTime) => $macro!(IntervalDayTimeType $(, $opt_args)*),
+            #[cfg(feature = "dtype-interval")]
             ArrowDataType::Interval(IntervalUnit::YearMonth) => $macro!(IntervalYearMonthType $(, $opt_args)*),
             ArrowDataType::Duration(TimeUnit::Nanosecond) => $macro!(DurationNanosecondType $(, $opt_args)*),
             ArrowDataType::Duration(TimeUnit::Microsecond) => $macro!(DurationMicrosecondType $(, $opt_args)*),
@@ -220,7 +222,9 @@ macro_rules! apply_method_all_arrow_series {
             Series::TimestampMicrosecond(a) => a.$method($($args),*),
             Series::TimestampMillisecond(a) => a.$method($($args),*),
             Series::TimestampSecond(a) => a.$method($($args),*),
+            #[cfg(feature = "dtype-interval")]
             Series::IntervalDayTime(a) => a.$method($($args),*),
+            #[cfg(feature = "dtype-interval")]
             Series::IntervalYearMonth(a) => a.$method($($args),*),
             Series::List(a) => a.$method($($args),*),
             Series::Object(_) => panic!("not implemented for object type"),
@@ -258,7 +262,9 @@ macro_rules! apply_method_all_series {
             Series::TimestampMicrosecond(a) => a.$method($($args),*),
             Series::TimestampMillisecond(a) => a.$method($($args),*),
             Series::TimestampSecond(a) => a.$method($($args),*),
+            #[cfg(feature = "dtype-interval")]
             Series::IntervalDayTime(a) => a.$method($($args),*),
+            #[cfg(feature = "dtype-interval")]
             Series::IntervalYearMonth(a) => a.$method($($args),*),
             Series::List(a) => a.$method($($args),*),
             Series::Object(a) => a.$method($($args),*),
@@ -295,7 +301,9 @@ macro_rules! apply_method_numeric_series {
             Series::TimestampMicrosecond(a) => a.$method($($args),*),
             Series::TimestampMillisecond(a) => a.$method($($args),*),
             Series::TimestampSecond(a) => a.$method($($args),*),
+            #[cfg(feature = "dtype-interval")]
             Series::IntervalDayTime(a) => a.$method($($args),*),
+            #[cfg(feature = "dtype-interval")]
             Series::IntervalYearMonth(a) => a.$method($($args),*),
             _ => unimplemented!(),
         }
@@ -330,7 +338,9 @@ macro_rules! apply_method_numeric_series_and_return {
             Series::TimestampMicrosecond(a) => Series::TimestampMicrosecond(a.$method($($args),*)$($opt_question_mark)*),
             Series::TimestampMillisecond(a) => Series::TimestampMillisecond(a.$method($($args),*)$($opt_question_mark)*),
             Series::TimestampSecond(a) => Series::TimestampSecond(a.$method($($args),*)$($opt_question_mark)*),
+            #[cfg(feature = "dtype-interval")]
             Series::IntervalDayTime(a) => Series::IntervalDayTime(a.$method($($args),*)$($opt_question_mark)*),
+            #[cfg(feature = "dtype-interval")]
             Series::IntervalYearMonth(a) => Series::IntervalYearMonth(a.$method($($args),*)$($opt_question_mark)*),
             _ => unimplemented!()
         }
@@ -366,7 +376,9 @@ macro_rules! apply_method_all_series_and_return {
             Series::TimestampMicrosecond(a) => Series::TimestampMicrosecond(a.$method($($args),*)$($opt_question_mark)*),
             Series::TimestampMillisecond(a) => Series::TimestampMillisecond(a.$method($($args),*)$($opt_question_mark)*),
             Series::TimestampSecond(a) => Series::TimestampSecond(a.$method($($args),*)$($opt_question_mark)*),
+            #[cfg(feature = "dtype-interval")]
             Series::IntervalDayTime(a) => Series::IntervalDayTime(a.$method($($args),*)$($opt_question_mark)*),
+            #[cfg(feature = "dtype-interval")]
             Series::IntervalYearMonth(a) => Series::IntervalYearMonth(a.$method($($args),*)$($opt_question_mark)*),
             Series::List(a) => Series::List(a.$method($($args),*)$($opt_question_mark)*),
             Series::Object(a) => Series::Object(a.$method($($args),*)$($opt_question_mark)*),
@@ -403,7 +415,9 @@ macro_rules! apply_method_all_arrow_series_and_return {
             Series::TimestampMicrosecond(a) => Series::TimestampMicrosecond(a.$method($($args),*)$($opt_question_mark)*),
             Series::TimestampMillisecond(a) => Series::TimestampMillisecond(a.$method($($args),*)$($opt_question_mark)*),
             Series::TimestampSecond(a) => Series::TimestampSecond(a.$method($($args),*)$($opt_question_mark)*),
+            #[cfg(feature = "dtype-interval")]
             Series::IntervalDayTime(a) => Series::IntervalDayTime(a.$method($($args),*)$($opt_question_mark)*),
+            #[cfg(feature = "dtype-interval")]
             Series::IntervalYearMonth(a) => Series::IntervalYearMonth(a.$method($($args),*)$($opt_question_mark)*),
             Series::List(a) => Series::List(a.$method($($args),*)$($opt_question_mark)*),
             Series::Object(_) => panic!("not implemented for object type"),

--- a/py-polars/pypolars/datatypes.py
+++ b/py-polars/pypolars/datatypes.py
@@ -95,14 +95,6 @@ class DurationSecond:
     pass
 
 
-class IntervalDayTime:
-    pass
-
-
-class IntervalYearMonth:
-    pass
-
-
 class TimestampNanosecond:
     pass
 
@@ -148,8 +140,6 @@ dtypes = [
     DurationMicrosecond,
     DurationMillisecond,
     DurationSecond,
-    IntervalDayTime,
-    IntervalYearMonth,
     TimestampNanosecond,
     TimestampMicrosecond,
     TimestampMillisecond,
@@ -180,8 +170,6 @@ DTYPE_TO_FFINAME = {
     DurationMicrosecond: "duration_microsecond",
     DurationMillisecond: "duration_millisecond",
     DurationSecond: "duration_second",
-    IntervalDayTime: "interval_daytime",
-    IntervalYearMonth: "interval_yearmonth",
     TimestampNanosecond: "timestamp_nanosecond",
     TimestampMicrosecond: "timestamp_microsecond",
     TimestampMillisecond: "timestamp_millisecond",

--- a/py-polars/src/dataframe.rs
+++ b/py-polars/src/dataframe.rs
@@ -297,7 +297,7 @@ impl PyDataFrame {
     }
 
     pub fn vstack(&mut self, df: &PyDataFrame) -> PyResult<()> {
-        self.df.vstack(&df.df).map_err(PyPolarsEr::from)?;
+        self.df.vstack_mut(&df.df).map_err(PyPolarsEr::from)?;
         Ok(())
     }
 

--- a/py-polars/src/datatypes.rs
+++ b/py-polars/src/datatypes.rs
@@ -26,8 +26,6 @@ pub enum DataType {
     DurationMicrosecond,
     DurationMillisecond,
     DurationSecond,
-    IntervalDayTime,
-    IntervalYearMonth,
     TimestampNanosecond,
     TimestampMicrosecond,
     TimestampMillisecond,
@@ -58,8 +56,6 @@ impl From<&ArrowDataType> for DataType {
             ArrowDataType::Time32(TimeUnit::Second) => Time32Second,
             ArrowDataType::Time64(TimeUnit::Nanosecond) => Time64Nanosecond,
             ArrowDataType::Time64(TimeUnit::Microsecond) => Time64Microsecond,
-            ArrowDataType::Interval(IntervalUnit::DayTime) => IntervalDayTime,
-            ArrowDataType::Interval(IntervalUnit::YearMonth) => IntervalYearMonth,
             ArrowDataType::Duration(TimeUnit::Nanosecond) => DurationNanosecond,
             ArrowDataType::Duration(TimeUnit::Microsecond) => DurationMicrosecond,
             ArrowDataType::Duration(TimeUnit::Millisecond) => DurationMillisecond,
@@ -95,8 +91,6 @@ impl PyPolarsPrimitiveType for DurationNanosecondType {}
 impl PyPolarsPrimitiveType for DurationMicrosecondType {}
 impl PyPolarsPrimitiveType for DurationMillisecondType {}
 impl PyPolarsPrimitiveType for DurationSecondType {}
-impl PyPolarsPrimitiveType for IntervalYearMonthType {}
-impl PyPolarsPrimitiveType for IntervalDayTimeType {}
 impl PyPolarsPrimitiveType for TimestampNanosecondType {}
 impl PyPolarsPrimitiveType for TimestampMicrosecondType {}
 impl PyPolarsPrimitiveType for TimestampMillisecondType {}

--- a/py-polars/src/dispatch.rs
+++ b/py-polars/src/dispatch.rs
@@ -26,8 +26,6 @@ impl PyArrowPrimitiveType for DurationNanosecondType {}
 impl PyArrowPrimitiveType for DurationMicrosecondType {}
 impl PyArrowPrimitiveType for DurationMillisecondType {}
 impl PyArrowPrimitiveType for DurationSecondType {}
-impl PyArrowPrimitiveType for IntervalYearMonthType {}
-impl PyArrowPrimitiveType for IntervalDayTimeType {}
 impl PyArrowPrimitiveType for TimestampNanosecondType {}
 impl PyArrowPrimitiveType for TimestampMicrosecondType {}
 impl PyArrowPrimitiveType for TimestampMillisecondType {}


### PR DESCRIPTION
Default to not compiling `Interval` datatype. Currently there are no clear advantages for that type. More to follow.