### PR TITLE
Fix Shift Overflow

### DIFF
--- a/polars/polars-core/src/chunked_array/mod.rs
+++ b/polars/polars-core/src/chunked_array/mod.rs
@@ -313,7 +313,8 @@ impl<T> ChunkedArray<T> {
     /// Slice the array. The chunks are reallocated the underlying data slices are zero copy.
     pub fn slice(&self, offset: usize, length: usize) -> Result<Self> {
         if offset + length > self.len() {
-            return Err(PolarsError::OutOfBounds("offset and length was larger than the size of the ChunkedArray during slice operation".into()));
+            return Err(PolarsError::OutOfBounds(format!("offset {} + length {} > len {}", offset, length, self.len()).into()));
+            // return Err(PolarsError::OutOfBounds("offset and length was larger than the size of the ChunkedArray during slice operation".into()));
         }
         let mut remaining_length = length;
         let mut remaining_offset = offset;

--- a/polars/polars-core/src/chunked_array/mod.rs
+++ b/polars/polars-core/src/chunked_array/mod.rs
@@ -313,8 +313,7 @@ impl<T> ChunkedArray<T> {
     /// Slice the array. The chunks are reallocated the underlying data slices are zero copy.
     pub fn slice(&self, offset: usize, length: usize) -> Result<Self> {
         if offset + length > self.len() {
-            return Err(PolarsError::OutOfBounds(format!("offset {} + length {} > len {}", offset, length, self.len()).into()));
-            // return Err(PolarsError::OutOfBounds("offset and length was larger than the size of the ChunkedArray during slice operation".into()));
+            return Err(PolarsError::OutOfBounds("offset and length was larger than the size of the ChunkedArray during slice operation".into()));
         }
         let mut remaining_length = length;
         let mut remaining_offset = offset;

--- a/polars/polars-core/src/chunked_array/ops/shift.rs
+++ b/polars/polars-core/src/chunked_array/ops/shift.rs
@@ -3,17 +3,18 @@ use num::{abs, clamp};
 
 macro_rules! impl_shift_fill {
     ($self:ident, $periods:expr, $fill_value:expr) => {{
-        let slice_offset = clamp(-$periods, 0, $self.len() as i64) as usize;
-        let length = $self.len() - abs($periods) as usize;
+        let periods = clamp($periods, -($self.len() as i64), $self.len() as i64);
+        let slice_offset = (-periods).max(0) as usize;
+        let length = $self.len() - abs(periods) as usize;
         let mut slice = $self.slice(slice_offset, length).unwrap();
 
-        let fill_length = abs($periods) as usize;
+        let fill_length = abs(periods) as usize;
         let mut fill = match $fill_value {
             Some(val) => Self::full($self.name(), val, fill_length),
             None => Self::full_null($self.name(), fill_length),
         };
 
-        if $periods < 0 {
+        if periods < 0 {
             slice.append(&fill);
             slice
         } else {

--- a/polars/polars-core/src/chunked_array/ops/shift.rs
+++ b/polars/polars-core/src/chunked_array/ops/shift.rs
@@ -112,19 +112,6 @@ mod test {
 
     #[test]
     fn test_shift() {
-        // n = 0
-        let ca = Int32Chunked::new_from_slice("", &[]);
-        let shifted = ca.shift_and_fill(0, None);
-        assert_eq!(Vec::from(&shifted), &[]);
-        let shifted = ca.shift_and_fill(2, None);
-        assert_eq!(Vec::from(&shifted), &[]);
-        let shifted = ca.shift_and_fill(-2, None);
-        assert_eq!(Vec::from(&shifted), &[]);
-        let shifted = ca.shift_and_fill(-2, Some(4));
-        assert_eq!(Vec::from(&shifted), &[]);
-        let shifted = ca.shift_and_fill(22, Some(4));
-        assert_eq!(Vec::from(&shifted), &[]);
-
         let ca = Int32Chunked::new_from_slice("", &[1, 2, 3]);
 
         // shift by 0, 1, 2, 3, 4

--- a/polars/polars-core/src/chunked_array/ops/shift.rs
+++ b/polars/polars-core/src/chunked_array/ops/shift.rs
@@ -112,18 +112,52 @@ mod test {
 
     #[test]
     fn test_shift() {
+        // n = 0
         let ca = Int32Chunked::new_from_slice("", &[1, 2, 3]);
-        let shifted = ca.shift_and_fill(1, Some(0));
-        assert_eq!(Vec::from(&shifted), &[Some(0), Some(1), Some(2)]);
+        let shifted = ca.shift_and_fill(0, None);
+        assert_eq!(Vec::from(&shifted), &[]);
+        let shifted = ca.shift_and_fill(2, None);
+        assert_eq!(Vec::from(&shifted), &[]);
+        let shifted = ca.shift_and_fill(-2, None);
+        assert_eq!(Vec::from(&shifted), &[]);
+        let shifted = ca.shift_and_fill(-2, Some(4));
+        assert_eq!(Vec::from(&shifted), &[]);
+        let shifted = ca.shift_and_fill(22, Some(4));
+        assert_eq!(Vec::from(&shifted), &[]);
+
+        let ca = Int32Chunked::new_from_slice("", &[1, 2, 3]);
+
+        // shift by 0, 1, 2, 3, 4
+        let shifted = ca.shift_and_fill(0, Some(5));
+        assert_eq!(Vec::from(&shifted), &[Some(1), Some(2), Some(3)]);
+        let shifted = ca.shift_and_fill(1, Some(5));
+        assert_eq!(Vec::from(&shifted), &[Some(5), Some(1), Some(2)]);
+        let shifted = ca.shift_and_fill(2, Some(5));
+        assert_eq!(Vec::from(&shifted), &[Some(5), Some(5), Some(2)]);
+        let shifted = ca.shift_and_fill(3, Some(5));
+        assert_eq!(Vec::from(&shifted), &[Some(5), Some(5), Some(5)]);
+        let shifted = ca.shift_and_fill(4, Some(5));
+        assert_eq!(Vec::from(&shifted), &[Some(5), Some(5), Some(5)]);
+
+        // shift by -1, -2, -3, -4
+        let shifted = ca.shift_and_fill(-1, Some(5));
+        assert_eq!(Vec::from(&shifted), &[Some(2), Some(3), Some(5)]);
+        let shifted = ca.shift_and_fill(-2, Some(5));
+        assert_eq!(Vec::from(&shifted), &[Some(3), Some(5), Some(5)]);
+        let shifted = ca.shift_and_fill(-3, Some(5));
+        assert_eq!(Vec::from(&shifted), &[Some(5), Some(5), Some(5)]);
+        let shifted = ca.shift_and_fill(-4, Some(5));
+        assert_eq!(Vec::from(&shifted), &[Some(5), Some(5), Some(5)]);
+
+        // fill with None
         let shifted = ca.shift_and_fill(1, None);
         assert_eq!(Vec::from(&shifted), &[None, Some(1), Some(2)]);
-        let shifted = ca.shift_and_fill(-1, None);
-        assert_eq!(Vec::from(&shifted), &[Some(2), Some(3), None]);
-
-        // shift overflow
-        let shifted = ca.shift_and_fill(3, None);
+        let shifted = ca.shift_and_fill(10, None);
         assert_eq!(Vec::from(&shifted), &[None, None, None]);
+        let shifted = ca.shift_and_fill(-2, None);
+        assert_eq!(Vec::from(&shifted), &[Some(3), None, None]);
 
+        // string
         let s = Series::new("a", ["a", "b", "c"]);
         let shifted = s.shift(-1);
         assert_eq!(

--- a/polars/polars-core/src/chunked_array/ops/shift.rs
+++ b/polars/polars-core/src/chunked_array/ops/shift.rs
@@ -113,7 +113,7 @@ mod test {
     #[test]
     fn test_shift() {
         // n = 0
-        let ca = Int32Chunked::new_from_slice("", &[1, 2, 3]);
+        let ca = Int32Chunked::new_from_slice("", &[]);
         let shifted = ca.shift_and_fill(0, None);
         assert_eq!(Vec::from(&shifted), &[]);
         let shifted = ca.shift_and_fill(2, None);

--- a/polars/polars-core/src/chunked_array/ops/shift.rs
+++ b/polars/polars-core/src/chunked_array/ops/shift.rs
@@ -120,7 +120,7 @@ mod test {
         let shifted = ca.shift_and_fill(1, Some(5));
         assert_eq!(Vec::from(&shifted), &[Some(5), Some(1), Some(2)]);
         let shifted = ca.shift_and_fill(2, Some(5));
-        assert_eq!(Vec::from(&shifted), &[Some(5), Some(5), Some(2)]);
+        assert_eq!(Vec::from(&shifted), &[Some(5), Some(5), Some(1)]);
         let shifted = ca.shift_and_fill(3, Some(5));
         assert_eq!(Vec::from(&shifted), &[Some(5), Some(5), Some(5)]);
         let shifted = ca.shift_and_fill(4, Some(5));


### PR DESCRIPTION
Overflowing shift actually overflowed.

```
>>> pypolars.Series([1,2,3]).shift(4)
thread '<unnamed>' panicked at 'called `Result::unwrap()` on an `Err` value: OutOfBounds("offset and length was larger than the size of the ChunkedArray during slice operation")', polars/polars-core/src/chunked_array/ops/shift.rs:32:9

>>> pypolars.Series([1,2,3]).shift(-4)
Series: '' [i64]
[
	null
	null
	null
	null
]
# length became 4
```

```
// 3_usize - 4_usize = overflow
let length = $self.len() - abs($periods) as usize;
```
