### PR TITLE
fix: out of bound when splitting on join with empty df

### DIFF
--- a/polars/polars-core/src/chunked_array/kernels/take.rs
+++ b/polars/polars-core/src/chunked_array/kernels/take.rs
@@ -365,8 +365,11 @@ pub(crate) unsafe fn take_utf8(
     // The required size is yet unknown
     // Allocate 2.0 times the expected size.
     // where expected size is the length of bytes multiplied by the factor (take_len / current_len)
-    let mut values_capacity =
-        ((arr.value_data().len() as f32 * 2.0) as usize) / arr.len() * indices.len() as usize;
+    let mut values_capacity = if arr.len() > 0 {
+        ((arr.value_data().len() as f32 * 2.0) as usize) / arr.len() * indices.len() as usize
+    } else {
+        0
+    };
 
     // 16 bytes per string as default alloc
     let mut values_buf = AlignedVec::<u8>::with_capacity_aligned(values_capacity);

--- a/polars/polars-core/src/chunked_array/mod.rs
+++ b/polars/polars-core/src/chunked_array/mod.rs
@@ -319,7 +319,7 @@ impl<T> ChunkedArray<T> {
 
         for chunk in &self.chunks {
             let chunk_len = chunk.len();
-            if remaining_offset >= chunk_len {
+            if remaining_offset > 0 && remaining_offset >= chunk_len {
                 remaining_offset -= chunk_len;
                 continue;
             }

--- a/polars/polars-core/src/frame/hash_join.rs
+++ b/polars/polars-core/src/frame/hash_join.rs
@@ -1288,4 +1288,25 @@ mod test {
 
         assert_eq!(Vec::from(ca), correct_ham);
     }
+
+    #[test]
+    fn empty_df_join() {
+        let empty: Vec<String> = vec![];
+        let left = DataFrame::new(vec![
+            Series::new("key", &empty),
+            Series::new("lval", &empty),
+        ])
+        .unwrap();
+
+        let right = DataFrame::new(vec![
+            Series::new("key", &["foo"]),
+            Series::new("rval", &[4]),
+        ])
+        .unwrap();
+
+        let res = left.inner_join(&right, "key", "key");
+
+        assert!(res.is_ok());
+        assert_eq!(res.unwrap().height(), 0);
+    }
 }


### PR DESCRIPTION
There is a bug when you are trying to join with empty df.
`ChunkedArray.slice` doesn't work as expected on an empty dataframe and produces slice with no chunk.

After this fix join breaks on division by zero. I'm not completely sure that I fixed it properly, @ritchie46 check this out please in `polars/polars-core/src/chunked_array/kernels/take.rs`.