### PR TITLE
Resizing utf8 buffer for very long utf8

### DIFF
--- a/polars/polars-io/src/csv.rs
+++ b/polars/polars-io/src/csv.rs
@@ -618,6 +618,35 @@ hello,","," ",world,"!""#;
     }
 
     #[test]
+    fn test_very_long_utf8() {
+        let csv = r#"column_1,column_2,column_3
+-86.64408227,"Lorem Ipsum is simply dummy text of the printing and typesetting 
+industry. Lorem Ipsum has been the industry's standard dummy text ever since th
+e 1500s, when an unknown printer took a galley of type and scrambled it to make 
+a type specimen book. It has survived not only five centuries, but also the leap 
+into electronic typesetting, remaining essentially unchanged. It was popularised 
+in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, 
+and more recently with desktop publishing software like Aldus PageMaker including 
+versions of Lorem Ipsum.",11"#;
+        let file = Cursor::new(csv);
+        let df = CsvReader::new(file).finish().unwrap();
+
+        assert!(df.column("column_2").unwrap().series_equal(&Series::new(
+            "column_2",
+            &[
+                r#"Lorem Ipsum is simply dummy text of the printing and typesetting 
+industry. Lorem Ipsum has been the industry's standard dummy text ever since th
+e 1500s, when an unknown printer took a galley of type and scrambled it to make 
+a type specimen book. It has survived not only five centuries, but also the leap 
+into electronic typesetting, remaining essentially unchanged. It was popularised 
+in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, 
+and more recently with desktop publishing software like Aldus PageMaker including 
+versions of Lorem Ipsum."#,
+            ]
+        )));
+    }
+
+    #[test]
     fn test_nulls_parser() {
         // test it does not fail on the leading comma.
         let csv = r#"id1,id2,id3,id4,id5,id6,v1,v2,v3


### PR DESCRIPTION
Previously the resizing of utf8 was done with the method `.reserve()`. This unfortunatly did not change the length of the buffer which truncated the parsed field.

In order to not get truncated field, we need to increase the length with `.resize()`.