### PR TITLE
Faster groupby's for multiple keys and hash join on floats

### DIFF
--- a/polars/polars-arrow/src/builder.rs
+++ b/polars/polars-arrow/src/builder.rs
@@ -391,8 +391,10 @@ impl LargeStringBuilder {
 
     /// Builds the `StringArray` and reset this builder.
     pub fn finish(&mut self) -> LargeStringArray {
-        let values = mem::take(&mut self.values);
-        let offsets = mem::take(&mut self.offsets);
+        let mut values = mem::take(&mut self.values);
+        values.shrink_to_fit();
+        let mut offsets = mem::take(&mut self.offsets);
+        offsets.shrink_to_fit();
 
         let arraydata = ArrayData::builder(DataType::LargeUtf8)
             .len(offsets.len() - 1)

--- a/polars/polars-core/src/frame/group_by.rs
+++ b/polars/polars-core/src/frame/group_by.rs
@@ -113,7 +113,7 @@ impl VecHash for Float32Chunked {
         if self.null_count() == 0 {
             self.into_no_null_iter()
                 .map(|v| {
-                    let v = v.to_bits() as i32;
+                    let v = v.to_bits();
                     let mut hasher = random_state.build_hasher();
                     v.hash(&mut hasher);
                     hasher.finish()
@@ -123,7 +123,7 @@ impl VecHash for Float32Chunked {
         } else {
             self.into_iter()
                 .map(|opt_v| {
-                    let opt_v = opt_v.map(|v| v.to_bits() as i32);
+                    let opt_v = opt_v.map(|v| v.to_bits());
                     let mut hasher = random_state.build_hasher();
                     opt_v.hash(&mut hasher);
                     hasher.finish()
@@ -138,7 +138,7 @@ impl VecHash for Float64Chunked {
         if self.null_count() == 0 {
             self.into_no_null_iter()
                 .map(|v| {
-                    let v = v.to_bits() as i64;
+                    let v = v.to_bits();
                     let mut hasher = random_state.build_hasher();
                     v.hash(&mut hasher);
                     hasher.finish()
@@ -148,7 +148,7 @@ impl VecHash for Float64Chunked {
         } else {
             self.into_iter()
                 .map(|opt_v| {
-                    let opt_v = opt_v.map(|v| v.to_bits() as i64);
+                    let opt_v = opt_v.map(|v| v.to_bits());
                     let mut hasher = random_state.build_hasher();
                     opt_v.hash(&mut hasher);
                     hasher.finish()
@@ -469,29 +469,22 @@ macro_rules! impl_into_group_tpls_float {
                 0 => {
                     let iters = splitted
                         .iter()
-                        .map(|ca| ca.into_no_null_iter().map(|v| v.integer_decode()))
+                        .map(|ca| ca.into_no_null_iter().map(|v| v.to_bits()))
                         .collect_vec();
                     groupby_threaded_flat(iters)
                 }
                 _ => {
                     let iters = splitted
                         .iter()
-                        .map(|ca| {
-                            ca.into_iter()
-                                .map(|opt_v| opt_v.map(|v| v.integer_decode()))
-                        })
+                        .map(|ca| ca.into_iter().map(|opt_v| opt_v.map(|v| v.to_bits())))
                         .collect_vec();
                     groupby_threaded_flat(iters)
                 }
             }
         } else {
             match $self.null_count() {
-                0 => groupby($self.into_no_null_iter().map(|v| v.integer_decode())),
-                _ => groupby(
-                    $self
-                        .into_iter()
-                        .map(|opt_v| opt_v.map(|v| v.integer_decode())),
-                ),
+                0 => groupby($self.into_no_null_iter().map(|v| v.to_bits())),
+                _ => groupby($self.into_iter().map(|opt_v| opt_v.map(|v| v.to_bits()))),
             }
         }
     };

--- a/polars/polars-core/src/frame/hash_join.rs
+++ b/polars/polars-core/src/frame/hash_join.rs
@@ -15,6 +15,24 @@ use std::hash::Hash;
 use std::ops::Deref;
 use unsafe_unwrap::UnsafeUnwrap;
 
+macro_rules! det_hash_prone_order {
+    ($self:expr, $other:expr) => {{
+        // The shortest relation will be used to create a hash table.
+        let left_first = $self.len() > $other.len();
+        let a;
+        let b;
+        if left_first {
+            a = $self;
+            b = $other;
+        } else {
+            b = $self;
+            a = $other;
+        }
+
+        (a, b, !left_first)
+    }};
+}
+
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum JoinType {
     Left,
@@ -40,14 +58,15 @@ where
 }
 
 #[allow(clippy::needless_collect)]
-fn hash_join_tuples_inner_threaded<T, I>(
+fn hash_join_tuples_inner_threaded<T, I, J>(
     a: Vec<I>,
-    b: Vec<I>,
+    b: Vec<J>,
     // Because b should be the shorter relation we could need to swap to keep left left and right right.
     swap: bool,
 ) -> Vec<(usize, usize)>
 where
     I: Iterator<Item = T> + Send,
+    J: Iterator<Item = T> + Send,
     T: Send + Hash + Eq + Sync + Copy + Debug,
 {
     // first we hash one relation
@@ -121,9 +140,10 @@ where
 }
 
 #[allow(clippy::needless_collect)]
-fn hash_join_tuples_left_threaded<T, I>(a: Vec<I>, b: Vec<I>) -> Vec<(usize, Option<usize>)>
+fn hash_join_tuples_left_threaded<T, I, J>(a: Vec<I>, b: Vec<J>) -> Vec<(usize, Option<usize>)>
 where
     I: Iterator<Item = T> + Send,
+    J: Iterator<Item = T> + Send,
     T: Send + Hash + Eq + Sync + Copy + Debug,
 {
     // first we hash one relation
@@ -309,8 +329,97 @@ pub(crate) trait HashJoin<T> {
     }
 }
 
-impl HashJoin<Float64Type> for Float64Chunked {}
-impl HashJoin<Float32Type> for Float32Chunked {}
+macro_rules! impl_float_hash_join {
+    ($type: ty, $ca: ty) => {
+        impl HashJoin<$type> for $ca {
+            fn hash_join_inner(&self, other: &$ca) -> Vec<(usize, usize)> {
+                let (a, b, swap) = det_hash_prone_order!(self, other);
+
+                let n_threads = n_join_threads();
+                let splitted_a = split_ca(a, n_threads).unwrap();
+                let splitted_b = split_ca(b, n_threads).unwrap();
+
+                match (a.null_count(), b.null_count()) {
+                    (0, 0) => {
+                        let iters_a = splitted_a
+                            .iter()
+                            .map(|ca| ca.into_no_null_iter().map(|v| v.to_bits()))
+                            .collect_vec();
+                        let iters_b = splitted_b
+                            .iter()
+                            .map(|ca| ca.into_no_null_iter().map(|v| v.to_bits()))
+                            .collect_vec();
+                        hash_join_tuples_inner_threaded(iters_a, iters_b, swap)
+                    }
+                    _ => {
+                        let iters_a = splitted_a
+                            .iter()
+                            .map(|ca| ca.into_iter().map(|opt_v| opt_v.map(|v| v.to_bits())))
+                            .collect_vec();
+                        let iters_b = splitted_b
+                            .iter()
+                            .map(|ca| ca.into_iter().map(|opt_v| opt_v.map(|v| v.to_bits())))
+                            .collect_vec();
+                        hash_join_tuples_inner_threaded(iters_a, iters_b, swap)
+                    }
+                }
+            }
+            fn hash_join_left(&self, other: &$ca) -> Vec<(usize, Option<usize>)> {
+                let n_threads = n_join_threads();
+
+                let a = self;
+                let b = other;
+                let splitted_a = split_ca(a, n_threads).unwrap();
+                let splitted_b = split_ca(b, n_threads).unwrap();
+
+                match (a.null_count(), b.null_count()) {
+                    (0, 0) => {
+                        let iters_a = splitted_a
+                            .iter()
+                            .map(|ca| ca.into_no_null_iter().map(|v| v.to_bits()))
+                            .collect_vec();
+                        let iters_b = splitted_b
+                            .iter()
+                            .map(|ca| ca.into_no_null_iter().map(|v| v.to_bits()))
+                            .collect_vec();
+                        hash_join_tuples_left_threaded(iters_a, iters_b)
+                    }
+                    _ => {
+                        let iters_a = splitted_a
+                            .iter()
+                            .map(|ca| ca.into_iter().map(|opt_v| opt_v.map(|v| v.to_bits())))
+                            .collect_vec();
+                        let iters_b = splitted_b
+                            .iter()
+                            .map(|ca| ca.into_iter().map(|opt_v| opt_v.map(|v| v.to_bits())))
+                            .collect_vec();
+                        hash_join_tuples_left_threaded(iters_a, iters_b)
+                    }
+                }
+            }
+            fn hash_join_outer(&self, other: &$ca) -> Vec<(Option<usize>, Option<usize>)> {
+                let (a, b, swap) = det_hash_prone_order!(self, other);
+
+                match (a.null_count() == 0, b.null_count() == 0) {
+                    (true, true) => hash_join_tuples_outer(
+                        a.into_no_null_iter().map(|v| v.to_bits()),
+                        b.into_no_null_iter().map(|v| v.to_bits()),
+                        swap,
+                    ),
+                    _ => hash_join_tuples_outer(
+                        a.into_iter().map(|opt_v| opt_v.map(|v| v.to_bits())),
+                        b.into_iter().map(|opt_v| opt_v.map(|v| v.to_bits())),
+                        swap,
+                    ),
+                }
+            }
+        }
+    };
+}
+
+impl_float_hash_join!(Float32Type, Float32Chunked);
+impl_float_hash_join!(Float64Type, Float64Chunked);
+
 impl HashJoin<ListType> for ListChunked {}
 impl HashJoin<CategoricalType> for CategoricalChunked {
     fn hash_join_inner(&self, other: &CategoricalChunked) -> Vec<(usize, usize)> {
@@ -322,24 +431,6 @@ impl HashJoin<CategoricalType> for CategoricalChunked {
     fn hash_join_outer(&self, other: &CategoricalChunked) -> Vec<(Option<usize>, Option<usize>)> {
         self.deref().hash_join_outer(&other.cast().unwrap())
     }
-}
-
-macro_rules! det_hash_prone_order {
-    ($self:expr, $other:expr) => {{
-        // The shortest relation will be used to create a hash table.
-        let left_first = $self.len() > $other.len();
-        let a;
-        let b;
-        if left_first {
-            a = $self;
-            b = $other;
-        } else {
-            b = $self;
-            a = $other;
-        }
-
-        (a, b, !left_first)
-    }};
 }
 
 fn n_join_threads() -> usize {
@@ -411,23 +502,12 @@ where
 
     fn hash_join_outer(&self, other: &ChunkedArray<T>) -> Vec<(Option<usize>, Option<usize>)> {
         let (a, b, swap) = det_hash_prone_order!(self, other);
-        match (a.cont_slice(), b.cont_slice()) {
-            (Ok(a_slice), Ok(b_slice)) => {
-                hash_join_tuples_outer(a_slice.iter(), b_slice.iter(), swap)
+
+        match (a.null_count() == 0, b.null_count() == 0) {
+            (true, true) => {
+                hash_join_tuples_outer(a.into_no_null_iter(), b.into_no_null_iter(), swap)
             }
-            (Ok(a_slice), Err(_)) => {
-                hash_join_tuples_outer(
-                    a_slice.iter().map(|v| Some(*v)), // take ownership
-                    b.into_iter(),
-                    swap,
-                )
-            }
-            (Err(_), Ok(b_slice)) => hash_join_tuples_outer(
-                a.into_iter(),
-                b_slice.iter().map(|v: &T::Native| Some(*v)),
-                swap,
-            ),
-            (Err(_), Err(_)) => hash_join_tuples_outer(a.into_iter(), b.into_iter(), swap),
+            _ => hash_join_tuples_outer(a.into_iter(), b.into_iter(), swap),
         }
     }
 }

--- a/polars/polars-core/src/prelude.rs
+++ b/polars/polars-core/src/prelude.rs
@@ -20,7 +20,7 @@ pub use crate::{
     datatypes,
     datatypes::*,
     error::{PolarsError, Result},
-    frame::{hash_join::JoinType, DataFrame, IntoSeries},
+    frame::{hash_join::JoinType, DataFrame, IntoSeries, group_by::VecHash},
     series::{
         arithmetic::{LhsNumOps, NumOpsDispatch},
         NamedFrom, Series, SeriesTrait,

--- a/polars/polars-core/src/prelude.rs
+++ b/polars/polars-core/src/prelude.rs
@@ -20,7 +20,7 @@ pub use crate::{
     datatypes,
     datatypes::*,
     error::{PolarsError, Result},
-    frame::{hash_join::JoinType, DataFrame, IntoSeries, group_by::VecHash},
+    frame::{group_by::VecHash, hash_join::JoinType, DataFrame, IntoSeries},
     series::{
         arithmetic::{LhsNumOps, NumOpsDispatch},
         NamedFrom, Series, SeriesTrait,

--- a/polars/polars-core/src/series/implementations.rs
+++ b/polars/polars-core/src/series/implementations.rs
@@ -10,6 +10,7 @@ use crate::frame::hash_join::{HashJoin, ZipOuterJoinColumn};
 use crate::prelude::*;
 #[cfg(feature = "object")]
 use crate::series::private::PrivateSeries;
+use ahash::RandomState;
 use arrow::array::{ArrayDataRef, ArrayRef};
 use arrow::buffer::Buffer;
 #[cfg(feature = "object")]
@@ -17,7 +18,6 @@ use std::any::Any;
 #[cfg(feature = "object")]
 use std::fmt::Debug;
 use std::ops::Deref;
-use ahash::RandomState;
 
 pub(crate) struct Wrap<T>(pub T);
 
@@ -58,7 +58,6 @@ where
 macro_rules! impl_dyn_series {
     ($ca: ident) => {
         impl private::PrivateSeries for Wrap<$ca> {
-
             fn vec_hash(&self, random_state: RandomState) -> UInt64Chunked {
                 self.0.vec_hash(random_state)
             }

--- a/polars/polars-core/src/series/implementations.rs
+++ b/polars/polars-core/src/series/implementations.rs
@@ -17,6 +17,7 @@ use std::any::Any;
 #[cfg(feature = "object")]
 use std::fmt::Debug;
 use std::ops::Deref;
+use ahash::RandomState;
 
 pub(crate) struct Wrap<T>(pub T);
 
@@ -57,6 +58,11 @@ where
 macro_rules! impl_dyn_series {
     ($ca: ident) => {
         impl private::PrivateSeries for Wrap<$ca> {
+
+            fn vec_hash(&self, random_state: RandomState) -> UInt64Chunked {
+                self.0.vec_hash(random_state)
+            }
+
             fn agg_mean(&self, groups: &[(usize, Vec<usize>)]) -> Option<Series> {
                 self.0.agg_mean(groups)
             }

--- a/polars/polars-core/src/series/mod.rs
+++ b/polars/polars-core/src/series/mod.rs
@@ -24,7 +24,7 @@ pub(crate) mod private {
     use ahash::RandomState;
 
     pub trait PrivateSeries {
-        fn vec_hash(&self, random_state: RandomState) -> UInt64Chunked {
+        fn vec_hash(&self, _random_state: RandomState) -> UInt64Chunked {
             unimplemented!()
         }
         fn agg_mean(&self, _groups: &[(usize, Vec<usize>)]) -> Option<Series> {

--- a/polars/polars-core/src/series/mod.rs
+++ b/polars/polars-core/src/series/mod.rs
@@ -21,8 +21,12 @@ use std::sync::Arc;
 pub(crate) mod private {
     use super::*;
     use crate::frame::group_by::PivotAgg;
+    use ahash::RandomState;
 
     pub trait PrivateSeries {
+        fn vec_hash(&self, random_state: RandomState) -> UInt64Chunked {
+            unimplemented!()
+        }
         fn agg_mean(&self, _groups: &[(usize, Vec<usize>)]) -> Option<Series> {
             unimplemented!()
         }

--- a/polars/polars-core/src/utils.rs
+++ b/polars/polars-core/src/utils.rs
@@ -80,7 +80,7 @@ pub fn get_iter_capacity<T, I: Iterator<Item = T>>(iter: &I) -> usize {
     }
 }
 
-macro_rules! split_ca {
+macro_rules! split_array {
     ($ca: ident, $n: expr) => {{
         if $n == 1 {
             return Ok(vec![$ca.clone()]);
@@ -104,11 +104,7 @@ macro_rules! split_ca {
 }
 
 pub(crate) fn split_ca<T>(ca: &ChunkedArray<T>, n: usize) -> Result<Vec<ChunkedArray<T>>> {
-    split_ca!(ca, n)
-}
-
-pub(crate) fn split_series(series: &Series, n: usize) -> Result<Vec<Series>> {
-    split_ca!(series, n)
+    split_array!(ca, n)
 }
 
 pub fn split_df(df: &DataFrame, n: usize) -> Result<Vec<DataFrame>> {
@@ -120,7 +116,7 @@ pub fn split_df(df: &DataFrame, n: usize) -> Result<Vec<DataFrame>> {
             self.height()
         }
     }
-    split_ca!(df, n)
+    split_array!(df, n)
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]

--- a/polars/polars-core/src/vector_hasher.rs
+++ b/polars/polars-core/src/vector_hasher.rs
@@ -181,22 +181,6 @@ where
     .unwrap()
 }
 
-pub(crate) fn create_hash_vectorized<I, T>(iter: I) -> (Vec<u64>, RandomState)
-where
-    I: Iterator<Item = T>,
-    T: Hash + Eq,
-{
-    let random_state = RandomState::default();
-    let v = iter
-        .map(|val| {
-            let mut hasher = random_state.build_hasher();
-            val.hash(&mut hasher);
-            hasher.finish()
-        })
-        .collect_vec();
-    (v, random_state)
-}
-
 pub(crate) fn create_hash_and_keys_threaded_vectorized<I, T>(
     iters: Vec<I>,
     random_state: Option<RandomState>,

--- a/polars/polars-lazy/src/physical_plan/executors.rs
+++ b/polars/polars-lazy/src/physical_plan/executors.rs
@@ -579,8 +579,6 @@ impl Executor for PartitionGroupByExec {
         // splitted on several threads. Than the final result we apply the same groupby again.
         let dfs = split_df(&original_df, n_threads)?;
 
-        let n_threads = num_cpus::get();
-
         let dfs: Result<_> = thread::scope(|s| {
 
             let handles = (0..n_threads)

--- a/py-polars/pypolars/functions.py
+++ b/py-polars/pypolars/functions.py
@@ -26,6 +26,7 @@ def read_csv(
     encoding: str = "utf8",
     n_threads: Optional[int] = None,
     dtype: "Optional[Dict[str, DataType]]" = None,
+    new_columns: "Optional[List[str]]" = None,
 ) -> "DataFrame":
     """
     Read into a DataFrame from a csv file.
@@ -68,7 +69,7 @@ def read_csv(
     DataFrame
     """
 
-    return DataFrame.read_csv(
+    df = DataFrame.read_csv(
         file=file,
         infer_schema_length=infer_schema_length,
         batch_size=batch_size,
@@ -84,6 +85,9 @@ def read_csv(
         n_threads=n_threads,
         dtype=dtype,
     )
+    if new_columns:
+        df.columns = new_columns
+    return df
 
 
 def scan_csv(


### PR DESCRIPTION
Uses the vectorized hasher similar to https://www.cockroachlabs.com/blog/vectorized-hash-joiner/.|
This relies less on macro's to create the groupable and hashes faster.