### PR TITLE
Use size hint in groupby containers

### DIFF
--- a/polars/polars-core/src/chunked_array/upstream_traits.rs
+++ b/polars/polars-core/src/chunked_array/upstream_traits.rs
@@ -245,8 +245,9 @@ where
         let vectors = collect_into_linked_list(iter);
         let capacity: usize = get_capacity_from_par_results(&vectors);
 
-        let iter = TrustMyLength::new(vectors.into_iter().flatten(), capacity).map(Some);
-        let arr: PrimitiveArray<T> = unsafe { PrimitiveArray::from_trusted_len_iter(iter) };
+        let av: AlignedVec<_> =
+            TrustMyLength::new(vectors.into_iter().flatten(), capacity).collect();
+        let arr = av.into_primitive_array::<T>(None);
         NoNull::new(ChunkedArray::new_from_chunks("", vec![Arc::new(arr)]))
     }
 }
@@ -258,6 +259,7 @@ where
     fn from_par_iter<I: IntoParallelIterator<Item = Option<T::Native>>>(iter: I) -> Self {
         // Get linkedlist filled with different vec result from different threads
         let vectors = collect_into_linked_list(iter);
+
         let capacity: usize = get_capacity_from_par_results(&vectors);
 
         let iter = TrustMyLength::new(vectors.into_iter().flatten(), capacity);

--- a/polars/polars-core/src/series/mod.rs
+++ b/polars/polars-core/src/series/mod.rs
@@ -1281,8 +1281,13 @@ impl std::convert::TryFrom<(&str, Vec<ArrayRef>)> for Series {
             ArrowDataType::LargeList(_) => {
                 Ok(ListChunked::new_from_chunks(name, chunks).into_series())
             }
+            ArrowDataType::Null => {
+                // we don't support null types yet so we use a small digit type filled with nulls
+                let len = chunks.iter().fold(0, |acc, array| acc + array.len());
+                Ok(Int8Chunked::full_null(name, len).into_series())
+            }
             dt => Err(PolarsError::InvalidOperation(
-                format!("Cannot create polars series from {:?}", dt).into(),
+                format!("Cannot create polars series from {:?} type", dt).into(),
             )),
         }
     }

--- a/polars/polars-lazy/src/physical_plan/executors.rs
+++ b/polars/polars-lazy/src/physical_plan/executors.rs
@@ -497,7 +497,9 @@ fn groupby_helper(
 
     let agg_columns = POOL.install(|| {
        aggs
-            .par_iter()
+           // benchmarked that using iter was 5% faster than par_iter on db-benchmark q4
+           // probably less congestion.
+            .iter()
             .map(|expr| {
                 let agg_expr = expr.as_agg_expr()?;
                 let opt_agg = agg_expr.evaluate(&df, groups)?;

--- a/py-polars/Cargo.toml
+++ b/py-polars/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "py-polars"
-version = "0.6.4"
+version = "0.6.5"
 authors = ["ritchie46 <ritchie46@gmail.com>"]
 edition = "2018"
 readme = "README.md"


### PR DESCRIPTION
When the groupby key is categorical welalready know the number of groups, so we can allocate the tuple containers to an estimated size.