### PR TITLE
Numeric parallel iterators

### DIFF
--- a/polars/src/chunked_array/iterator/mod.rs
+++ b/polars/src/chunked_array/iterator/mod.rs
@@ -138,7 +138,11 @@ where
         let idx_left = 0;
         let idx_right = arr.len();
 
-        NumIterSingleChunkNullCheck { arr, idx_left, idx_right }
+        NumIterSingleChunkNullCheck {
+            arr,
+            idx_left,
+            idx_right,
+        }
     }
 
     fn return_opt_val(&self, index: usize) -> Option<T::Native> {
@@ -392,7 +396,6 @@ where
     }
 
     fn set_current_iter_right(&mut self) {
-
         if self.chunk_idx_left == self.chunk_idx_right {
             // If the left and the right chunk are the same iterator, then, use the
             // the same iterator. The left iterator is kept to maintain the left index
@@ -525,7 +528,10 @@ where
         self.idx_right -= 1;
         self.current_array_idx_right -= 1;
 
-        if self.current_data_right.is_null(self.current_array_idx_right) {
+        if self
+            .current_data_right
+            .is_null(self.current_array_idx_right)
+        {
             Some(None)
         } else {
             opt_val.map(Some)

--- a/polars/src/chunked_array/iterator/mod.rs
+++ b/polars/src/chunked_array/iterator/mod.rs
@@ -3,6 +3,7 @@ use arrow::array::{
     Array, ArrayDataRef, ArrayRef, BooleanArray, ListArray, PrimitiveArray, PrimitiveArrayOps,
     StringArray,
 };
+use std::convert::TryFrom;
 use std::iter::Copied;
 use std::slice::Iter;
 
@@ -1288,7 +1289,8 @@ impl_all_iterators!(
 
 // used for macro
 fn return_from_list_iter(method_name: &str, v: ArrayRef) -> Series {
-    (method_name, v).into()
+    let s = Series::try_from((method_name, v));
+    s.unwrap()
 }
 
 impl_all_iterators!(

--- a/polars/src/chunked_array/iterator/mod.rs
+++ b/polars/src/chunked_array/iterator/mod.rs
@@ -3,7 +3,6 @@ use arrow::array::{
     Array, ArrayDataRef, ArrayRef, BooleanArray, ListArray, PrimitiveArray, PrimitiveArrayOps,
     StringArray,
 };
-use std::convert::TryFrom;
 use std::iter::Copied;
 use std::slice::Iter;
 
@@ -1255,8 +1254,7 @@ impl_all_iterators!(
 
 // used for macro
 fn return_from_list_iter(method_name: &str, v: ArrayRef) -> Series {
-    let s = Series::try_from((method_name, v));
-    s.unwrap()
+    (method_name, v).into()
 }
 
 impl_all_iterators!(
@@ -1310,6 +1308,8 @@ mod test {
                 assert_eq!(it.next(), Some(Some($second_val)));
                 assert_eq!(it.next(), Some(Some($third_val)));
                 assert_eq!(it.next(), None);
+                // ensure both sides are consumes.
+                assert_eq!(it.next_back(), None);
 
                 // reverse iterator
                 let mut it = a.into_iter();
@@ -1317,6 +1317,8 @@ mod test {
                 assert_eq!(it.next_back(), Some(Some($second_val)));
                 assert_eq!(it.next_back(), Some(Some($first_val)));
                 assert_eq!(it.next_back(), None);
+                // ensure both sides are consumes.
+                assert_eq!(it.next(), None);
 
                 // iterators should not cross
                 let mut it = a.into_iter();
@@ -1325,6 +1327,8 @@ mod test {
                 assert_eq!(it.next(), Some(Some($second_val)));
                 // should stop here as we took this one from the back
                 assert_eq!(it.next(), None);
+                // ensure both sides are consumes.
+                assert_eq!(it.next_back(), None);
 
                 // do the same from the right side
                 let mut it = a.into_iter();
@@ -1332,6 +1336,8 @@ mod test {
                 assert_eq!(it.next_back(), Some(Some($third_val)));
                 assert_eq!(it.next_back(), Some(Some($second_val)));
                 assert_eq!(it.next_back(), None);
+                // ensure both sides are consumes.
+                assert_eq!(it.next(), None);
             }
         };
     }
@@ -1364,6 +1370,8 @@ mod test {
                 assert_eq!(it.next(), Some($second_val));
                 assert_eq!(it.next(), Some($third_val));
                 assert_eq!(it.next(), None);
+                // ensure both sides are consumes.
+                assert_eq!(it.next_back(), None);
 
                 // reverse iterator
                 let mut it = a.into_iter();
@@ -1371,6 +1379,8 @@ mod test {
                 assert_eq!(it.next_back(), Some($second_val));
                 assert_eq!(it.next_back(), Some($first_val));
                 assert_eq!(it.next_back(), None);
+                // ensure both sides are consumes.
+                assert_eq!(it.next(), None);
 
                 // iterators should not cross
                 let mut it = a.into_iter();
@@ -1379,6 +1389,8 @@ mod test {
                 assert_eq!(it.next(), Some($second_val));
                 // should stop here as we took this one from the back
                 assert_eq!(it.next(), None);
+                // ensure both sides are consumes.
+                assert_eq!(it.next_back(), None);
 
                 // do the same from the right side
                 let mut it = a.into_iter();
@@ -1386,6 +1398,8 @@ mod test {
                 assert_eq!(it.next_back(), Some($third_val));
                 assert_eq!(it.next_back(), Some($second_val));
                 assert_eq!(it.next_back(), None);
+                // ensure both sides are consumes.
+                assert_eq!(it.next(), None);
             }
         };
     }
@@ -1437,6 +1451,8 @@ mod test {
                 assert_eq!(it.next(), Some(Some($second_val)));
                 assert_eq!(it.next(), Some(Some($third_val)));
                 assert_eq!(it.next(), None);
+                // ensure both sides are consumes.
+                assert_eq!(it.next_back(), None);
 
                 // reverse iterator
                 let mut it = a.into_iter();
@@ -1444,6 +1460,8 @@ mod test {
                 assert_eq!(it.next_back(), Some(Some($second_val)));
                 assert_eq!(it.next_back(), Some(Some($first_val)));
                 assert_eq!(it.next_back(), None);
+                // ensure both sides are consumes.
+                assert_eq!(it.next(), None);
 
                 // iterators should not cross
                 let mut it = a.into_iter();
@@ -1452,6 +1470,8 @@ mod test {
                 assert_eq!(it.next(), Some(Some($second_val)));
                 // should stop here as we took this one from the back
                 assert_eq!(it.next(), None);
+                // ensure both sides are consumes.
+                assert_eq!(it.next_back(), None);
 
                 // do the same from the right side
                 let mut it = a.into_iter();
@@ -1459,6 +1479,8 @@ mod test {
                 assert_eq!(it.next_back(), Some(Some($third_val)));
                 assert_eq!(it.next_back(), Some(Some($second_val)));
                 assert_eq!(it.next_back(), None);
+                // ensure both sides are consumes.
+                assert_eq!(it.next(), None);
             }
         };
     }
@@ -1492,6 +1514,8 @@ mod test {
                 assert_eq!(it.next(), Some($second_val));
                 assert_eq!(it.next(), Some($third_val));
                 assert_eq!(it.next(), None);
+                // ensure both sides are consumes.
+                assert_eq!(it.next_back(), None);
 
                 // reverse iterator
                 let mut it = a.into_iter();
@@ -1499,6 +1523,8 @@ mod test {
                 assert_eq!(it.next_back(), Some($second_val));
                 assert_eq!(it.next_back(), Some($first_val));
                 assert_eq!(it.next_back(), None);
+                // ensure both sides are consumes.
+                assert_eq!(it.next(), None);
 
                 // iterators should not cross
                 let mut it = a.into_iter();
@@ -1507,6 +1533,8 @@ mod test {
                 assert_eq!(it.next(), Some($second_val));
                 // should stop here as we took this one from the back
                 assert_eq!(it.next(), None);
+                // ensure both sides are consumes.
+                assert_eq!(it.next_back(), None);
 
                 // do the same from the right side
                 let mut it = a.into_iter();
@@ -1514,6 +1542,8 @@ mod test {
                 assert_eq!(it.next_back(), Some($third_val));
                 assert_eq!(it.next_back(), Some($second_val));
                 assert_eq!(it.next_back(), None);
+                // ensure both sides are consumes.
+                assert_eq!(it.next(), None);
             }
         };
     }
@@ -1563,6 +1593,8 @@ mod test {
                 assert_eq!(it.next(), Some($second_val));
                 assert_eq!(it.next(), Some($third_val));
                 assert_eq!(it.next(), None);
+                // ensure both sides are consumes.
+                assert_eq!(it.next_back(), None);
 
                 // reverse iterator
                 let mut it = a.into_no_null_iter();
@@ -1570,6 +1602,8 @@ mod test {
                 assert_eq!(it.next_back(), Some($second_val));
                 assert_eq!(it.next_back(), Some($first_val));
                 assert_eq!(it.next_back(), None);
+                // ensure both sides are consumes.
+                assert_eq!(it.next(), None);
 
                 // iterators should not cross
                 let mut it = a.into_no_null_iter();
@@ -1578,6 +1612,8 @@ mod test {
                 assert_eq!(it.next(), Some($second_val));
                 // should stop here as we took this one from the back
                 assert_eq!(it.next(), None);
+                // ensure both sides are consumes.
+                assert_eq!(it.next_back(), None);
 
                 // do the same from the right side
                 let mut it = a.into_no_null_iter();
@@ -1585,26 +1621,22 @@ mod test {
                 assert_eq!(it.next_back(), Some($third_val));
                 assert_eq!(it.next_back(), Some($second_val));
                 assert_eq!(it.next_back(), None);
+                // ensure both sides are consumes.
+                assert_eq!(it.next(), None);
             }
         };
     }
 
+    impl_test_no_null_iter_single_chunk!(num_no_null_iter_single_chunk, UInt32Chunked, 1, 2, 3);
     impl_test_no_null_iter_single_chunk!(
-        num_no_null_iter_single_chunk_null_check,
-        UInt32Chunked,
-        1,
-        2,
-        3
-    );
-    impl_test_no_null_iter_single_chunk!(
-        utf8_no_null_iter_single_chunk_null_check,
+        utf8_no_null_iter_single_chunk,
         Utf8Chunked,
         "a",
         "b",
         "c"
     );
     impl_test_no_null_iter_single_chunk!(
-        bool_no_null_iter_single_chunk_null_check,
+        bool_no_null_iter_single_chunk,
         BooleanChunked,
         true,
         true,
@@ -1636,6 +1668,8 @@ mod test {
                 assert_eq!(it.next(), Some($second_val));
                 assert_eq!(it.next(), Some($third_val));
                 assert_eq!(it.next(), None);
+                // ensure both sides are consumes.
+                assert_eq!(it.next_back(), None);
 
                 // reverse iterator
                 let mut it = a.into_no_null_iter();
@@ -1643,6 +1677,8 @@ mod test {
                 assert_eq!(it.next_back(), Some($second_val));
                 assert_eq!(it.next_back(), Some($first_val));
                 assert_eq!(it.next_back(), None);
+                // ensure both sides are consumes.
+                assert_eq!(it.next(), None);
 
                 // iterators should not cross
                 let mut it = a.into_no_null_iter();
@@ -1651,6 +1687,8 @@ mod test {
                 assert_eq!(it.next(), Some($second_val));
                 // should stop here as we took this one from the back
                 assert_eq!(it.next(), None);
+                // ensure both sides are consumes.
+                assert_eq!(it.next_back(), None);
 
                 // do the same from the right side
                 let mut it = a.into_no_null_iter();
@@ -1658,26 +1696,16 @@ mod test {
                 assert_eq!(it.next_back(), Some($third_val));
                 assert_eq!(it.next_back(), Some($second_val));
                 assert_eq!(it.next_back(), None);
+                // ensure both sides are consumes.
+                assert_eq!(it.next(), None);
             }
         };
     }
 
+    impl_test_no_null_iter_many_chunk!(num_no_null_iter_many_chunk, UInt32Chunked, 1, 2, 3);
+    impl_test_no_null_iter_many_chunk!(utf8_no_null_iter_many_chunk, Utf8Chunked, "a", "b", "c");
     impl_test_no_null_iter_many_chunk!(
-        num_no_null_iter_many_chunk_null_check,
-        UInt32Chunked,
-        1,
-        2,
-        3
-    );
-    impl_test_no_null_iter_many_chunk!(
-        utf8_no_null_iter_many_chunk_null_check,
-        Utf8Chunked,
-        "a",
-        "b",
-        "c"
-    );
-    impl_test_no_null_iter_many_chunk!(
-        bool_no_null_iter_many_chunk_null_check,
+        bool_no_null_iter_many_chunk,
         BooleanChunked,
         true,
         true,

--- a/polars/src/chunked_array/iterator/mod.rs
+++ b/polars/src/chunked_array/iterator/mod.rs
@@ -372,17 +372,18 @@ where
     T: PolarsNumericType,
 {
     fn set_current_iter_left(&mut self) {
-        let current_chunk = unsafe { self.chunks.get_unchecked(self.chunk_idx_left) };
-        self.current_data_left = current_chunk.data();
-
         if self.chunk_idx_left == self.chunk_idx_right {
             // If the left and the right chunk are the same iterator, then, use the
             // the same iterator. The right iterator is kept to maintain the right index
             // in the iterator, as the left index will be the first index in the chunk.
+            self.current_data_left = self.current_data_right.clone();
             if let Some(current_iter_right) = self.current_iter_right.take() {
                 self.current_iter_left = current_iter_right;
             }
         } else {
+            let current_chunk = unsafe { self.chunks.get_unchecked(self.chunk_idx_left) };
+            self.current_data_left = current_chunk.data();
+
             self.current_iter_left = current_chunk
                 .value_slice(0, current_chunk.len())
                 .iter()
@@ -391,15 +392,17 @@ where
     }
 
     fn set_current_iter_right(&mut self) {
-        let current_chunk = unsafe { self.chunks.get_unchecked(self.chunk_idx_right) };
-        self.current_data_right = current_chunk.data();
 
         if self.chunk_idx_left == self.chunk_idx_right {
             // If the left and the right chunk are the same iterator, then, use the
             // the same iterator. The left iterator is kept to maintain the left index
             // in the iterator, as the right index will be the last index in the chunk.
+            self.current_data_right = self.current_data_left.clone();
             self.current_iter_right = None
         } else {
+            let current_chunk = unsafe { self.chunks.get_unchecked(self.chunk_idx_right) };
+            self.current_data_right = current_chunk.data();
+
             self.current_iter_right = Some(
                 current_chunk
                     .value_slice(0, current_chunk.len())

--- a/polars/src/chunked_array/iterator/par/mod.rs
+++ b/polars/src/chunked_array/iterator/par/mod.rs
@@ -4,6 +4,7 @@ use crate::chunked_array::ChunkedArray;
 mod macros;
 pub mod boolean;
 pub mod list;
+pub mod numeric;
 pub mod utf8;
 
 impl<T> ChunkedArray<T> {

--- a/polars/src/chunked_array/iterator/par/numeric.rs
+++ b/polars/src/chunked_array/iterator/par/numeric.rs
@@ -1,0 +1,827 @@
+use crate::chunked_array::iterator::{
+    NumIterManyChunk, NumIterManyChunkNullCheck, NumIterSingleChunk, NumIterSingleChunkNullCheck,
+    SomeIterator,
+};
+use crate::prelude::*;
+use arrow::array::Array;
+use rayon::iter::plumbing::*;
+use rayon::iter::plumbing::{Consumer, ProducerCallback};
+use rayon::prelude::*;
+
+/// Generate the code for body of a parallel iterator based on the associated sequential iterator.
+/// It implements the trait methods.
+///
+/// # Input
+///
+/// seq_iter: The sequential iterator to cast the parallel iterator once it is splitted in threads.
+macro_rules! impl_numeric_parallel_iterator_body {
+    ($seq_iter:ty) => {
+        type Item = <$seq_iter as Iterator>::Item;
+
+        fn drive_unindexed<C>(self, consumer: C) -> C::Result
+        where
+            C: UnindexedConsumer<Self::Item>,
+        {
+            bridge(self, consumer)
+        }
+
+        fn opt_len(&self) -> Option<usize> {
+            Some(self.ca.len())
+        }
+    };
+}
+
+
+/// Generate the code for body of an unindexed parallel iterator. It implements the trait methods.
+///
+/// # Input
+///
+/// producer: The producer used to split the iterator into smaller pieces before cast to a sequential iterator.
+macro_rules! impl_numeric_indexed_parallel_iterator_body {
+    ($producer:ident) => {
+        fn len(&self) -> usize {
+            self.ca.len()
+        }
+
+        fn drive<C>(self, consumer: C) -> C::Result
+        where
+            C: Consumer<Self::Item>,
+        {
+            bridge(self, consumer)
+        }
+
+        fn with_producer<CB>(self, callback: CB) -> CB::Output
+        where
+            CB: ProducerCallback<Self::Item>,
+        {
+            callback.callback($producer {
+                ca: &self.ca,
+                offset: 0,
+                len: self.ca.len(),
+            })
+        }
+    };
+}
+
+
+/// Generate the code for body of a producer. It implements the trait methods.
+///
+/// # Input
+///
+/// seq_iter: The sequential iterator this producer cast after spliting.
+macro_rules! impl_numeric_producer_body {
+    ($seq_iter:ty) => {
+        type Item =  <$seq_iter as Iterator>::Item;
+        type IntoIter = $seq_iter;
+
+        fn into_iter(self) -> Self::IntoIter {
+            self.into()
+        }
+
+        fn split_at(self, index: usize) -> (Self, Self) {
+            (
+                Self {
+                    ca: self.ca,
+                    offset: self.offset,
+                    len: index,
+                },
+                Self {
+                    ca: self.ca,
+                    offset: self.offset + index,
+                    len: self.len - index,
+                },
+            )
+        }
+
+    };
+}
+
+// Implement methods to generate sequential iterators from raw parts.
+// The methods are the same for the `ReturnOption` and `ReturnUnwrap` variant.
+impl<'a, T> NumIterSingleChunk<'a, T>
+where
+    T: PolarsNumericType + Send + Sync
+{
+    fn from_parts(ca: &'a ChunkedArray<T>, offset: usize, len: usize) -> Self {
+        let chunk = ca.downcast_chunks()[0];
+        let slice = chunk.value_slice(offset, len);
+        let iter = slice.iter().copied();
+
+        Self { iter }
+    }
+}
+
+impl<'a, T> NumIterManyChunk<'a, T>
+where
+    T: PolarsNumericType + Send + Sync
+{
+    fn from_parts(ca: &'a ChunkedArray<T>, offset: usize, len: usize) -> Self {
+        let chunks = ca.downcast_chunks();
+
+        // Compute left array indexes.
+        let idx_left = offset;
+        let (chunk_idx_left, current_array_idx_left) = ca.index_to_chunked_index(idx_left);
+        let current_array_left = chunks[chunk_idx_left];
+
+        // Compute right array indexes.
+        let idx_right = offset + len;
+        let (chunk_idx_right, current_array_idx_right) = ca.right_index_to_chunked_index(idx_right);
+
+        let (current_array_left_len, current_iter_right) = if chunk_idx_left == chunk_idx_right {
+            // If both iterators belong to the same chunk, then, only the left chunk is goin to be used
+            // and iterate from both sides. This iterator will be the left one and will go from
+            // `current_array_idx_left` to `current_array_idx_right`.
+            let current_array_left_len = current_array_idx_right;
+
+            (current_array_left_len, None)
+        } else {
+            // If the iterators belong to different chunks, then, an iterator for chunk is needed.
+            // The left iterator will go from `current_array_idx_left` to the end of the chunk, and
+            // the right one will go from the beginning of the chunk to `current_array_idx_right`.
+            let current_array_left_len = current_array_left.len();
+
+            let current_array_right = chunks[chunk_idx_right];
+            let current_iter_right = Some(
+                current_array_right
+                    .value_slice(0, current_array_idx_right)
+                    .iter()
+                    .copied(),
+            );
+
+            (current_array_left_len, current_iter_right)
+        };
+
+        let current_iter_left = current_array_left
+            .value_slice(current_array_idx_left, current_array_left_len)
+            .iter()
+            .copied();
+
+        Self {
+            ca,
+            current_iter_left,
+            chunks,
+            current_iter_right,
+            idx_left,
+            chunk_idx_left,
+            idx_right,
+            chunk_idx_right,
+        }
+    }
+}
+
+/// Parallel Iterator for chunked arrays with just one chunk.
+/// It does NOT perform null check, then, it is appropriated for chunks whose contents are never null.
+///
+/// It returns the result wrapped in an `Option`.
+#[derive(Debug, Clone)]
+pub struct NumParIterSingleChunkReturnOption<'a, T>
+where
+    T: PolarsNumericType + Send + Sync
+{
+    ca: &'a ChunkedArray<T>,
+}
+
+impl<'a, T> NumParIterSingleChunkReturnOption<'a, T>
+where
+    T: PolarsNumericType + Send + Sync
+{
+    fn new(ca: &'a ChunkedArray<T>) -> Self {
+        Self { ca }
+    }
+}
+
+impl<'a, T> From<NumProducerSingleChunkReturnOption<'a, T>>
+    for SomeIterator<NumIterSingleChunk<'a, T>>
+where
+    T: PolarsNumericType + Send + Sync
+{
+    fn from(prod: NumProducerSingleChunkReturnOption<'a, T>) -> Self {
+        SomeIterator(<NumIterSingleChunk<'a, T>>::from_parts(
+            prod.ca,
+            prod.offset,
+            prod.len,
+        ))
+    }
+}
+
+// Implement parallel iterator for NumParIterSingleChunkReturnOption.
+impl<'a, T> ParallelIterator for NumParIterSingleChunkReturnOption<'a, T>
+where
+    T: PolarsNumericType + Send + Sync
+{
+    impl_numeric_parallel_iterator_body!(SomeIterator<NumIterSingleChunk<'a, T>>);
+}
+
+struct NumProducerSingleChunkReturnOption<'a, T>
+where
+    T: PolarsNumericType + Send + Sync
+{
+    ca: &'a ChunkedArray<T>,
+    offset: usize,
+    len: usize,
+}
+
+impl<'a, T> IndexedParallelIterator for NumParIterSingleChunkReturnOption<'a, T>
+where
+    T: PolarsNumericType + Send + Sync
+{
+    impl_numeric_indexed_parallel_iterator_body!(NumProducerSingleChunkReturnOption);
+}
+
+impl<'a, T> Producer for NumProducerSingleChunkReturnOption<'a, T>
+where
+    T: PolarsNumericType + Send + Sync
+{
+    impl_numeric_producer_body!(SomeIterator<NumIterSingleChunk<'a, T>>);
+}
+
+
+/// Parallel Iterator for chunked arrays with just one chunk.
+/// It DOES perform null check, then, it is appropriated for chunks whose contents can be null.
+///
+/// It returns the result wrapped in an `Option`.
+#[derive(Debug, Clone)]
+pub struct NumParIterSingleChunkNullCheckReturnOption<'a, T>
+where
+    T: PolarsNumericType + Send + Sync
+{
+    ca: &'a ChunkedArray<T>,
+}
+
+impl<'a, T> NumParIterSingleChunkNullCheckReturnOption<'a, T>
+where
+    T: PolarsNumericType + Send + Sync
+{
+    fn new(ca: &'a ChunkedArray<T>) -> Self {
+        Self { ca }
+    }
+}
+
+impl<'a, T> From<NumProducerSingleChunkNullCheckReturnOption<'a, T>> for NumIterSingleChunkNullCheck<'a, T>
+where
+    T: PolarsNumericType + Send + Sync
+{
+    fn from(prod: NumProducerSingleChunkNullCheckReturnOption<'a, T>) -> Self {
+        let chunks = prod.ca.downcast_chunks();
+        let arr = chunks[0];
+        let idx_left = prod.offset;
+        let idx_right = prod.offset + prod.len;
+
+        Self {
+            arr,
+            idx_left,
+            idx_right,
+        }
+    }
+}
+
+// Implement parallel iterator for NumParIterSingleChunkNullCheckReturnOption.
+impl<'a, T> ParallelIterator for NumParIterSingleChunkNullCheckReturnOption<'a, T>
+where
+    T: PolarsNumericType + Send + Sync
+{
+    impl_numeric_parallel_iterator_body!(NumIterSingleChunkNullCheck<'a, T>);
+}
+
+struct NumProducerSingleChunkNullCheckReturnOption<'a, T>
+where
+    T: PolarsNumericType + Send + Sync
+{
+    ca: &'a ChunkedArray<T>,
+    offset: usize,
+    len: usize,
+}
+
+impl<'a, T> IndexedParallelIterator for NumParIterSingleChunkNullCheckReturnOption<'a, T>
+where
+    T: PolarsNumericType + Send + Sync
+{
+    impl_numeric_indexed_parallel_iterator_body!(NumProducerSingleChunkNullCheckReturnOption);
+}
+
+impl<'a, T> Producer for NumProducerSingleChunkNullCheckReturnOption<'a, T>
+where
+    T: PolarsNumericType + Send + Sync
+{
+    impl_numeric_producer_body!(NumIterSingleChunkNullCheck<'a, T>);
+}
+
+/// Parallel Iterator for chunked arrays with more than one chunk.
+/// It does NOT perform null check, then, it is appropriated for chunks whose contents are never null.
+///
+/// It returns the result wrapped in an `Option`.
+#[derive(Debug, Clone)]
+pub struct NumParIterManyChunkReturnOption<'a, T>
+where
+    T: PolarsNumericType + Send + Sync
+{
+    ca: &'a ChunkedArray<T>,
+}
+
+impl<'a, T> NumParIterManyChunkReturnOption<'a, T>
+where
+    T: PolarsNumericType + Send + Sync
+{
+    fn new(ca: &'a ChunkedArray<T>) -> Self {
+        Self { ca }
+    }
+}
+
+impl<'a, T> From<NumProducerManyChunkReturnOption<'a, T>> for SomeIterator<NumIterManyChunk<'a, T>>
+where
+    T: PolarsNumericType + Send + Sync
+{
+    fn from(prod: NumProducerManyChunkReturnOption<'a, T>) -> Self {
+        SomeIterator(<NumIterManyChunk<'a, T>>::from_parts(
+            prod.ca,
+            prod.offset,
+            prod.len,
+        ))
+    }
+}
+
+// Implement parallel iterator for NumParIterManyChunkReturnOption.
+impl<'a, T> ParallelIterator for NumParIterManyChunkReturnOption<'a, T>
+where
+    T: PolarsNumericType + Send + Sync
+{
+    impl_numeric_parallel_iterator_body!(SomeIterator<NumIterManyChunk<'a, T>>);
+}
+
+struct NumProducerManyChunkReturnOption<'a, T>
+where
+    T: PolarsNumericType + Send + Sync
+{
+    ca: &'a ChunkedArray<T>,
+    offset: usize,
+    len: usize,
+}
+
+impl<'a, T> IndexedParallelIterator for NumParIterManyChunkReturnOption<'a, T>
+where
+    T: PolarsNumericType + Send + Sync
+{
+    impl_numeric_indexed_parallel_iterator_body!(NumProducerManyChunkReturnOption);
+}
+
+impl<'a, T> Producer for NumProducerManyChunkReturnOption<'a, T>
+where
+    T: PolarsNumericType + Send + Sync
+{
+    impl_numeric_producer_body!(SomeIterator<NumIterManyChunk<'a, T>>);
+}
+
+/// Parallel Iterator for chunked arrays with more than one chunk.
+/// It DOES perform null check, then, it is appropriated for chunks whose contents can be null.
+///
+/// It returns the result wrapped in an `Option`.
+#[derive(Debug, Clone)]
+pub struct NumParIterManyChunkNullCheckReturnOption<'a, T>
+where
+    T: PolarsNumericType + Send + Sync
+{
+    ca: &'a ChunkedArray<T>,
+}
+
+impl<'a, T> NumParIterManyChunkNullCheckReturnOption<'a, T>
+where
+    T: PolarsNumericType + Send + Sync
+{
+    fn new(ca: &'a ChunkedArray<T>) -> Self {
+        Self { ca }
+    }
+}
+
+impl<'a, T> From<NumProducerManyChunkNullCheckReturnOption<'a, T>>
+    for NumIterManyChunkNullCheck<'a, T>
+where
+    T: PolarsNumericType + Send + Sync
+{
+    fn from(prod: NumProducerManyChunkNullCheckReturnOption<'a, T>) -> Self {
+        let ca = prod.ca;
+        let chunks = prod.ca.downcast_chunks();
+
+        // Compute left array indexes and data.
+        let idx_left = prod.offset;
+        let (chunk_idx_left, current_array_idx_left) = ca.index_to_chunked_index(idx_left);
+        let current_array_left = chunks[chunk_idx_left];
+        let current_data_left = current_array_left.data();
+
+        // Compute right array indexes and data.
+        let idx_right = prod.offset + prod.len;
+        let (chunk_idx_right, current_array_idx_right) = ca.right_index_to_chunked_index(idx_right);
+        let current_array_right = chunks[chunk_idx_right];
+        let current_data_right = current_array_right.data();
+
+        let (current_array_left_len, current_iter_right) = if chunk_idx_left == chunk_idx_right {
+            // If both iterators belong to the same chunk, then, only the left chunk is goin to be used
+            // and iterate from both sides. This iterator will be the left one and will go from
+            // `current_array_idx_left` to `current_array_idx_right`.
+            (current_array_idx_right, None)
+        } else {
+            // If the iterators belong to different chunks, then, an iterator for chunk is needed.
+            // The left iterator will go from `current_array_idx_left` to the end of the chunk, and
+            // the right one will go from the beginning of the chunk to `current_array_idx_right`.
+            let current_array_left_len = current_array_left.len();
+
+            let current_iter_right = Some(
+                current_array_right
+                    .value_slice(0, current_array_idx_right)
+                    .iter()
+                    .copied(),
+            );
+
+            (current_array_left_len, current_iter_right)
+        };
+
+        let current_iter_left = current_array_left
+            .value_slice(current_array_idx_left, current_array_left_len)
+            .iter()
+            .copied();
+
+        Self {
+            ca,
+            current_iter_left,
+            current_data_left,
+            current_array_idx_left,
+            chunks,
+            current_iter_right,
+            current_data_right,
+            current_array_idx_right,
+            idx_left,
+            chunk_idx_left,
+            idx_right,
+            chunk_idx_right,
+        }
+    }
+}
+
+// Implement parallel iterator for NumParIterManyChunkNullCheckReturnOption.
+impl<'a, T> ParallelIterator for NumParIterManyChunkNullCheckReturnOption<'a, T>
+where
+    T: PolarsNumericType + Send + Sync
+{
+    impl_numeric_parallel_iterator_body!(NumIterManyChunkNullCheck<'a, T>);
+}
+
+struct NumProducerManyChunkNullCheckReturnOption<'a, T>
+where
+    T: PolarsNumericType + Send + Sync
+{
+    ca: &'a ChunkedArray<T>,
+    offset: usize,
+    len: usize,
+}
+
+impl<'a, T> IndexedParallelIterator for NumParIterManyChunkNullCheckReturnOption<'a, T>
+where
+    T: PolarsNumericType + Send + Sync
+{
+    impl_numeric_indexed_parallel_iterator_body!(NumProducerManyChunkNullCheckReturnOption);
+}
+
+impl<'a, T> Producer for NumProducerManyChunkNullCheckReturnOption<'a, T>
+where
+    T: PolarsNumericType + Send + Sync
+{
+    impl_numeric_producer_body!(NumIterManyChunkNullCheck<'a, T>);
+}
+
+/// Parallel Iterator for chunked arrays with just one chunk.
+/// The chunks cannot have null values so it does NOT perform null checks.
+///
+/// The return type is `PolarsNumericType`. So this structure cannot be handled by the `NumParIterDispatcher` but
+/// by `NumNoNullParIterDispatcher` which is aimed for non-nullable chunked arrays.
+#[derive(Debug, Clone)]
+pub struct NumParIterSingleChunkReturnUnwrapped<'a, T>
+where
+    T: PolarsNumericType + Send + Sync
+{
+    ca: &'a ChunkedArray<T>,
+}
+
+impl<'a, T> NumParIterSingleChunkReturnUnwrapped<'a, T>
+where
+    T: PolarsNumericType + Send + Sync
+{
+    fn new(ca: &'a ChunkedArray<T>) -> Self {
+        Self { ca }
+    }
+}
+
+impl<'a, T> From<NumProducerSingleChunkReturnUnwrapped<'a, T>> for NumIterSingleChunk<'a, T>
+where
+    T: PolarsNumericType + Send + Sync
+{
+    fn from(prod: NumProducerSingleChunkReturnUnwrapped<'a, T>) -> Self {
+        Self::from_parts(prod.ca, prod.offset, prod.len)
+    }
+}
+
+// Implement parallel iterator for NumParIterSingleChunkReturnUnwrapped.
+impl<'a, T> ParallelIterator for NumParIterSingleChunkReturnUnwrapped<'a, T>
+where
+    T: PolarsNumericType + Send + Sync
+{
+    impl_numeric_parallel_iterator_body!(NumIterSingleChunk<'a, T>);
+}
+
+struct NumProducerSingleChunkReturnUnwrapped<'a, T>
+where
+    T: PolarsNumericType + Send + Sync
+{
+    ca: &'a ChunkedArray<T>,
+    offset: usize,
+    len: usize,
+}
+
+impl<'a, T> IndexedParallelIterator for NumParIterSingleChunkReturnUnwrapped<'a, T>
+where
+    T: PolarsNumericType + Send + Sync
+{
+    impl_numeric_indexed_parallel_iterator_body!(NumProducerSingleChunkReturnUnwrapped);
+}
+
+impl<'a, T> Producer for NumProducerSingleChunkReturnUnwrapped<'a, T>
+where
+    T: PolarsNumericType + Send + Sync
+{
+    impl_numeric_producer_body!(NumIterSingleChunk<'a, T>);
+}
+
+/// Parallel Iterator for chunked arrays with many chunk.
+/// The chunks cannot have null values so it does NOT perform null checks.
+///
+/// The return type is `PolarsNumericType`. So this structure cannot be handled by the `NumParIterDispatcher` but
+/// by `NumNoNullParIterDispatcher` which is aimed for non-nullable chunked arrays.
+#[derive(Debug, Clone)]
+pub struct NumParIterManyChunkReturnUnwrapped<'a, T>
+where
+    T: PolarsNumericType + Send + Sync
+{
+    ca: &'a ChunkedArray<T>,
+}
+
+impl<'a, T> NumParIterManyChunkReturnUnwrapped<'a, T>
+where
+    T: PolarsNumericType + Send + Sync
+{
+    fn new(ca: &'a ChunkedArray<T>) -> Self {
+        Self { ca }
+    }
+}
+
+impl<'a, T> From<NumProducerManyChunkReturnUnwrapped<'a, T>> for NumIterManyChunk<'a, T>
+where
+    T: PolarsNumericType + Send + Sync
+{
+    fn from(prod: NumProducerManyChunkReturnUnwrapped<'a, T>) -> Self {
+        Self::from_parts(prod.ca, prod.offset, prod.len)
+    }
+}
+
+// Implement parallel iterator for NumParIterManyChunkReturnUnwrapped.
+impl<'a, T> ParallelIterator for NumParIterManyChunkReturnUnwrapped<'a, T>
+where
+    T: PolarsNumericType + Send + Sync
+{
+    impl_numeric_parallel_iterator_body!(NumIterManyChunk<'a, T>);
+}
+
+struct NumProducerManyChunkReturnUnwrapped<'a, T>
+where
+    T: PolarsNumericType + Send + Sync
+{
+    ca: &'a ChunkedArray<T>,
+    offset: usize,
+    len: usize,
+}
+
+impl<'a, T> IndexedParallelIterator for NumParIterManyChunkReturnUnwrapped<'a, T>
+where
+    T: PolarsNumericType + Send + Sync
+{
+    impl_numeric_indexed_parallel_iterator_body!(NumProducerManyChunkReturnUnwrapped);
+}
+
+impl<'a, T> Producer for NumProducerManyChunkReturnUnwrapped<'a, T>
+where
+    T: PolarsNumericType + Send + Sync
+{
+    impl_numeric_producer_body!(NumIterManyChunk<'a, T>);
+}
+
+/// Static dispatching structure to allow static polymorphism of chunked parallel iterators.
+///
+/// All the iterators of the dispatcher returns `Option<PolarsNumericType::Native>`.
+pub enum NumParIterDispatcher<'a, T>
+where
+    T: PolarsNumericType + Send + Sync
+{
+    SingleChunk(NumParIterSingleChunkReturnOption<'a, T>),
+    SingleChunkNullCheck(NumParIterSingleChunkNullCheckReturnOption<'a, T>),
+    ManyChunk(NumParIterManyChunkReturnOption<'a, T>),
+    ManyChunkNullCheck(NumParIterManyChunkNullCheckReturnOption<'a, T>),
+}
+
+/// Convert `ChunkedArray` into a `ParallelIterator` using the most efficient
+/// `ParallelIterator` implementation for the given `ChunkedArray<T>` of polars numeric types.
+///
+/// - If `ChunkedArray<T>` has only a chunk and has no null values, it uses `NumParIterSingleChunkReturnOption`.
+/// - If `ChunkedArray<T>` has only a chunk and does have null values, it uses `NumParIterSingleChunkNullCheckReturnOption`.
+/// - If `ChunkedArray<T>` has many chunks and has no null values, it uses `NumParIterManyChunkReturnOption`.
+/// - If `ChunkedArray<T>` has many chunks and does have null values, it uses `NumParIterManyChunkNullCheckReturnOption`.
+impl<'a, T> IntoParallelIterator for &'a ChunkedArray<T>
+where
+    T: PolarsNumericType + Send + Sync
+{
+    type Iter = NumParIterDispatcher<'a, T>;
+    type Item = Option<T::Native>;
+
+    fn into_par_iter(self) -> Self::Iter {
+        let chunks = self.downcast_chunks();
+        match chunks.len() {
+            1 => {
+                if self.null_count() == 0 {
+                    NumParIterDispatcher::SingleChunk(
+                        NumParIterSingleChunkReturnOption::new(self),
+                    )
+                } else {
+                    NumParIterDispatcher::SingleChunkNullCheck(
+                        NumParIterSingleChunkNullCheckReturnOption::new(self),
+                    )
+                }
+            }
+            _ => {
+                if self.null_count() == 0 {
+                    NumParIterDispatcher::ManyChunk(
+                        NumParIterManyChunkReturnOption::new(self),
+                    )
+                } else {
+                    NumParIterDispatcher::ManyChunkNullCheck(
+                        NumParIterManyChunkNullCheckReturnOption::new(self),
+                    )
+                }
+            }
+        }
+    }
+}
+
+impl<'a, T> ParallelIterator for NumParIterDispatcher<'a, T>
+where
+    T: PolarsNumericType + Send + Sync
+{
+    type Item = Option<T::Native>;
+
+    fn drive_unindexed<C>(self, consumer: C) -> C::Result
+    where
+        C: UnindexedConsumer<Self::Item>,
+    {
+        match self {
+            NumParIterDispatcher::SingleChunk(a) => a.drive_unindexed(consumer),
+            NumParIterDispatcher::SingleChunkNullCheck(a) => a.drive_unindexed(consumer),
+            NumParIterDispatcher::ManyChunk(a) => a.drive_unindexed(consumer),
+            NumParIterDispatcher::ManyChunkNullCheck(a) => a.drive_unindexed(consumer),
+        }
+    }
+
+    fn opt_len(&self) -> Option<usize> {
+        match self {
+            NumParIterDispatcher::SingleChunk(a) => a.opt_len(),
+            NumParIterDispatcher::SingleChunkNullCheck(a) => a.opt_len(),
+            NumParIterDispatcher::ManyChunk(a) => a.opt_len(),
+            NumParIterDispatcher::ManyChunkNullCheck(a) => a.opt_len(),
+        }
+    }
+}
+
+impl<'a, T> IndexedParallelIterator for NumParIterDispatcher<'a, T>
+where
+    T: PolarsNumericType + Send + Sync
+{
+    fn len(&self) -> usize {
+        match self {
+            NumParIterDispatcher::SingleChunk(a) => a.len(),
+            NumParIterDispatcher::SingleChunkNullCheck(a) => a.len(),
+            NumParIterDispatcher::ManyChunk(a) => a.len(),
+            NumParIterDispatcher::ManyChunkNullCheck(a) => a.len(),
+        }
+    }
+
+    fn drive<C>(self, consumer: C) -> C::Result
+    where
+        C: Consumer<Self::Item>,
+    {
+        match self {
+            NumParIterDispatcher::SingleChunk(a) => a.drive(consumer),
+            NumParIterDispatcher::SingleChunkNullCheck(a) => a.drive(consumer),
+            NumParIterDispatcher::ManyChunk(a) => a.drive(consumer),
+            NumParIterDispatcher::ManyChunkNullCheck(a) => a.drive(consumer),
+        }
+    }
+
+    fn with_producer<CB>(self, callback: CB) -> CB::Output
+    where
+        CB: ProducerCallback<Self::Item>,
+    {
+        match self {
+            NumParIterDispatcher::SingleChunk(a) => a.with_producer(callback),
+            NumParIterDispatcher::SingleChunkNullCheck(a) => a.with_producer(callback),
+            NumParIterDispatcher::ManyChunk(a) => a.with_producer(callback),
+            NumParIterDispatcher::ManyChunkNullCheck(a) => a.with_producer(callback),
+        }
+    }
+}
+
+/// Static dispatching structure to allow static polymorphism of non-nullable chunked parallel iterators.
+///
+/// All the iterators of the dispatcher returns `PolarsNumericType::Native`, as there are no nulls in the chunked array.
+pub enum NumNoNullParIterDispatcher<'a, T>
+where
+    T: PolarsNumericType + Send + Sync
+{
+    SingleChunk(NumParIterSingleChunkReturnUnwrapped<'a,T>),
+    ManyChunk(NumParIterManyChunkReturnUnwrapped<'a, T>),
+}
+
+/// Convert a `ChunkedArray` of numeric types into a non-nullable `ParallelIterator` using the most
+/// efficient `ParallelIterator` implementation for the given `ChunkeArray`.
+///
+/// - If `ChunkeArray<T>` has only a chunk, it uses `NumParIterSingleChunkReturnUnwrapped`.
+/// - If `ChunkeArray<T>` has many chunks, it uses `NumParIterManyChunkReturnUnwrapped`.
+impl<'a, T> IntoParallelIterator for NoNull<&'a ChunkedArray<T>>
+where
+    T: PolarsNumericType + Send + Sync
+{
+    type Iter = NumNoNullParIterDispatcher<'a, T>;
+    type Item = T::Native;
+
+    fn into_par_iter(self) -> Self::Iter {
+        let ca = self.0;
+        let chunks = ca.downcast_chunks();
+        match chunks.len() {
+            1 => NumNoNullParIterDispatcher::SingleChunk(
+                NumParIterSingleChunkReturnUnwrapped::new(ca),
+            ),
+            _ => NumNoNullParIterDispatcher::ManyChunk(
+                NumParIterManyChunkReturnUnwrapped::new(ca),
+            ),
+        }
+    }
+}
+
+impl<'a, T> ParallelIterator for NumNoNullParIterDispatcher<'a, T>
+where
+    T: PolarsNumericType + Send + Sync
+{
+    type Item = T::Native;
+
+    fn drive_unindexed<C>(self, consumer: C) -> C::Result
+    where
+        C: UnindexedConsumer<Self::Item>,
+    {
+        match self {
+            NumNoNullParIterDispatcher::SingleChunk(a) => a.drive_unindexed(consumer),
+            NumNoNullParIterDispatcher::ManyChunk(a) => a.drive_unindexed(consumer),
+        }
+    }
+
+    fn opt_len(&self) -> Option<usize> {
+        match self {
+            NumNoNullParIterDispatcher::SingleChunk(a) => a.opt_len(),
+            NumNoNullParIterDispatcher::ManyChunk(a) => a.opt_len(),
+        }
+    }
+}
+
+impl<'a, T> IndexedParallelIterator for NumNoNullParIterDispatcher<'a, T>
+where
+    T: PolarsNumericType + Send + Sync
+{
+    fn len(&self) -> usize {
+        match self {
+            NumNoNullParIterDispatcher::SingleChunk(a) => a.len(),
+            NumNoNullParIterDispatcher::ManyChunk(a) => a.len(),
+        }
+    }
+
+    fn drive<C>(self, consumer: C) -> C::Result
+    where
+        C: Consumer<Self::Item>,
+    {
+        match self {
+            NumNoNullParIterDispatcher::SingleChunk(a) => a.drive(consumer),
+            NumNoNullParIterDispatcher::ManyChunk(a) => a.drive(consumer),
+        }
+    }
+
+    fn with_producer<CB>(self, callback: CB) -> CB::Output
+    where
+        CB: ProducerCallback<Self::Item>,
+    {
+        match self {
+            NumNoNullParIterDispatcher::SingleChunk(a) => a.with_producer(callback),
+            NumNoNullParIterDispatcher::ManyChunk(a) => a.with_producer(callback),
+        }
+    }
+}

--- a/polars/src/chunked_array/iterator/par/numeric.rs
+++ b/polars/src/chunked_array/iterator/par/numeric.rs
@@ -31,7 +31,6 @@ macro_rules! impl_numeric_parallel_iterator_body {
     };
 }
 
-
 /// Generate the code for body of an unindexed parallel iterator. It implements the trait methods.
 ///
 /// # Input
@@ -63,7 +62,6 @@ macro_rules! impl_numeric_indexed_parallel_iterator_body {
     };
 }
 
-
 /// Generate the code for body of a producer. It implements the trait methods.
 ///
 /// # Input
@@ -71,7 +69,7 @@ macro_rules! impl_numeric_indexed_parallel_iterator_body {
 /// seq_iter: The sequential iterator this producer cast after spliting.
 macro_rules! impl_numeric_producer_body {
     ($seq_iter:ty) => {
-        type Item =  <$seq_iter as Iterator>::Item;
+        type Item = <$seq_iter as Iterator>::Item;
         type IntoIter = $seq_iter;
 
         fn into_iter(self) -> Self::IntoIter {
@@ -92,7 +90,6 @@ macro_rules! impl_numeric_producer_body {
                 },
             )
         }
-        
     };
 }
 
@@ -100,7 +97,7 @@ macro_rules! impl_numeric_producer_body {
 // The methods are the same for the `ReturnOption` and `ReturnUnwrap` variant.
 impl<'a, T> NumIterSingleChunk<'a, T>
 where
-    T: PolarsNumericType + Send + Sync
+    T: PolarsNumericType + Send + Sync,
 {
     fn from_parts(ca: &'a ChunkedArray<T>, offset: usize, len: usize) -> Self {
         let chunk = ca.downcast_chunks()[0];
@@ -113,7 +110,7 @@ where
 
 impl<'a, T> NumIterManyChunk<'a, T>
 where
-    T: PolarsNumericType + Send + Sync
+    T: PolarsNumericType + Send + Sync,
 {
     fn from_parts(ca: &'a ChunkedArray<T>, offset: usize, len: usize) -> Self {
         let chunks = ca.downcast_chunks();
@@ -126,7 +123,6 @@ where
         // Compute right array indexes.
         let idx_right = offset + len;
         let (chunk_idx_right, current_array_idx_right) = ca.right_index_to_chunked_index(idx_right);
-
 
         let (current_array_left_len, current_iter_right) = if chunk_idx_left == chunk_idx_right {
             // If both iterators belong to the same chunk, then, only the left chunk is goin to be used
@@ -146,7 +142,6 @@ where
                     .iter()
                     .copied(),
             );
-
 
             (current_array_left_len, current_iter_right)
         };
@@ -176,14 +171,14 @@ where
 #[derive(Debug, Clone)]
 pub struct NumParIterSingleChunkReturnOption<'a, T>
 where
-    T: PolarsNumericType + Send + Sync
+    T: PolarsNumericType + Send + Sync,
 {
     ca: &'a ChunkedArray<T>,
 }
 
 impl<'a, T> NumParIterSingleChunkReturnOption<'a, T>
 where
-    T: PolarsNumericType + Send + Sync
+    T: PolarsNumericType + Send + Sync,
 {
     fn new(ca: &'a ChunkedArray<T>) -> Self {
         Self { ca }
@@ -193,7 +188,7 @@ where
 impl<'a, T> From<NumProducerSingleChunkReturnOption<'a, T>>
     for SomeIterator<NumIterSingleChunk<'a, T>>
 where
-    T: PolarsNumericType + Send + Sync
+    T: PolarsNumericType + Send + Sync,
 {
     fn from(prod: NumProducerSingleChunkReturnOption<'a, T>) -> Self {
         SomeIterator(<NumIterSingleChunk<'a, T>>::from_parts(
@@ -207,14 +202,14 @@ where
 // Implement parallel iterator for NumParIterSingleChunkReturnOption.
 impl<'a, T> ParallelIterator for NumParIterSingleChunkReturnOption<'a, T>
 where
-    T: PolarsNumericType + Send + Sync
+    T: PolarsNumericType + Send + Sync,
 {
     impl_numeric_parallel_iterator_body!(SomeIterator<NumIterSingleChunk<'a, T>>);
 }
 
 struct NumProducerSingleChunkReturnOption<'a, T>
 where
-    T: PolarsNumericType + Send + Sync
+    T: PolarsNumericType + Send + Sync,
 {
     ca: &'a ChunkedArray<T>,
     offset: usize,
@@ -223,18 +218,17 @@ where
 
 impl<'a, T> IndexedParallelIterator for NumParIterSingleChunkReturnOption<'a, T>
 where
-    T: PolarsNumericType + Send + Sync
+    T: PolarsNumericType + Send + Sync,
 {
     impl_numeric_indexed_parallel_iterator_body!(NumProducerSingleChunkReturnOption);
 }
 
 impl<'a, T> Producer for NumProducerSingleChunkReturnOption<'a, T>
 where
-    T: PolarsNumericType + Send + Sync
+    T: PolarsNumericType + Send + Sync,
 {
     impl_numeric_producer_body!(SomeIterator<NumIterSingleChunk<'a, T>>);
 }
-
 
 /// Parallel Iterator for chunked arrays with just one chunk.
 /// It DOES perform null check, then, it is appropriated for chunks whose contents can be null.
@@ -243,23 +237,24 @@ where
 #[derive(Debug, Clone)]
 pub struct NumParIterSingleChunkNullCheckReturnOption<'a, T>
 where
-    T: PolarsNumericType + Send + Sync
+    T: PolarsNumericType + Send + Sync,
 {
     ca: &'a ChunkedArray<T>,
 }
 
 impl<'a, T> NumParIterSingleChunkNullCheckReturnOption<'a, T>
 where
-    T: PolarsNumericType + Send + Sync
+    T: PolarsNumericType + Send + Sync,
 {
     fn new(ca: &'a ChunkedArray<T>) -> Self {
         Self { ca }
     }
 }
 
-impl<'a, T> From<NumProducerSingleChunkNullCheckReturnOption<'a, T>> for NumIterSingleChunkNullCheck<'a, T>
+impl<'a, T> From<NumProducerSingleChunkNullCheckReturnOption<'a, T>>
+    for NumIterSingleChunkNullCheck<'a, T>
 where
-    T: PolarsNumericType + Send + Sync
+    T: PolarsNumericType + Send + Sync,
 {
     fn from(prod: NumProducerSingleChunkNullCheckReturnOption<'a, T>) -> Self {
         let chunks = prod.ca.downcast_chunks();
@@ -278,14 +273,14 @@ where
 // Implement parallel iterator for NumParIterSingleChunkNullCheckReturnOption.
 impl<'a, T> ParallelIterator for NumParIterSingleChunkNullCheckReturnOption<'a, T>
 where
-    T: PolarsNumericType + Send + Sync
+    T: PolarsNumericType + Send + Sync,
 {
     impl_numeric_parallel_iterator_body!(NumIterSingleChunkNullCheck<'a, T>);
 }
 
 struct NumProducerSingleChunkNullCheckReturnOption<'a, T>
 where
-    T: PolarsNumericType + Send + Sync
+    T: PolarsNumericType + Send + Sync,
 {
     ca: &'a ChunkedArray<T>,
     offset: usize,
@@ -294,14 +289,14 @@ where
 
 impl<'a, T> IndexedParallelIterator for NumParIterSingleChunkNullCheckReturnOption<'a, T>
 where
-    T: PolarsNumericType + Send + Sync
+    T: PolarsNumericType + Send + Sync,
 {
     impl_numeric_indexed_parallel_iterator_body!(NumProducerSingleChunkNullCheckReturnOption);
 }
 
 impl<'a, T> Producer for NumProducerSingleChunkNullCheckReturnOption<'a, T>
 where
-    T: PolarsNumericType + Send + Sync
+    T: PolarsNumericType + Send + Sync,
 {
     impl_numeric_producer_body!(NumIterSingleChunkNullCheck<'a, T>);
 }
@@ -313,14 +308,14 @@ where
 #[derive(Debug, Clone)]
 pub struct NumParIterManyChunkReturnOption<'a, T>
 where
-    T: PolarsNumericType + Send + Sync
+    T: PolarsNumericType + Send + Sync,
 {
     ca: &'a ChunkedArray<T>,
 }
 
 impl<'a, T> NumParIterManyChunkReturnOption<'a, T>
 where
-    T: PolarsNumericType + Send + Sync
+    T: PolarsNumericType + Send + Sync,
 {
     fn new(ca: &'a ChunkedArray<T>) -> Self {
         Self { ca }
@@ -329,7 +324,7 @@ where
 
 impl<'a, T> From<NumProducerManyChunkReturnOption<'a, T>> for SomeIterator<NumIterManyChunk<'a, T>>
 where
-    T: PolarsNumericType + Send + Sync
+    T: PolarsNumericType + Send + Sync,
 {
     fn from(prod: NumProducerManyChunkReturnOption<'a, T>) -> Self {
         SomeIterator(<NumIterManyChunk<'a, T>>::from_parts(
@@ -343,14 +338,14 @@ where
 // Implement parallel iterator for NumParIterManyChunkReturnOption.
 impl<'a, T> ParallelIterator for NumParIterManyChunkReturnOption<'a, T>
 where
-    T: PolarsNumericType + Send + Sync
+    T: PolarsNumericType + Send + Sync,
 {
     impl_numeric_parallel_iterator_body!(SomeIterator<NumIterManyChunk<'a, T>>);
 }
 
 struct NumProducerManyChunkReturnOption<'a, T>
 where
-    T: PolarsNumericType + Send + Sync
+    T: PolarsNumericType + Send + Sync,
 {
     ca: &'a ChunkedArray<T>,
     offset: usize,
@@ -359,14 +354,14 @@ where
 
 impl<'a, T> IndexedParallelIterator for NumParIterManyChunkReturnOption<'a, T>
 where
-    T: PolarsNumericType + Send + Sync
+    T: PolarsNumericType + Send + Sync,
 {
     impl_numeric_indexed_parallel_iterator_body!(NumProducerManyChunkReturnOption);
 }
 
 impl<'a, T> Producer for NumProducerManyChunkReturnOption<'a, T>
 where
-    T: PolarsNumericType + Send + Sync
+    T: PolarsNumericType + Send + Sync,
 {
     impl_numeric_producer_body!(SomeIterator<NumIterManyChunk<'a, T>>);
 }
@@ -378,14 +373,14 @@ where
 #[derive(Debug, Clone)]
 pub struct NumParIterManyChunkNullCheckReturnOption<'a, T>
 where
-    T: PolarsNumericType + Send + Sync
+    T: PolarsNumericType + Send + Sync,
 {
     ca: &'a ChunkedArray<T>,
 }
 
 impl<'a, T> NumParIterManyChunkNullCheckReturnOption<'a, T>
 where
-    T: PolarsNumericType + Send + Sync
+    T: PolarsNumericType + Send + Sync,
 {
     fn new(ca: &'a ChunkedArray<T>) -> Self {
         Self { ca }
@@ -395,7 +390,7 @@ where
 impl<'a, T> From<NumProducerManyChunkNullCheckReturnOption<'a, T>>
     for NumIterManyChunkNullCheck<'a, T>
 where
-    T: PolarsNumericType + Send + Sync
+    T: PolarsNumericType + Send + Sync,
 {
     fn from(prod: NumProducerManyChunkNullCheckReturnOption<'a, T>) -> Self {
         let ca = prod.ca;
@@ -459,14 +454,14 @@ where
 // Implement parallel iterator for NumParIterManyChunkNullCheckReturnOption.
 impl<'a, T> ParallelIterator for NumParIterManyChunkNullCheckReturnOption<'a, T>
 where
-    T: PolarsNumericType + Send + Sync
+    T: PolarsNumericType + Send + Sync,
 {
     impl_numeric_parallel_iterator_body!(NumIterManyChunkNullCheck<'a, T>);
 }
 
 struct NumProducerManyChunkNullCheckReturnOption<'a, T>
 where
-    T: PolarsNumericType + Send + Sync
+    T: PolarsNumericType + Send + Sync,
 {
     ca: &'a ChunkedArray<T>,
     offset: usize,
@@ -475,14 +470,14 @@ where
 
 impl<'a, T> IndexedParallelIterator for NumParIterManyChunkNullCheckReturnOption<'a, T>
 where
-    T: PolarsNumericType + Send + Sync
+    T: PolarsNumericType + Send + Sync,
 {
     impl_numeric_indexed_parallel_iterator_body!(NumProducerManyChunkNullCheckReturnOption);
 }
 
 impl<'a, T> Producer for NumProducerManyChunkNullCheckReturnOption<'a, T>
 where
-    T: PolarsNumericType + Send + Sync
+    T: PolarsNumericType + Send + Sync,
 {
     impl_numeric_producer_body!(NumIterManyChunkNullCheck<'a, T>);
 }
@@ -495,14 +490,14 @@ where
 #[derive(Debug, Clone)]
 pub struct NumParIterSingleChunkReturnUnwrapped<'a, T>
 where
-    T: PolarsNumericType + Send + Sync
+    T: PolarsNumericType + Send + Sync,
 {
     ca: &'a ChunkedArray<T>,
 }
 
 impl<'a, T> NumParIterSingleChunkReturnUnwrapped<'a, T>
 where
-    T: PolarsNumericType + Send + Sync
+    T: PolarsNumericType + Send + Sync,
 {
     fn new(ca: &'a ChunkedArray<T>) -> Self {
         Self { ca }
@@ -511,7 +506,7 @@ where
 
 impl<'a, T> From<NumProducerSingleChunkReturnUnwrapped<'a, T>> for NumIterSingleChunk<'a, T>
 where
-    T: PolarsNumericType + Send + Sync
+    T: PolarsNumericType + Send + Sync,
 {
     fn from(prod: NumProducerSingleChunkReturnUnwrapped<'a, T>) -> Self {
         Self::from_parts(prod.ca, prod.offset, prod.len)
@@ -521,14 +516,14 @@ where
 // Implement parallel iterator for NumParIterSingleChunkReturnUnwrapped.
 impl<'a, T> ParallelIterator for NumParIterSingleChunkReturnUnwrapped<'a, T>
 where
-    T: PolarsNumericType + Send + Sync
+    T: PolarsNumericType + Send + Sync,
 {
     impl_numeric_parallel_iterator_body!(NumIterSingleChunk<'a, T>);
 }
 
 struct NumProducerSingleChunkReturnUnwrapped<'a, T>
 where
-    T: PolarsNumericType + Send + Sync
+    T: PolarsNumericType + Send + Sync,
 {
     ca: &'a ChunkedArray<T>,
     offset: usize,
@@ -537,14 +532,14 @@ where
 
 impl<'a, T> IndexedParallelIterator for NumParIterSingleChunkReturnUnwrapped<'a, T>
 where
-    T: PolarsNumericType + Send + Sync
+    T: PolarsNumericType + Send + Sync,
 {
     impl_numeric_indexed_parallel_iterator_body!(NumProducerSingleChunkReturnUnwrapped);
 }
 
 impl<'a, T> Producer for NumProducerSingleChunkReturnUnwrapped<'a, T>
 where
-    T: PolarsNumericType + Send + Sync
+    T: PolarsNumericType + Send + Sync,
 {
     impl_numeric_producer_body!(NumIterSingleChunk<'a, T>);
 }
@@ -557,14 +552,14 @@ where
 #[derive(Debug, Clone)]
 pub struct NumParIterManyChunkReturnUnwrapped<'a, T>
 where
-    T: PolarsNumericType + Send + Sync
+    T: PolarsNumericType + Send + Sync,
 {
     ca: &'a ChunkedArray<T>,
 }
 
 impl<'a, T> NumParIterManyChunkReturnUnwrapped<'a, T>
 where
-    T: PolarsNumericType + Send + Sync
+    T: PolarsNumericType + Send + Sync,
 {
     fn new(ca: &'a ChunkedArray<T>) -> Self {
         Self { ca }
@@ -573,7 +568,7 @@ where
 
 impl<'a, T> From<NumProducerManyChunkReturnUnwrapped<'a, T>> for NumIterManyChunk<'a, T>
 where
-    T: PolarsNumericType + Send + Sync
+    T: PolarsNumericType + Send + Sync,
 {
     fn from(prod: NumProducerManyChunkReturnUnwrapped<'a, T>) -> Self {
         Self::from_parts(prod.ca, prod.offset, prod.len)
@@ -583,14 +578,14 @@ where
 // Implement parallel iterator for NumParIterManyChunkReturnUnwrapped.
 impl<'a, T> ParallelIterator for NumParIterManyChunkReturnUnwrapped<'a, T>
 where
-    T: PolarsNumericType + Send + Sync
+    T: PolarsNumericType + Send + Sync,
 {
     impl_numeric_parallel_iterator_body!(NumIterManyChunk<'a, T>);
 }
 
 struct NumProducerManyChunkReturnUnwrapped<'a, T>
 where
-    T: PolarsNumericType + Send + Sync
+    T: PolarsNumericType + Send + Sync,
 {
     ca: &'a ChunkedArray<T>,
     offset: usize,
@@ -599,14 +594,14 @@ where
 
 impl<'a, T> IndexedParallelIterator for NumParIterManyChunkReturnUnwrapped<'a, T>
 where
-    T: PolarsNumericType + Send + Sync
+    T: PolarsNumericType + Send + Sync,
 {
     impl_numeric_indexed_parallel_iterator_body!(NumProducerManyChunkReturnUnwrapped);
 }
 
 impl<'a, T> Producer for NumProducerManyChunkReturnUnwrapped<'a, T>
 where
-    T: PolarsNumericType + Send + Sync
+    T: PolarsNumericType + Send + Sync,
 {
     impl_numeric_producer_body!(NumIterManyChunk<'a, T>);
 }
@@ -614,9 +609,9 @@ where
 /// Static dispatching structure to allow static polymorphism of chunked parallel iterators.
 ///
 /// All the iterators of the dispatcher returns `Option<PolarsNumericType::Native>`.
-pub enum NumParIterDispatcher<'a, T> 
+pub enum NumParIterDispatcher<'a, T>
 where
-    T: PolarsNumericType + Send + Sync
+    T: PolarsNumericType + Send + Sync,
 {
     SingleChunk(NumParIterSingleChunkReturnOption<'a, T>),
     SingleChunkNullCheck(NumParIterSingleChunkNullCheckReturnOption<'a, T>),
@@ -631,9 +626,9 @@ where
 /// - If `ChunkedArray<T>` has only a chunk and does have null values, it uses `NumParIterSingleChunkNullCheckReturnOption`.
 /// - If `ChunkedArray<T>` has many chunks and has no null values, it uses `NumParIterManyChunkReturnOption`.
 /// - If `ChunkedArray<T>` has many chunks and does have null values, it uses `NumParIterManyChunkNullCheckReturnOption`.
-impl<'a, T> IntoParallelIterator for &'a ChunkedArray<T> 
+impl<'a, T> IntoParallelIterator for &'a ChunkedArray<T>
 where
-    T: PolarsNumericType + Send + Sync
+    T: PolarsNumericType + Send + Sync,
 {
     type Iter = NumParIterDispatcher<'a, T>;
     type Item = Option<T::Native>;
@@ -643,9 +638,7 @@ where
         match chunks.len() {
             1 => {
                 if self.null_count() == 0 {
-                    NumParIterDispatcher::SingleChunk(
-                        NumParIterSingleChunkReturnOption::new(self),
-                    )
+                    NumParIterDispatcher::SingleChunk(NumParIterSingleChunkReturnOption::new(self))
                 } else {
                     NumParIterDispatcher::SingleChunkNullCheck(
                         NumParIterSingleChunkNullCheckReturnOption::new(self),
@@ -654,9 +647,7 @@ where
             }
             _ => {
                 if self.null_count() == 0 {
-                    NumParIterDispatcher::ManyChunk(
-                        NumParIterManyChunkReturnOption::new(self),
-                    )
+                    NumParIterDispatcher::ManyChunk(NumParIterManyChunkReturnOption::new(self))
                 } else {
                     NumParIterDispatcher::ManyChunkNullCheck(
                         NumParIterManyChunkNullCheckReturnOption::new(self),
@@ -667,9 +658,9 @@ where
     }
 }
 
-impl<'a, T> ParallelIterator for NumParIterDispatcher<'a, T> 
+impl<'a, T> ParallelIterator for NumParIterDispatcher<'a, T>
 where
-    T: PolarsNumericType + Send + Sync
+    T: PolarsNumericType + Send + Sync,
 {
     type Item = Option<T::Native>;
 
@@ -695,9 +686,9 @@ where
     }
 }
 
-impl<'a, T> IndexedParallelIterator for NumParIterDispatcher<'a, T> 
+impl<'a, T> IndexedParallelIterator for NumParIterDispatcher<'a, T>
 where
-    T: PolarsNumericType + Send + Sync
+    T: PolarsNumericType + Send + Sync,
 {
     fn len(&self) -> usize {
         match self {
@@ -736,11 +727,11 @@ where
 /// Static dispatching structure to allow static polymorphism of non-nullable chunked parallel iterators.
 ///
 /// All the iterators of the dispatcher returns `PolarsNumericType::Native`, as there are no nulls in the chunked array.
-pub enum NumNoNullParIterDispatcher<'a, T> 
+pub enum NumNoNullParIterDispatcher<'a, T>
 where
-    T: PolarsNumericType + Send + Sync
+    T: PolarsNumericType + Send + Sync,
 {
-    SingleChunk(NumParIterSingleChunkReturnUnwrapped<'a,T>),
+    SingleChunk(NumParIterSingleChunkReturnUnwrapped<'a, T>),
     ManyChunk(NumParIterManyChunkReturnUnwrapped<'a, T>),
 }
 
@@ -751,7 +742,7 @@ where
 /// - If `ChunkeArray<T>` has many chunks, it uses `NumParIterManyChunkReturnUnwrapped`.
 impl<'a, T> IntoParallelIterator for NoNull<&'a ChunkedArray<T>>
 where
-    T: PolarsNumericType + Send + Sync
+    T: PolarsNumericType + Send + Sync,
 {
     type Iter = NumNoNullParIterDispatcher<'a, T>;
     type Item = T::Native;
@@ -763,16 +754,14 @@ where
             1 => NumNoNullParIterDispatcher::SingleChunk(
                 NumParIterSingleChunkReturnUnwrapped::new(ca),
             ),
-            _ => NumNoNullParIterDispatcher::ManyChunk(
-                NumParIterManyChunkReturnUnwrapped::new(ca),
-            ),
+            _ => NumNoNullParIterDispatcher::ManyChunk(NumParIterManyChunkReturnUnwrapped::new(ca)),
         }
     }
 }
 
-impl<'a, T> ParallelIterator for NumNoNullParIterDispatcher<'a, T> 
+impl<'a, T> ParallelIterator for NumNoNullParIterDispatcher<'a, T>
 where
-    T: PolarsNumericType + Send + Sync
+    T: PolarsNumericType + Send + Sync,
 {
     type Item = T::Native;
 
@@ -794,9 +783,9 @@ where
     }
 }
 
-impl<'a, T> IndexedParallelIterator for NumNoNullParIterDispatcher<'a, T> 
+impl<'a, T> IndexedParallelIterator for NumNoNullParIterDispatcher<'a, T>
 where
-    T: PolarsNumericType + Send + Sync
+    T: PolarsNumericType + Send + Sync,
 {
     fn len(&self) -> usize {
         match self {
@@ -826,7 +815,6 @@ where
     }
 }
 
-
 #[cfg(test)]
 mod test {
     use crate::prelude::*;
@@ -837,9 +825,7 @@ mod test {
 
     /// Generates a `Vec` of `u32`, where every position is the `u32` representation of its index.
     fn generate_uint32_vec(size: usize) -> Vec<u32> {
-        (0..size)
-            .map(|n| n as u32)
-            .collect()
+        (0..size).map(|n| n as u32).collect()
     }
 
     /// Generate a `Vec` of `Option<u32>`, where even indexes are `Some(idx)` and odd indexes are `None`.
@@ -982,50 +968,78 @@ mod test {
     // Single Chunk Null Check Parallel Iterator Tests.
     impl_par_iter_return_option_map_test!(
         uint32_par_iter_single_chunk_null_check_return_option_map,
-        { UInt32Chunked::new_from_opt_slice("a", &generate_opt_uint32_vec(UINT32_CHUNKED_ARRAY_SIZE)) }
+        {
+            UInt32Chunked::new_from_opt_slice(
+                "a",
+                &generate_opt_uint32_vec(UINT32_CHUNKED_ARRAY_SIZE),
+            )
+        }
     );
 
     impl_par_iter_return_option_filter_test!(
         uint32_par_iter_single_chunk_null_check_return_option_filter,
-        { UInt32Chunked::new_from_opt_slice("a", &generate_opt_uint32_vec(UINT32_CHUNKED_ARRAY_SIZE)) }
+        {
+            UInt32Chunked::new_from_opt_slice(
+                "a",
+                &generate_opt_uint32_vec(UINT32_CHUNKED_ARRAY_SIZE),
+            )
+        }
     );
 
     impl_par_iter_return_option_fold_test!(
         uint32_par_iter_single_chunk_null_check_return_option_fold,
-        { UInt32Chunked::new_from_opt_slice("a", &generate_opt_uint32_vec(UINT32_CHUNKED_ARRAY_SIZE)) }
+        {
+            UInt32Chunked::new_from_opt_slice(
+                "a",
+                &generate_opt_uint32_vec(UINT32_CHUNKED_ARRAY_SIZE),
+            )
+        }
     );
 
     // Many Chunk Parallel Iterator Tests.
     impl_par_iter_return_option_map_test!(uint32_par_iter_many_chunk_return_option_map, {
-        let mut a = UInt32Chunked::new_from_slice("a", &generate_uint32_vec(UINT32_CHUNKED_ARRAY_SIZE));
-        let a_b = UInt32Chunked::new_from_slice("a", &generate_uint32_vec(UINT32_CHUNKED_ARRAY_SIZE));
+        let mut a =
+            UInt32Chunked::new_from_slice("a", &generate_uint32_vec(UINT32_CHUNKED_ARRAY_SIZE));
+        let a_b =
+            UInt32Chunked::new_from_slice("a", &generate_uint32_vec(UINT32_CHUNKED_ARRAY_SIZE));
         a.append(&a_b);
         a
     });
 
     impl_par_iter_return_option_filter_test!(uint32_par_iter_many_chunk_return_option_filter, {
-        let mut a = UInt32Chunked::new_from_slice("a", &generate_uint32_vec(UINT32_CHUNKED_ARRAY_SIZE));
-        let a_b = UInt32Chunked::new_from_slice("a", &generate_uint32_vec(UINT32_CHUNKED_ARRAY_SIZE));
+        let mut a =
+            UInt32Chunked::new_from_slice("a", &generate_uint32_vec(UINT32_CHUNKED_ARRAY_SIZE));
+        let a_b =
+            UInt32Chunked::new_from_slice("a", &generate_uint32_vec(UINT32_CHUNKED_ARRAY_SIZE));
         a.append(&a_b);
         a
     });
 
     impl_par_iter_return_option_fold_test!(uint32_par_iter_many_chunk_return_option_fold, {
-        let mut a = UInt32Chunked::new_from_slice("a", &generate_uint32_vec(UINT32_CHUNKED_ARRAY_SIZE));
-        let a_b = UInt32Chunked::new_from_slice("a", &generate_uint32_vec(UINT32_CHUNKED_ARRAY_SIZE));
+        let mut a =
+            UInt32Chunked::new_from_slice("a", &generate_uint32_vec(UINT32_CHUNKED_ARRAY_SIZE));
+        let a_b =
+            UInt32Chunked::new_from_slice("a", &generate_uint32_vec(UINT32_CHUNKED_ARRAY_SIZE));
         a.append(&a_b);
         a
     });
 
     // Many Chunk Null Check Parallel Iterator Tests.
-    impl_par_iter_return_option_map_test!(uint32_par_iter_many_chunk_null_check_return_option_map, {
-        let mut a =
-            UInt32Chunked::new_from_opt_slice("a", &generate_opt_uint32_vec(UINT32_CHUNKED_ARRAY_SIZE));
-        let a_b =
-            UInt32Chunked::new_from_opt_slice("a", &generate_opt_uint32_vec(UINT32_CHUNKED_ARRAY_SIZE));
-        a.append(&a_b);
-        a
-    });
+    impl_par_iter_return_option_map_test!(
+        uint32_par_iter_many_chunk_null_check_return_option_map,
+        {
+            let mut a = UInt32Chunked::new_from_opt_slice(
+                "a",
+                &generate_opt_uint32_vec(UINT32_CHUNKED_ARRAY_SIZE),
+            );
+            let a_b = UInt32Chunked::new_from_opt_slice(
+                "a",
+                &generate_opt_uint32_vec(UINT32_CHUNKED_ARRAY_SIZE),
+            );
+            a.append(&a_b);
+            a
+        }
+    );
 
     impl_par_iter_return_option_filter_test!(
         uint32_par_iter_many_chunk_null_check_return_option_filter,
@@ -1080,10 +1094,7 @@ mod test {
                     .collect::<Vec<_>>();
 
                 // Perform a sequetial maping.
-                let seq_result = a
-                    .into_no_null_iter()
-                    .map(|u| u + 10)
-                    .collect::<Vec<_>>();
+                let seq_result = a.into_no_null_iter().map(|u| u + 10).collect::<Vec<_>>();
 
                 // Check sequetial and parallel results are equal.
                 assert_eq!(par_result, seq_result);
@@ -1144,9 +1155,7 @@ mod test {
                     .reduce(|| 0u64, |left, right| left + right);
 
                 // Perform a sequential sum of length.
-                let seq_result = a
-                    .into_no_null_iter()
-                    .fold(0u64, |acc, u| acc + u as u64);
+                let seq_result = a.into_no_null_iter().fold(0u64, |acc, u| acc + u as u64);
 
                 // Check sequetial and parallel results are equal.
                 assert_eq!(par_result, seq_result);
@@ -1164,14 +1173,17 @@ mod test {
         { UInt32Chunked::new_from_slice("a", &generate_uint32_vec(UINT32_CHUNKED_ARRAY_SIZE)) }
     );
 
-    impl_par_iter_return_unwrapped_fold_test!(uint32_par_iter_single_chunk_return_unwrapped_fold, {
-        UInt32Chunked::new_from_slice("a", &generate_uint32_vec(UINT32_CHUNKED_ARRAY_SIZE))
-    });
+    impl_par_iter_return_unwrapped_fold_test!(
+        uint32_par_iter_single_chunk_return_unwrapped_fold,
+        { UInt32Chunked::new_from_slice("a", &generate_uint32_vec(UINT32_CHUNKED_ARRAY_SIZE)) }
+    );
 
     // Many Chunk Return Unwrapped
     impl_par_iter_return_unwrapped_map_test!(uint32_par_iter_many_chunk_return_unwrapped_map, {
-        let mut a = UInt32Chunked::new_from_slice("a", &generate_uint32_vec(UINT32_CHUNKED_ARRAY_SIZE));
-        let a_b = UInt32Chunked::new_from_slice("a", &generate_uint32_vec(UINT32_CHUNKED_ARRAY_SIZE));
+        let mut a =
+            UInt32Chunked::new_from_slice("a", &generate_uint32_vec(UINT32_CHUNKED_ARRAY_SIZE));
+        let a_b =
+            UInt32Chunked::new_from_slice("a", &generate_uint32_vec(UINT32_CHUNKED_ARRAY_SIZE));
         a.append(&a_b);
         a
     });
@@ -1181,15 +1193,18 @@ mod test {
         {
             let mut a =
                 UInt32Chunked::new_from_slice("a", &generate_uint32_vec(UINT32_CHUNKED_ARRAY_SIZE));
-            let a_b = UInt32Chunked::new_from_slice("a", &generate_uint32_vec(UINT32_CHUNKED_ARRAY_SIZE));
+            let a_b =
+                UInt32Chunked::new_from_slice("a", &generate_uint32_vec(UINT32_CHUNKED_ARRAY_SIZE));
             a.append(&a_b);
             a
         }
     );
 
     impl_par_iter_return_unwrapped_fold_test!(uint32_par_iter_many_chunk_return_unwrapped_fold, {
-        let mut a = UInt32Chunked::new_from_slice("a", &generate_uint32_vec(UINT32_CHUNKED_ARRAY_SIZE));
-        let a_b = UInt32Chunked::new_from_slice("a", &generate_uint32_vec(UINT32_CHUNKED_ARRAY_SIZE));
+        let mut a =
+            UInt32Chunked::new_from_slice("a", &generate_uint32_vec(UINT32_CHUNKED_ARRAY_SIZE));
+        let a_b =
+            UInt32Chunked::new_from_slice("a", &generate_uint32_vec(UINT32_CHUNKED_ARRAY_SIZE));
         a.append(&a_b);
         a
     });

--- a/polars/src/chunked_array/iterator/par/utf8.rs
+++ b/polars/src/chunked_array/iterator/par/utf8.rs
@@ -62,7 +62,7 @@ mod test {
         (0..size).map(|n| n.to_string()).collect()
     }
 
-    /// Generate a `Vec` of `Option<String>`, where even indexes are `None` and odd indexes are `Some("{idx}")`.
+    /// Generate a `Vec` of `Option<String>`, where even indexes are `Some("{idx}")` and odd indexes are `None`.
     fn generate_opt_utf8_vec(size: usize) -> Vec<Option<String>> {
         (0..size)
             .map(|n| {


### PR DESCRIPTION
Final commit for issue #79, implement parallel iterators for `PolarsNumericTypes`. This commit add the following changes:
1. Iterators for Numeric Chunked Arrays with many chunks failed when first chunk was consumed using `next`, the right chunk could be consumed twice by using `next` and `next_back`. Then, tests have been added to detect this problem. Also, a fix for this problem has been added.
2. Added parallel iterators for numeric types.
3. Added tests for parallel iterators with numeric types.