### PR TITLE
py-polars: build abi3 wheels

### DIFF
--- a/.github/workflows/create-py-release-test.yaml
+++ b/.github/workflows/create-py-release-test.yaml
@@ -40,7 +40,7 @@ jobs:
     strategy:
       matrix:
         os: ["macos-latest", "windows-latest"]
-        python-version: ["3.6", "3.7", "3.8"]
+        python-version: 3.6
     steps:
         - uses: actions/checkout@v2
         - name: Install latest Rust nightly

--- a/py-polars/Cargo.toml
+++ b/py-polars/Cargo.toml
@@ -14,7 +14,7 @@ homepage = "https://github.com/ritchie46/polars"
 [dependencies]
 polars = {path = "../polars", features = ["parquet", "simd", "lazy", "strings", "temporal", "random", "object", "ipc", "pretty_fmt", "mimalloc"]}
 polars-core = {path = "../polars/polars-core", default-features = false}
-pyo3 = {version = "0.13", features = ["extension-module"] }
+pyo3 = {version = "0.13", features = ["abi3-py36", "extension-module"] }
 libc = "0.2"
 thiserror = "1.0.20"
 numpy = "0.13.0"


### PR DESCRIPTION
abi3 wheels has the advantage of only one wheel needs to be built for each CPU architecture of OSes and it will generally work on new Python minor versions without efforts.

See https://pyo3.rs/v0.13.2/building_and_distribution.html#py_limited_apiabi3