### PR TITLE
Link to Python reference was not working

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Want to know about all the features Polars support? Read the docs!
 #### Python
 * installation guide: `pip install py-polars`
 * [the book](https://ritchie46.github.io/polars-book/)
-* [Reference guide](https://ritchie46.github.io/polars/pypolars/index.html)
+* [Reference guide](https://ritchie46.github.io/polars/pypolars/pypolars/index.html)
 
 ## Performance
 Polars is written to be performant, and it is! But don't take my word for it, take a look at the results in 


### PR DESCRIPTION
The Python reference link was not working. After searching the code I found the link that worked for me. I added another /pypolars/ to the path.