### PR TITLE
Remove redundant tuple in group tuples

### DIFF
--- a/polars/polars-core/src/chunked_array/ops/unique.rs
+++ b/polars/polars-core/src/chunked_array/ops/unique.rs
@@ -1,5 +1,6 @@
 #[cfg(feature = "object")]
 use crate::chunked_array::object::ObjectType;
+use crate::frame::group_by::GroupTuples;
 use crate::prelude::*;
 use crate::utils::{floating_encode_f64, integer_decode_f64, NoNull};
 use crate::{chunked_array::float::IntegerDecode, frame::group_by::IntoGroupTuples};
@@ -12,7 +13,7 @@ use std::fmt::Display;
 use std::hash::Hash;
 
 pub(crate) fn is_unique_helper(
-    mut groups: Vec<(u32, Vec<u32>)>,
+    mut groups: GroupTuples,
     len: u32,
     unique_val: bool,
     duplicated_val: bool,

--- a/polars/polars-core/src/frame/mod.rs
+++ b/polars/polars-core/src/frame/mod.rs
@@ -1307,7 +1307,11 @@ impl DataFrame {
             None => self.get_column_names(),
         };
         let gb = self.groupby(names)?;
-        let groups = gb.get_groups().iter().map(|v| v.0);
+        let groups = gb.get_groups().iter().map(|v| {
+            // Safety:
+            // all groups have at least one member;
+            unsafe { *v.get_unchecked(0) }
+        });
 
         let df = if maintain_order {
             let mut groups = groups.collect::<Vec<_>>();

--- a/polars/polars-core/src/series/implementations.rs
+++ b/polars/polars-core/src/series/implementations.rs
@@ -82,51 +82,51 @@ macro_rules! impl_dyn_series {
                 self.0.vec_hash(random_state)
             }
 
-            fn agg_mean(&self, groups: &[(u32, Vec<u32>)]) -> Option<Series> {
+            fn agg_mean(&self, groups: &[Vec<u32>]) -> Option<Series> {
                 self.0.agg_mean(groups)
             }
 
-            fn agg_min(&self, groups: &[(u32, Vec<u32>)]) -> Option<Series> {
+            fn agg_min(&self, groups: &[Vec<u32>]) -> Option<Series> {
                 self.0.agg_min(groups)
             }
 
-            fn agg_max(&self, groups: &[(u32, Vec<u32>)]) -> Option<Series> {
+            fn agg_max(&self, groups: &[Vec<u32>]) -> Option<Series> {
                 self.0.agg_max(groups)
             }
 
-            fn agg_sum(&self, groups: &[(u32, Vec<u32>)]) -> Option<Series> {
+            fn agg_sum(&self, groups: &[Vec<u32>]) -> Option<Series> {
                 self.0.agg_sum(groups)
             }
 
-            fn agg_first(&self, groups: &[(u32, Vec<u32>)]) -> Series {
+            fn agg_first(&self, groups: &[Vec<u32>]) -> Series {
                 self.0.agg_first(groups)
             }
 
-            fn agg_last(&self, groups: &[(u32, Vec<u32>)]) -> Series {
+            fn agg_last(&self, groups: &[Vec<u32>]) -> Series {
                 self.0.agg_last(groups)
             }
 
-            fn agg_std(&self, groups: &[(u32, Vec<u32>)]) -> Option<Series> {
+            fn agg_std(&self, groups: &[Vec<u32>]) -> Option<Series> {
                 self.0.agg_std(groups)
             }
 
-            fn agg_var(&self, groups: &[(u32, Vec<u32>)]) -> Option<Series> {
+            fn agg_var(&self, groups: &[Vec<u32>]) -> Option<Series> {
                 self.0.agg_var(groups)
             }
 
-            fn agg_n_unique(&self, groups: &[(u32, Vec<u32>)]) -> Option<UInt32Chunked> {
+            fn agg_n_unique(&self, groups: &[Vec<u32>]) -> Option<UInt32Chunked> {
                 self.0.agg_n_unique(groups)
             }
 
-            fn agg_list(&self, groups: &[(u32, Vec<u32>)]) -> Option<Series> {
+            fn agg_list(&self, groups: &[Vec<u32>]) -> Option<Series> {
                 self.0.agg_list(groups)
             }
 
-            fn agg_quantile(&self, groups: &[(u32, Vec<u32>)], quantile: f64) -> Option<Series> {
+            fn agg_quantile(&self, groups: &[Vec<u32>], quantile: f64) -> Option<Series> {
                 self.0.agg_quantile(groups, quantile)
             }
 
-            fn agg_median(&self, groups: &[(u32, Vec<u32>)]) -> Option<Series> {
+            fn agg_median(&self, groups: &[Vec<u32>]) -> Option<Series> {
                 self.0.agg_median(groups)
             }
 
@@ -134,7 +134,7 @@ macro_rules! impl_dyn_series {
                 &self,
                 pivot_series: &'a (dyn SeriesTrait + 'a),
                 keys: Vec<Series>,
-                groups: &[(u32, Vec<u32>)],
+                groups: &[Vec<u32>],
                 agg_type: PivotAgg,
             ) -> Result<DataFrame> {
                 self.0.pivot(pivot_series, keys, groups, agg_type)
@@ -144,7 +144,7 @@ macro_rules! impl_dyn_series {
                 &self,
                 pivot_series: &'a (dyn SeriesTrait + 'a),
                 keys: Vec<Series>,
-                groups: &[(u32, Vec<u32>)],
+                groups: &[Vec<u32>],
             ) -> Result<DataFrame> {
                 self.0.pivot_count(pivot_series, keys, groups)
             }

--- a/polars/polars-core/src/series/implementations.rs
+++ b/polars/polars-core/src/series/implementations.rs
@@ -179,7 +179,7 @@ macro_rules! impl_dyn_series {
             fn remainder(&self, rhs: &Series) -> Result<Series> {
                 NumOpsDispatch::remainder(&self.0, rhs)
             }
-            fn group_tuples(&self, multithreaded: bool) -> Vec<(u32, Vec<u32>)> {
+            fn group_tuples(&self, multithreaded: bool) -> GroupTuples {
                 IntoGroupTuples::group_tuples(&self.0, multithreaded)
             }
         }

--- a/polars/polars-core/src/series/mod.rs
+++ b/polars/polars-core/src/series/mod.rs
@@ -26,7 +26,7 @@ pub trait IntoSeries {
 
 pub(crate) mod private {
     use super::*;
-    use crate::frame::group_by::PivotAgg;
+    use crate::frame::group_by::{GroupTuples, PivotAgg};
     use ahash::RandomState;
 
     pub trait PrivateSeries {
@@ -120,7 +120,7 @@ pub(crate) mod private {
         fn remainder(&self, _rhs: &Series) -> Result<Series> {
             unimplemented!()
         }
-        fn group_tuples(&self, _multithreaded: bool) -> Vec<(u32, Vec<u32>)> {
+        fn group_tuples(&self, _multithreaded: bool) -> GroupTuples {
             unimplemented!()
         }
     }

--- a/polars/polars-core/src/series/mod.rs
+++ b/polars/polars-core/src/series/mod.rs
@@ -33,47 +33,47 @@ pub(crate) mod private {
         fn vec_hash(&self, _random_state: RandomState) -> UInt64Chunked {
             unimplemented!()
         }
-        fn agg_mean(&self, _groups: &[(u32, Vec<u32>)]) -> Option<Series> {
+        fn agg_mean(&self, _groups: &[Vec<u32>]) -> Option<Series> {
             unimplemented!()
         }
-        fn agg_min(&self, _groups: &[(u32, Vec<u32>)]) -> Option<Series> {
+        fn agg_min(&self, _groups: &[Vec<u32>]) -> Option<Series> {
             unimplemented!()
         }
-        fn agg_max(&self, _groups: &[(u32, Vec<u32>)]) -> Option<Series> {
+        fn agg_max(&self, _groups: &[Vec<u32>]) -> Option<Series> {
             unimplemented!()
         }
-        fn agg_sum(&self, _groups: &[(u32, Vec<u32>)]) -> Option<Series> {
+        fn agg_sum(&self, _groups: &[Vec<u32>]) -> Option<Series> {
             unimplemented!()
         }
-        fn agg_std(&self, _groups: &[(u32, Vec<u32>)]) -> Option<Series> {
+        fn agg_std(&self, _groups: &[Vec<u32>]) -> Option<Series> {
             unimplemented!()
         }
-        fn agg_var(&self, _groups: &[(u32, Vec<u32>)]) -> Option<Series> {
+        fn agg_var(&self, _groups: &[Vec<u32>]) -> Option<Series> {
             unimplemented!()
         }
-        fn agg_first(&self, _groups: &[(u32, Vec<u32>)]) -> Series {
+        fn agg_first(&self, _groups: &[Vec<u32>]) -> Series {
             unimplemented!()
         }
-        fn agg_last(&self, _groups: &[(u32, Vec<u32>)]) -> Series {
+        fn agg_last(&self, _groups: &[Vec<u32>]) -> Series {
             unimplemented!()
         }
-        fn agg_n_unique(&self, _groups: &[(u32, Vec<u32>)]) -> Option<UInt32Chunked> {
+        fn agg_n_unique(&self, _groups: &[Vec<u32>]) -> Option<UInt32Chunked> {
             unimplemented!()
         }
-        fn agg_list(&self, _groups: &[(u32, Vec<u32>)]) -> Option<Series> {
+        fn agg_list(&self, _groups: &[Vec<u32>]) -> Option<Series> {
             unimplemented!()
         }
-        fn agg_quantile(&self, _groups: &[(u32, Vec<u32>)], _quantile: f64) -> Option<Series> {
+        fn agg_quantile(&self, _groups: &[Vec<u32>], _quantile: f64) -> Option<Series> {
             unimplemented!()
         }
-        fn agg_median(&self, _groups: &[(u32, Vec<u32>)]) -> Option<Series> {
+        fn agg_median(&self, _groups: &[Vec<u32>]) -> Option<Series> {
             unimplemented!()
         }
         fn pivot<'a>(
             &self,
             _pivot_series: &'a (dyn SeriesTrait + 'a),
             _keys: Vec<Series>,
-            _groups: &[(u32, Vec<u32>)],
+            _groups: &[Vec<u32>],
             _agg_type: PivotAgg,
         ) -> Result<DataFrame> {
             unimplemented!()
@@ -83,7 +83,7 @@ pub(crate) mod private {
             &self,
             _pivot_series: &'a (dyn SeriesTrait + 'a),
             _keys: Vec<Series>,
-            _groups: &[(u32, Vec<u32>)],
+            _groups: &[Vec<u32>],
         ) -> Result<DataFrame> {
             unimplemented!()
         }

--- a/polars/polars-io/src/csv.rs
+++ b/polars/polars-io/src/csv.rs
@@ -1,5 +1,9 @@
 //! # (De)serializing CSV files
 //!
+//! ## Maximal performance
+//! Currently [CsvReader::new](CsvReader::new) has an extra copy. If you want optimal performance in CSV parsing/
+//! reading, it is adviced to use [CsvReader::from_path](CsvReader::from_path).
+//!
 //! ## Write a DataFrame to a csv file.
 //!
 //! ## Example
@@ -50,6 +54,7 @@
 //! assert_eq!("sepal.length", df.get_columns()[0].name());
 //! # assert_eq!(1, df.column("sepal.length").unwrap().chunks().len());
 //! ```
+//!
 use crate::csv_core::csv::{build_csv_reader, SequentialReader};
 use crate::{SerReader, SerWriter};
 pub use arrow::csv::WriterBuilder;
@@ -147,7 +152,6 @@ pub enum CsvEncoding {
 /// use std::fs::File;
 ///
 /// fn example() -> Result<DataFrame> {
-///
 ///     CsvReader::from_path("iris_csv")?
 ///             .infer_schema(None)
 ///             .has_header(true)

--- a/polars/polars-lazy/src/physical_plan/mod.rs
+++ b/polars/polars-lazy/src/physical_plan/mod.rs
@@ -77,12 +77,12 @@ impl PhysicalIoExpr for dyn PhysicalExpr {
 }
 
 pub trait AggPhysicalExpr {
-    fn evaluate(&self, df: &DataFrame, groups: &[(u32, Vec<u32>)]) -> Result<Option<Series>>;
+    fn evaluate(&self, df: &DataFrame, groups: &[Vec<u32>]) -> Result<Option<Series>>;
 
     fn evaluate_partitioned(
         &self,
         df: &DataFrame,
-        groups: &[(u32, Vec<u32>)],
+        groups: &[Vec<u32>],
     ) -> Result<Option<Vec<Series>>> {
         // we return a vec, such that an implementor can return more information, such as a sum and count.
         self.evaluate(df, groups).map(|opt| opt.map(|s| vec![s]))
@@ -91,7 +91,7 @@ pub trait AggPhysicalExpr {
     fn evaluate_partitioned_final(
         &self,
         final_df: &DataFrame,
-        groups: &[(u32, Vec<u32>)],
+        groups: &[Vec<u32>],
     ) -> Result<Option<Series>> {
         self.evaluate(final_df, groups)
     }


### PR DESCRIPTION
Group tuples were `Vec<(u32, Vec<u32>)>`. They are now simplified to `Vec<Vec<u32>>`