### PR TITLE
fix: broadcast filter for utf8 and list datatypes

### DIFF
--- a/polars/polars-core/src/chunked_array/ops/filter.rs
+++ b/polars/polars-core/src/chunked_array/ops/filter.rs
@@ -79,7 +79,7 @@ impl ChunkFilter<Utf8Type> for Utf8Chunked {
         if filter.len() == 1 {
             return match filter.get(0) {
                 Some(true) => Ok(self.clone()),
-                _ => Ok(Utf8Chunked::new_from_chunks(self.name(), vec![])),
+                _ => self.slice(0, 0),
             };
         }
         check_filter_len!(self, filter);
@@ -111,7 +111,7 @@ impl ChunkFilter<ListType> for ListChunked {
         if filter.len() == 1 {
             return match filter.get(0) {
                 Some(true) => Ok(self.clone()),
-                _ => Ok(ListChunked::new_from_chunks(self.name(), vec![])),
+                _ => self.slice(0, 0),
             };
         }
         let (left, filter) = align_chunks_binary(self, filter);

--- a/polars/polars-core/src/frame/mod.rs
+++ b/polars/polars-core/src/frame/mod.rs
@@ -1529,6 +1529,32 @@ mod test {
     }
 
     #[test]
+    fn test_filter_broadcast_on_utf8_col() {
+        let col_name = "some_col";
+        let v = vec!["test".to_string()];
+        let s0 = Series::new(col_name, v);
+        let mut df = DataFrame::new(vec![s0]).unwrap();
+        println!("{}", df.column(col_name).unwrap());
+        println!("{:?}", df);
+
+        df = df.filter(&df.column(col_name).unwrap().eq("")).unwrap();
+        assert_eq!(df.column(col_name).unwrap().n_chunks(), 1);
+        println!("{:?}", df);
+    }
+
+    #[test]
+    fn test_filter_broadcast_on_list_col() {
+        let s1 = Series::new("", &[true, false, true]);
+        let ll: ListChunked = [&s1].iter().copied().collect();
+
+        let mask = BooleanChunked::new_from_slice("", &[false]);
+        let new = ll.filter(&mask).unwrap();
+
+        assert_eq!(new.chunks.len(), 1);
+        assert_eq!(new.len(), 0);
+    }
+
+    #[test]
     fn test_sort() {
         let mut df = create_frame();
         df.sort_in_place("temp", false).unwrap();

--- a/py-polars/pypolars/frame.py
+++ b/py-polars/pypolars/frame.py
@@ -246,7 +246,7 @@ class DataFrame:
             Cast dates to objects. If False, convert to datetime64[ns] dtype
         kwargs
             arguments will be sent to pyarrow.Table.to_pandas
-        
+
         Example
         ---
         ```python
@@ -256,7 +256,7 @@ class DataFrame:
             "bar": [6, 7, 8],
             "ham": ['a', 'b', 'c']
             })
-        
+
         >>> pandas_df = dataframe.to_pandas()
         >>> type(pandas_df)
         pandas.core.frame.DataFrame
@@ -334,7 +334,7 @@ class DataFrame:
             "bar": [6, 7, 8],
             "ham": ['a', 'b', 'c']
             })
-        
+
         >>> numpy_array = dataframe.to_numpy()
         >>> type(numpy_array)
         numpy.ndarray
@@ -691,7 +691,7 @@ class DataFrame:
             "bar": [6.0, 7.0, 8.0],
             "ham": ['a', 'b', 'c']
             })
-        
+
         >>> df2 = pl.DataFrame({
             "foo": [3, 2, 1],
             "bar": [8.0, 7.0, 6.0],
@@ -750,7 +750,7 @@ class DataFrame:
             "bar": [6, 7, 8, 9, 10],
             "ham": ['a', 'b', 'c', 'd','e']
             })
-        
+
         >>> dataframe.head(3)
         shape: (3, 3)
         ╭─────┬─────┬─────╮
@@ -785,7 +785,7 @@ class DataFrame:
             "bar": [6, 7, 8, 9, 10],
             "ham": ['a', 'b', 'c', 'd','e']
             })
-        
+
         >>> dataframe.tail(3)
         shape: (3, 3)
         ╭─────┬─────┬─────╮
@@ -897,12 +897,12 @@ class DataFrame:
             "bar": [6.0, 7.0, 8.0],
             "ham": ['a', 'b', 'c']
             })
-        
+
         >>> other_dataframe = pl.DataFrame({
             "apple": ['x', 'y', 'z'],
             "ham": ['a', 'b', 'd']
             })
-        
+
         >>> dataframe.join(other_dataframe, on='ham')
         shape: (2, 4)
         ╭─────┬─────┬─────┬───────╮
@@ -1007,7 +1007,7 @@ class DataFrame:
             "bar": [6.0, 7.0, 8.0],
             "ham": ['a', 'b', 'c']
             })
-        
+
         >>> dataframe.drop('ham')
         shape: (3, 2)
         ╭─────┬─────╮


### PR DESCRIPTION
@ritchie46 thank you for a great job in developing this awesome crate.

Here is a fix for a problem, when we try filter by broadcast or filter series with one element.
In the case of Utf8, filter will return chunked array with no chunks and any subsequent call to filter will be failed.
For other datatypes there is no problem, because it uses `new_from_slice` method instead of `new_from_chunks`.