### PR TITLE
Fix and improve setting items

### DIFF
--- a/py-polars/pypolars/frame.py
+++ b/py-polars/pypolars/frame.py
@@ -508,7 +508,7 @@ class DataFrame:
             # now find the location to place series
             # df[idx]
             if isinstance(col_selection, int):
-                self.replace_at_idx(0, s)
+                self.replace_at_idx(col_selection, s)
             # df["foo"]
             elif isinstance(col_selection, str):
                 self.replace(col_selection, s)

--- a/py-polars/pypolars/series.py
+++ b/py-polars/pypolars/series.py
@@ -397,9 +397,13 @@ class Series:
             elif key.dtype == UInt32:
                 self._s = self.set_at_idx(key.cast_u64(), value)._s
         # TODO: implement for these types without casting to series
-        if isinstance(key, (np.ndarray, list, tuple)):
+        elif isinstance(key, (np.ndarray, list, tuple)):
             s = wrap_s(PySeries.new_u64("", np.array(key, np.uint64)))
             self.__setitem__(s, value)
+        elif isinstance(key, int):
+            self.__setitem__([key], value)
+        else:
+            raise ValueError(f'cannot use "{key}" for indexing')
 
     def drop_nulls(self) -> "Series":
         return wrap_s(self._s.drop_nulls())


### PR DESCRIPTION
when setting an item at `[row_idx, col_idx]`, it would actually replace the item at `[row_idx, 0]`. This PR fixes that.

Also allows to set an item in a `Series` with an `int` index, and raises an exception if an invalid indexing type is used instead of failing silently.