### PR TITLE
Opt in dtypes

### DIFF
--- a/polars/Cargo.toml
+++ b/polars/Cargo.toml
@@ -39,9 +39,13 @@ performant = ["polars-core/performant"]
 plain_fmt = ["polars-core/plain_fmt"]
 pretty_fmt = ["polars-core/pretty_fmt"]
 
-## opt-in datatypes
+# opt-in datatypes
+dtype-full = ["dtype-time64-ns", "dtype-duration-ns", "dtype-duration-ms"]
+
 # Time64 Nanosecond
-dtype-tns = ["polars-core/dtype-tns"]
+dtype-time64-ns = ["polars-core/dtype-time64-ns"]
+dtype-duration-ns = ["polars-core/dtype-duration-ns"]
+dtype-duration-ms = ["polars-core/dtype-duration-ms"]
 
 [dependencies]
 polars-core = {version = "0.12.0", path = "./polars-core", features= ["docs"], default-features = false}

--- a/polars/Cargo.toml
+++ b/polars/Cargo.toml
@@ -39,6 +39,10 @@ performant = ["polars-core/performant"]
 plain_fmt = ["polars-core/plain_fmt"]
 pretty_fmt = ["polars-core/pretty_fmt"]
 
+## opt-in datatypes
+# Time64 Nanosecond
+dtype-tns = ["polars-core/dtype-tns"]
+
 [dependencies]
 polars-core = {version = "0.12.0", path = "./polars-core", features= ["docs"], default-features = false}
 polars-io = {version = "0.12.0", path = "./polars-io", default-features = false}

--- a/polars/Cargo.toml
+++ b/polars/Cargo.toml
@@ -40,13 +40,23 @@ plain_fmt = ["polars-core/plain_fmt"]
 pretty_fmt = ["polars-core/pretty_fmt"]
 
 # opt-in datatypes
-dtype-full = ["dtype-time64-ns", "dtype-duration-ns", "dtype-duration-ms"]
+dtype-full = [
+    "dtype-time64-ns",
+    "dtype-duration-ns",
+    "dtype-duration-ms",
+    "dtype-date32",
+    "dtype-date64",
+    "dtype-i8",
+    "dtype-i16",
+]
 
 dtype-time64-ns = ["polars-core/dtype-time64-ns"]
 dtype-duration-ns = ["polars-core/dtype-duration-ns"]
 dtype-duration-ms = ["polars-core/dtype-duration-ms"]
 dtype-date32 = ["polars-core/dtype-date32"]
-dtype-date64 = ["polars-core/dtype-date64"]
+dtype-date64 = ["polars-core/dtype-date64", "polars-lazy/dtype-date64"]
+dtype-i8 = ["polars-core/dtype-i8", "polars-lazy/dtype-i8"]
+dtype-i16 = ["polars-core/dtype-i16", "polars-lazy/dtype-i8"]
 
 [dependencies]
 polars-core = {version = "0.12.0", path = "./polars-core", features= ["docs"], default-features = false}

--- a/polars/Cargo.toml
+++ b/polars/Cargo.toml
@@ -42,10 +42,11 @@ pretty_fmt = ["polars-core/pretty_fmt"]
 # opt-in datatypes
 dtype-full = ["dtype-time64-ns", "dtype-duration-ns", "dtype-duration-ms"]
 
-# Time64 Nanosecond
 dtype-time64-ns = ["polars-core/dtype-time64-ns"]
 dtype-duration-ns = ["polars-core/dtype-duration-ns"]
 dtype-duration-ms = ["polars-core/dtype-duration-ms"]
+dtype-date32 = ["polars-core/dtype-date32"]
+dtype-date64 = ["polars-core/dtype-date64"]
 
 [dependencies]
 polars-core = {version = "0.12.0", path = "./polars-core", features= ["docs"], default-features = false}

--- a/polars/Cargo.toml
+++ b/polars/Cargo.toml
@@ -24,7 +24,8 @@ default = ["docs",
 ndarray = ["polars-core/ndarray"]
 parquet = ["polars-core/parquet", "polars-lazy/parquet", "polars-io/parquet"]
 lazy = ["polars-core/lazy"]
-parallel = ["polars-core/parallel"]
+# commented out until UB is fixed
+#parallel = ["polars-core/parallel"]
 # extra utilities for Utf8Chunked
 strings = ["polars-core/strings"]
 # support for ObjectChunked<T> (downcastable Series of any type)
@@ -56,7 +57,7 @@ dtype-duration-ms = ["polars-core/dtype-duration-ms"]
 dtype-date32 = ["polars-core/dtype-date32"]
 dtype-date64 = ["polars-core/dtype-date64", "polars-lazy/dtype-date64"]
 dtype-i8 = ["polars-core/dtype-i8", "polars-lazy/dtype-i8"]
-dtype-i16 = ["polars-core/dtype-i16", "polars-lazy/dtype-i8"]
+dtype-i16 = ["polars-core/dtype-i16", "polars-lazy/dtype-i16"]
 
 [dependencies]
 polars-core = {version = "0.12.0", path = "./polars-core", features= ["docs"], default-features = false}

--- a/polars/Makefile
+++ b/polars/Makefile
@@ -17,7 +17,7 @@ clippy:
 	-p polars-arrow
 
 test:
-	cargo t \
+	cargo t --all-features \
 	-p polars-lazy \
     -p polars-io \
     -p polars-core \

--- a/polars/polars-core/Cargo.toml
+++ b/polars/polars-core/Cargo.toml
@@ -25,7 +25,11 @@ object = ["serde_json"]
 # Cannot have mutually exclusive types. User should choose one of:
 pretty_fmt = ["comfy-table"]
 plain_fmt = ["prettytable-rs"]
-dtype-tns = []
+
+# opt-in datatypes
+dtype-time64-ns = []
+dtype-duration-ns = []
+dtype-duration-ms = []
 
 [dependencies]
 arrow = {version="4.0.0-SNAPSHOT", git = "https://github.com/apache/arrow", rev = "0f647261058892289b1722e5883f8610cc5dd3d9", default-features=false}

--- a/polars/polars-core/Cargo.toml
+++ b/polars/polars-core/Cargo.toml
@@ -30,6 +30,8 @@ plain_fmt = ["prettytable-rs"]
 dtype-time64-ns = []
 dtype-duration-ns = []
 dtype-duration-ms = []
+dtype-date32 = []
+dtype-date64 = []
 
 [dependencies]
 arrow = {version="4.0.0-SNAPSHOT", git = "https://github.com/apache/arrow", rev = "0f647261058892289b1722e5883f8610cc5dd3d9", default-features=false}

--- a/polars/polars-core/Cargo.toml
+++ b/polars/polars-core/Cargo.toml
@@ -16,7 +16,8 @@ temporal = ["chrono", "regex"]
 random = ["rand", "rand_distr"]
 default = ["docs", "temporal", "lazy", "parquet", "performant", "plain_fmt"]
 lazy = []
-parallel = []
+# commented out until UB is fixed
+#parallel = []
 performant = []
 # extra utilities for Utf8Chunked
 strings = ["regex"]

--- a/polars/polars-core/Cargo.toml
+++ b/polars/polars-core/Cargo.toml
@@ -25,6 +25,7 @@ object = ["serde_json"]
 # Cannot have mutually exclusive types. User should choose one of:
 pretty_fmt = ["comfy-table"]
 plain_fmt = ["prettytable-rs"]
+dtype-tns = []
 
 [dependencies]
 arrow = {version="4.0.0-SNAPSHOT", git = "https://github.com/apache/arrow", rev = "0f647261058892289b1722e5883f8610cc5dd3d9", default-features=false}

--- a/polars/polars-core/Cargo.toml
+++ b/polars/polars-core/Cargo.toml
@@ -32,6 +32,8 @@ dtype-duration-ns = []
 dtype-duration-ms = []
 dtype-date32 = []
 dtype-date64 = []
+dtype-i8 = []
+dtype-i16 = []
 
 [dependencies]
 arrow = {version="4.0.0-SNAPSHOT", git = "https://github.com/apache/arrow", rev = "0f647261058892289b1722e5883f8610cc5dd3d9", default-features=false}

--- a/polars/polars-core/src/chunked_array/object/mod.rs
+++ b/polars/polars-core/src/chunked_array/object/mod.rs
@@ -123,17 +123,3 @@ where
         arr.value(idx)
     }
 }
-
-#[cfg(test)]
-mod test {
-    use super::*;
-
-    #[test]
-    fn object_series() {
-        let s = ObjectChunked::new_from_opt_slice("foo", &[Some(1), None, Some(3)]);
-        assert_eq!(
-            Vec::from(s.is_null()),
-            &[Some(false), Some(true), Some(false)]
-        )
-    }
-}

--- a/polars/polars-core/src/chunked_array/ops/filter.rs
+++ b/polars/polars-core/src/chunked_array/ops/filter.rs
@@ -167,17 +167,3 @@ where
         Ok(builder.finish())
     }
 }
-
-#[cfg(test)]
-#[cfg(feature = "object")]
-mod test {
-    use super::*;
-
-    #[test]
-    fn object_filter() {
-        let ca = ObjectChunked::new_from_opt_slice("foo", &[Some(1), None, Some(3), None]);
-        let mask = BooleanChunked::new_from_slice("", &[true, false, false, true]);
-        let new = ca.filter(&mask).unwrap();
-        assert_eq!(Vec::from(new.is_null()), &[Some(false), Some(true)])
-    }
-}

--- a/polars/polars-core/src/series/implementations.rs
+++ b/polars/polars-core/src/series/implementations.rs
@@ -614,14 +614,16 @@ macro_rules! impl_dyn_series {
                     Float64 => ChunkCast::cast::<Float64Type>(&self.0).map(|ca| ca.into_series()),
                     Date32 => ChunkCast::cast::<Date32Type>(&self.0).map(|ca| ca.into_series()),
                     Date64 => ChunkCast::cast::<Date64Type>(&self.0).map(|ca| ca.into_series()),
-                    #[cfg(feature = "dtype-tns")]
+                    #[cfg(feature = "dtype-time64-ns")]
                     Time64(TimeUnit::Nanosecond) => {
                         ChunkCast::cast::<Time64NanosecondType>(&self.0).map(|ca| ca.into_series())
                     }
+                    #[cfg(feature = "dtype-duration-ns")]
                     Duration(TimeUnit::Nanosecond) => {
                         ChunkCast::cast::<DurationNanosecondType>(&self.0)
                             .map(|ca| ca.into_series())
                     }
+                    #[cfg(feature = "dtype-duration-ms")]
                     Duration(TimeUnit::Millisecond) => {
                         ChunkCast::cast::<DurationMillisecondType>(&self.0)
                             .map(|ca| ca.into_series())
@@ -921,11 +923,13 @@ impl_dyn_series!(Int8Chunked);
 impl_dyn_series!(Int16Chunked);
 impl_dyn_series!(Int32Chunked);
 impl_dyn_series!(Int64Chunked);
+#[cfg(feature = "dtype-duration-ns")]
 impl_dyn_series!(DurationNanosecondChunked);
+#[cfg(feature = "dtype-duration-ms")]
 impl_dyn_series!(DurationMillisecondChunked);
 impl_dyn_series!(Date32Chunked);
 impl_dyn_series!(Date64Chunked);
-#[cfg(feature = "dtype-tns")]
+#[cfg(feature = "dtype-time64-ns")]
 impl_dyn_series!(Time64NanosecondChunked);
 impl_dyn_series!(CategoricalChunked);
 

--- a/polars/polars-core/src/series/implementations.rs
+++ b/polars/polars-core/src/series/implementations.rs
@@ -606,9 +606,9 @@ macro_rules! impl_dyn_series {
                     UInt16 => ChunkCast::cast::<UInt16Type>(&self.0).map(|ca| ca.into_series()),
                     UInt32 => ChunkCast::cast::<UInt32Type>(&self.0).map(|ca| ca.into_series()),
                     UInt64 => ChunkCast::cast::<UInt64Type>(&self.0).map(|ca| ca.into_series()),
-            #[cfg(feature = "dtype-i8")]
+                    #[cfg(feature = "dtype-i8")]
                     Int8 => ChunkCast::cast::<Int8Type>(&self.0).map(|ca| ca.into_series()),
-            #[cfg(feature = "dtype-i16")]
+                    #[cfg(feature = "dtype-i16")]
                     Int16 => ChunkCast::cast::<Int16Type>(&self.0).map(|ca| ca.into_series()),
                     Int32 => ChunkCast::cast::<Int32Type>(&self.0).map(|ca| ca.into_series()),
                     Int64 => ChunkCast::cast::<Int64Type>(&self.0).map(|ca| ca.into_series()),

--- a/polars/polars-core/src/series/implementations.rs
+++ b/polars/polars-core/src/series/implementations.rs
@@ -606,7 +606,9 @@ macro_rules! impl_dyn_series {
                     UInt16 => ChunkCast::cast::<UInt16Type>(&self.0).map(|ca| ca.into_series()),
                     UInt32 => ChunkCast::cast::<UInt32Type>(&self.0).map(|ca| ca.into_series()),
                     UInt64 => ChunkCast::cast::<UInt64Type>(&self.0).map(|ca| ca.into_series()),
+            #[cfg(feature = "dtype-i8")]
                     Int8 => ChunkCast::cast::<Int8Type>(&self.0).map(|ca| ca.into_series()),
+            #[cfg(feature = "dtype-i16")]
                     Int16 => ChunkCast::cast::<Int16Type>(&self.0).map(|ca| ca.into_series()),
                     Int32 => ChunkCast::cast::<Int32Type>(&self.0).map(|ca| ca.into_series()),
                     Int64 => ChunkCast::cast::<Int64Type>(&self.0).map(|ca| ca.into_series()),
@@ -921,7 +923,9 @@ impl_dyn_series!(UInt8Chunked);
 impl_dyn_series!(UInt16Chunked);
 impl_dyn_series!(UInt32Chunked);
 impl_dyn_series!(UInt64Chunked);
+#[cfg(feature = "dtype-i8")]
 impl_dyn_series!(Int8Chunked);
+#[cfg(feature = "dtype-i16")]
 impl_dyn_series!(Int16Chunked);
 impl_dyn_series!(Int32Chunked);
 impl_dyn_series!(Int64Chunked);

--- a/polars/polars-core/src/series/implementations.rs
+++ b/polars/polars-core/src/series/implementations.rs
@@ -612,7 +612,9 @@ macro_rules! impl_dyn_series {
                     Int64 => ChunkCast::cast::<Int64Type>(&self.0).map(|ca| ca.into_series()),
                     Float32 => ChunkCast::cast::<Float32Type>(&self.0).map(|ca| ca.into_series()),
                     Float64 => ChunkCast::cast::<Float64Type>(&self.0).map(|ca| ca.into_series()),
+                    #[cfg(feature = "dtype-date32")]
                     Date32 => ChunkCast::cast::<Date32Type>(&self.0).map(|ca| ca.into_series()),
+                    #[cfg(feature = "dtype-date64")]
                     Date64 => ChunkCast::cast::<Date64Type>(&self.0).map(|ca| ca.into_series()),
                     #[cfg(feature = "dtype-time64-ns")]
                     Time64(TimeUnit::Nanosecond) => {
@@ -927,7 +929,9 @@ impl_dyn_series!(Int64Chunked);
 impl_dyn_series!(DurationNanosecondChunked);
 #[cfg(feature = "dtype-duration-ms")]
 impl_dyn_series!(DurationMillisecondChunked);
+#[cfg(feature = "dtype-date32")]
 impl_dyn_series!(Date32Chunked);
+#[cfg(feature = "dtype-date64")]
 impl_dyn_series!(Date64Chunked);
 #[cfg(feature = "dtype-time64-ns")]
 impl_dyn_series!(Time64NanosecondChunked);

--- a/polars/polars-core/src/series/implementations.rs
+++ b/polars/polars-core/src/series/implementations.rs
@@ -614,6 +614,7 @@ macro_rules! impl_dyn_series {
                     Float64 => ChunkCast::cast::<Float64Type>(&self.0).map(|ca| ca.into_series()),
                     Date32 => ChunkCast::cast::<Date32Type>(&self.0).map(|ca| ca.into_series()),
                     Date64 => ChunkCast::cast::<Date64Type>(&self.0).map(|ca| ca.into_series()),
+                    #[cfg(feature = "dtype-tns")]
                     Time64(TimeUnit::Nanosecond) => {
                         ChunkCast::cast::<Time64NanosecondType>(&self.0).map(|ca| ca.into_series())
                     }
@@ -924,6 +925,7 @@ impl_dyn_series!(DurationNanosecondChunked);
 impl_dyn_series!(DurationMillisecondChunked);
 impl_dyn_series!(Date32Chunked);
 impl_dyn_series!(Date64Chunked);
+#[cfg(feature = "dtype-tns")]
 impl_dyn_series!(Time64NanosecondChunked);
 impl_dyn_series!(CategoricalChunked);
 

--- a/polars/polars-core/src/series/iterator.rs
+++ b/polars/polars-core/src/series/iterator.rs
@@ -31,7 +31,9 @@ from_iterator!(u8, UInt8Type);
 from_iterator!(u16, UInt16Type);
 from_iterator!(u32, UInt32Type);
 from_iterator!(u64, UInt64Type);
+#[cfg(feature = "dtype-i8")]
 from_iterator!(i8, Int8Type);
+#[cfg(feature = "dtype-i16")]
 from_iterator!(i16, Int16Type);
 from_iterator!(i32, Int32Type);
 from_iterator!(i64, Int64Type);

--- a/polars/polars-core/src/series/mod.rs
+++ b/polars/polars-core/src/series/mod.rs
@@ -1279,13 +1279,15 @@ impl std::convert::TryFrom<(&str, Vec<ArrayRef>)> for Series {
             }
             ArrowDataType::Date32 => Ok(Date32Chunked::new_from_chunks(name, chunks).into_series()),
             ArrowDataType::Date64 => Ok(Date64Chunked::new_from_chunks(name, chunks).into_series()),
-            #[cfg(feature = "dtype-tns")]
+            #[cfg(feature = "dtype-time64-ns")]
             ArrowDataType::Time64(TimeUnit::Nanosecond) => {
                 Ok(Time64NanosecondChunked::new_from_chunks(name, chunks).into_series())
             }
+            #[cfg(feature = "dtype-duration-ns")]
             ArrowDataType::Duration(TimeUnit::Nanosecond) => {
                 Ok(DurationNanosecondChunked::new_from_chunks(name, chunks).into_series())
             }
+            #[cfg(feature = "dtype-duration-ms")]
             ArrowDataType::Duration(TimeUnit::Millisecond) => {
                 Ok(DurationMillisecondChunked::new_from_chunks(name, chunks).into_series())
             }

--- a/polars/polars-core/src/series/mod.rs
+++ b/polars/polars-core/src/series/mod.rs
@@ -1178,7 +1178,9 @@ impl_named_from!([u8], UInt8Type, new_from_slice);
 impl_named_from!([u16], UInt16Type, new_from_slice);
 impl_named_from!([u32], UInt32Type, new_from_slice);
 impl_named_from!([u64], UInt64Type, new_from_slice);
+#[cfg(feature = "dtype-i8")]
 impl_named_from!([i8], Int8Type, new_from_slice);
+#[cfg(feature = "dtype-i16")]
 impl_named_from!([i16], Int16Type, new_from_slice);
 impl_named_from!([i32], Int32Type, new_from_slice);
 impl_named_from!([i64], Int64Type, new_from_slice);
@@ -1190,7 +1192,9 @@ impl_named_from!([Option<u8>], UInt8Type, new_from_opt_slice);
 impl_named_from!([Option<u16>], UInt16Type, new_from_opt_slice);
 impl_named_from!([Option<u32>], UInt32Type, new_from_opt_slice);
 impl_named_from!([Option<u64>], UInt64Type, new_from_opt_slice);
+#[cfg(feature = "dtype-i8")]
 impl_named_from!([Option<i8>], Int8Type, new_from_opt_slice);
+#[cfg(feature = "dtype-i16")]
 impl_named_from!([Option<i16>], Int16Type, new_from_opt_slice);
 impl_named_from!([Option<i32>], Int32Type, new_from_opt_slice);
 impl_named_from!([Option<i64>], Int64Type, new_from_opt_slice);
@@ -1267,7 +1271,9 @@ impl std::convert::TryFrom<(&str, Vec<ArrayRef>)> for Series {
             ArrowDataType::UInt16 => Ok(UInt16Chunked::new_from_chunks(name, chunks).into_series()),
             ArrowDataType::UInt32 => Ok(UInt32Chunked::new_from_chunks(name, chunks).into_series()),
             ArrowDataType::UInt64 => Ok(UInt64Chunked::new_from_chunks(name, chunks).into_series()),
+            #[cfg(feature = "dtype-i8")]
             ArrowDataType::Int8 => Ok(Int8Chunked::new_from_chunks(name, chunks).into_series()),
+            #[cfg(feature = "dtype-i16")]
             ArrowDataType::Int16 => Ok(Int16Chunked::new_from_chunks(name, chunks).into_series()),
             ArrowDataType::Int32 => Ok(Int32Chunked::new_from_chunks(name, chunks).into_series()),
             ArrowDataType::Int64 => Ok(Int64Chunked::new_from_chunks(name, chunks).into_series()),
@@ -1299,7 +1305,10 @@ impl std::convert::TryFrom<(&str, Vec<ArrayRef>)> for Series {
             ArrowDataType::Null => {
                 // we don't support null types yet so we use a small digit type filled with nulls
                 let len = chunks.iter().fold(0, |acc, array| acc + array.len());
-                Ok(Int8Chunked::full_null(name, len).into_series())
+                #[cfg(feature = "dtype-i8")]
+                return Ok(Int8Chunked::full_null(name, len).into_series());
+                #[cfg(not(feature = "dtype-i8"))]
+                Ok(Int32Chunked::full_null(name, len).into_series())
             }
             dt => Err(PolarsError::InvalidOperation(
                 format!("Cannot create polars series from {:?} type", dt).into(),

--- a/polars/polars-core/src/series/mod.rs
+++ b/polars/polars-core/src/series/mod.rs
@@ -1279,6 +1279,7 @@ impl std::convert::TryFrom<(&str, Vec<ArrayRef>)> for Series {
             }
             ArrowDataType::Date32 => Ok(Date32Chunked::new_from_chunks(name, chunks).into_series()),
             ArrowDataType::Date64 => Ok(Date64Chunked::new_from_chunks(name, chunks).into_series()),
+            #[cfg(feature = "dtype-tns")]
             ArrowDataType::Time64(TimeUnit::Nanosecond) => {
                 Ok(Time64NanosecondChunked::new_from_chunks(name, chunks).into_series())
             }

--- a/polars/polars-core/src/series/mod.rs
+++ b/polars/polars-core/src/series/mod.rs
@@ -1277,7 +1277,9 @@ impl std::convert::TryFrom<(&str, Vec<ArrayRef>)> for Series {
             ArrowDataType::Float64 => {
                 Ok(Float64Chunked::new_from_chunks(name, chunks).into_series())
             }
+            #[cfg(feature = "dtype-date32")]
             ArrowDataType::Date32 => Ok(Date32Chunked::new_from_chunks(name, chunks).into_series()),
+            #[cfg(feature = "dtype-date64")]
             ArrowDataType::Date64 => Ok(Date64Chunked::new_from_chunks(name, chunks).into_series()),
             #[cfg(feature = "dtype-time64-ns")]
             ArrowDataType::Time64(TimeUnit::Nanosecond) => {

--- a/polars/polars-core/src/utils.rs
+++ b/polars/polars-core/src/utils.rs
@@ -263,7 +263,9 @@ macro_rules! match_arrow_data_type_apply_macro {
             DataType::UInt16 => $macro!(UInt16Type $(, $opt_args)*),
             DataType::UInt32 => $macro!(UInt32Type $(, $opt_args)*),
             DataType::UInt64 => $macro!(UInt64Type $(, $opt_args)*),
+            #[cfg(feature = "dtype-i8")]
             DataType::Int8 => $macro!(Int8Type $(, $opt_args)*),
+            #[cfg(feature = "dtype-i16")]
             DataType::Int16 => $macro!(Int16Type $(, $opt_args)*),
             DataType::Int32 => $macro!(Int32Type $(, $opt_args)*),
             DataType::Int64 => $macro!(Int64Type $(, $opt_args)*),
@@ -294,7 +296,9 @@ macro_rules! apply_method_all_arrow_series {
             DataType::UInt16 => $self.u16().unwrap().$method($($args),*),
             DataType::UInt32 => $self.u32().unwrap().$method($($args),*),
             DataType::UInt64 => $self.u64().unwrap().$method($($args),*),
+            #[cfg(feature = "dtype-i8")]
             DataType::Int8 => $self.i8().unwrap().$method($($args),*),
+            #[cfg(feature = "dtype-i16")]
             DataType::Int16 => $self.i16().unwrap().$method($($args),*),
             DataType::Int32 => $self.i32().unwrap().$method($($args),*),
             DataType::Int64 => $self.i64().unwrap().$method($($args),*),
@@ -326,7 +330,9 @@ macro_rules! apply_method_numeric_series {
             DataType::UInt16 => $self.u16().unwrap().$method($($args),*),
             DataType::UInt32 => $self.u32().unwrap().$method($($args),*),
             DataType::UInt64 => $self.u64().unwrap().$method($($args),*),
+            #[cfg(feature = "dtype-i8")]
             DataType::Int8 => $self.i8().unwrap().$method($($args),*),
+            #[cfg(feature = "dtype-i16")]
             DataType::Int16 => $self.i16().unwrap().$method($($args),*),
             DataType::Int32 => $self.i32().unwrap().$method($($args),*),
             DataType::Int64 => $self.i64().unwrap().$method($($args),*),

--- a/polars/polars-core/src/utils.rs
+++ b/polars/polars-core/src/utils.rs
@@ -269,7 +269,9 @@ macro_rules! match_arrow_data_type_apply_macro {
             DataType::Int64 => $macro!(Int64Type $(, $opt_args)*),
             DataType::Float32 => $macro!(Float32Type $(, $opt_args)*),
             DataType::Float64 => $macro!(Float64Type $(, $opt_args)*),
+            #[cfg(feature = "dtype-date32")]
             DataType::Date32 => $macro!(Date32Type $(, $opt_args)*),
+            #[cfg(feature = "dtype-date64")]
             DataType::Date64 => $macro!(Date64Type $(, $opt_args)*),
             #[cfg(feature = "dtype-time64-ns")]
             DataType::Time64(TimeUnit::Nanosecond) => $macro!(Time64NanosecondType $(, $opt_args)*),
@@ -298,7 +300,9 @@ macro_rules! apply_method_all_arrow_series {
             DataType::Int64 => $self.i64().unwrap().$method($($args),*),
             DataType::Float32 => $self.f32().unwrap().$method($($args),*),
             DataType::Float64 => $self.f64().unwrap().$method($($args),*),
+            #[cfg(feature = "dtype-date32")]
             DataType::Date32 => $self.date32().unwrap().$method($($args),*),
+            #[cfg(feature = "dtype-date64")]
             DataType::Date64 => $self.date64().unwrap().$method($($args),*),
             #[cfg(feature = "dtype-time64-ns")]
             DataType::Time64(TimeUnit::Nanosecond) => $self.time64_nanosecond().unwrap().$method($($args),*),
@@ -328,7 +332,9 @@ macro_rules! apply_method_numeric_series {
             DataType::Int64 => $self.i64().unwrap().$method($($args),*),
             DataType::Float32 => $self.f32().unwrap().$method($($args),*),
             DataType::Float64 => $self.f64().unwrap().$method($($args),*),
+            #[cfg(feature = "dtype-date32")]
             DataType::Date32 => $self.date32().unwrap().$method($($args),*),
+            #[cfg(feature = "dtype-date64")]
             DataType::Date64 => $self.date64().unwrap().$method($($args),*),
             #[cfg(feature = "dtype-time64-ns")]
             DataType::Time64(TimeUnit::Nanosecond) => $self.time64_nanosecond().unwrap().$method($($args),*),

--- a/polars/polars-core/src/utils.rs
+++ b/polars/polars-core/src/utils.rs
@@ -271,9 +271,11 @@ macro_rules! match_arrow_data_type_apply_macro {
             DataType::Float64 => $macro!(Float64Type $(, $opt_args)*),
             DataType::Date32 => $macro!(Date32Type $(, $opt_args)*),
             DataType::Date64 => $macro!(Date64Type $(, $opt_args)*),
-            #[cfg(feature = "dtype-tns")]
+            #[cfg(feature = "dtype-time64-ns")]
             DataType::Time64(TimeUnit::Nanosecond) => $macro!(Time64NanosecondType $(, $opt_args)*),
+            #[cfg(feature = "dtype-duration-ns")]
             DataType::Duration(TimeUnit::Nanosecond) => $macro!(DurationNanosecondType $(, $opt_args)*),
+            #[cfg(feature = "dtype-duration-ms")]
             DataType::Duration(TimeUnit::Millisecond) => $macro!(DurationMillisecondType $(, $opt_args)*),
             _ => unimplemented!(),
         }
@@ -298,9 +300,11 @@ macro_rules! apply_method_all_arrow_series {
             DataType::Float64 => $self.f64().unwrap().$method($($args),*),
             DataType::Date32 => $self.date32().unwrap().$method($($args),*),
             DataType::Date64 => $self.date64().unwrap().$method($($args),*),
-            #[cfg(feature = "dtype-tns")]
+            #[cfg(feature = "dtype-time64-ns")]
             DataType::Time64(TimeUnit::Nanosecond) => $self.time64_nanosecond().unwrap().$method($($args),*),
+            #[cfg(feature = "dtype-duration-ns")]
             DataType::Duration(TimeUnit::Nanosecond) => $self.duration_nanosecond().unwrap().$method($($args),*),
+            #[cfg(feature = "dtype-duration-ms")]
             DataType::Duration(TimeUnit::Millisecond) => $self.duration_millisecond().unwrap().$method($($args),*),
             DataType::List(_) => $self.list().unwrap().$method($($args),*),
             _ => unimplemented!()
@@ -326,9 +330,11 @@ macro_rules! apply_method_numeric_series {
             DataType::Float64 => $self.f64().unwrap().$method($($args),*),
             DataType::Date32 => $self.date32().unwrap().$method($($args),*),
             DataType::Date64 => $self.date64().unwrap().$method($($args),*),
-            #[cfg(feature = "dtype-tns")]
+            #[cfg(feature = "dtype-time64-ns")]
             DataType::Time64(TimeUnit::Nanosecond) => $self.time64_nanosecond().unwrap().$method($($args),*),
+            #[cfg(feature = "dtype-duration-ns")]
             DataType::Duration(TimeUnit::Nanosecond) => $self.duration_nanosecond().unwrap().$method($($args),*),
+            #[cfg(feature = "dtype-duration-ms")]
             DataType::Duration(TimeUnit::Millisecond) => $self.duration_millisecond().unwrap().$method($($args),*),
 
             _ => unimplemented!(),

--- a/polars/polars-core/src/utils.rs
+++ b/polars/polars-core/src/utils.rs
@@ -271,6 +271,7 @@ macro_rules! match_arrow_data_type_apply_macro {
             DataType::Float64 => $macro!(Float64Type $(, $opt_args)*),
             DataType::Date32 => $macro!(Date32Type $(, $opt_args)*),
             DataType::Date64 => $macro!(Date64Type $(, $opt_args)*),
+            #[cfg(feature = "dtype-tns")]
             DataType::Time64(TimeUnit::Nanosecond) => $macro!(Time64NanosecondType $(, $opt_args)*),
             DataType::Duration(TimeUnit::Nanosecond) => $macro!(DurationNanosecondType $(, $opt_args)*),
             DataType::Duration(TimeUnit::Millisecond) => $macro!(DurationMillisecondType $(, $opt_args)*),
@@ -297,6 +298,7 @@ macro_rules! apply_method_all_arrow_series {
             DataType::Float64 => $self.f64().unwrap().$method($($args),*),
             DataType::Date32 => $self.date32().unwrap().$method($($args),*),
             DataType::Date64 => $self.date64().unwrap().$method($($args),*),
+            #[cfg(feature = "dtype-tns")]
             DataType::Time64(TimeUnit::Nanosecond) => $self.time64_nanosecond().unwrap().$method($($args),*),
             DataType::Duration(TimeUnit::Nanosecond) => $self.duration_nanosecond().unwrap().$method($($args),*),
             DataType::Duration(TimeUnit::Millisecond) => $self.duration_millisecond().unwrap().$method($($args),*),
@@ -324,6 +326,7 @@ macro_rules! apply_method_numeric_series {
             DataType::Float64 => $self.f64().unwrap().$method($($args),*),
             DataType::Date32 => $self.date32().unwrap().$method($($args),*),
             DataType::Date64 => $self.date64().unwrap().$method($($args),*),
+            #[cfg(feature = "dtype-tns")]
             DataType::Time64(TimeUnit::Nanosecond) => $self.time64_nanosecond().unwrap().$method($($args),*),
             DataType::Duration(TimeUnit::Nanosecond) => $self.duration_nanosecond().unwrap().$method($($args),*),
             DataType::Duration(TimeUnit::Millisecond) => $self.duration_millisecond().unwrap().$method($($args),*),

--- a/polars/polars-io/src/csv_core/chunked_parser.rs
+++ b/polars/polars-io/src/csv_core/chunked_parser.rs
@@ -22,10 +22,8 @@ fn field_to_builder(i: usize, capacity: usize, schema: &SchemaRef) -> Result<Bui
 
     let builder = match field.data_type() {
         &DataType::Boolean => Builder::Boolean(BooleanChunkedBuilder::new(name, capacity)),
-        &DataType::Int16 => Builder::Int16(PrimitiveChunkedBuilder::new(name, capacity)),
         &DataType::Int32 => Builder::Int32(PrimitiveChunkedBuilder::new(name, capacity)),
         &DataType::Int64 => Builder::Int64(PrimitiveChunkedBuilder::new(name, capacity)),
-        &DataType::UInt16 => Builder::UInt16(PrimitiveChunkedBuilder::new(name, capacity)),
         &DataType::UInt32 => Builder::UInt32(PrimitiveChunkedBuilder::new(name, capacity)),
         &DataType::UInt64 => Builder::UInt64(PrimitiveChunkedBuilder::new(name, capacity)),
         &DataType::Float32 => Builder::Float32(PrimitiveChunkedBuilder::new(name, capacity)),
@@ -58,12 +56,8 @@ pub(crate) fn add_to_builders_core(
         let field = schema.field(*i).unwrap();
         match field.data_type() {
             DataType::Boolean => add_to_bool_core(rows, *i, builder.bool(), ignore_parser_error),
-            DataType::Int8 => add_to_primitive_core(rows, *i, builder.i32(), ignore_parser_error),
-            DataType::Int16 => add_to_primitive_core(rows, *i, builder.i32(), ignore_parser_error),
             DataType::Int32 => add_to_primitive_core(rows, *i, builder.i32(), ignore_parser_error),
             DataType::Int64 => add_to_primitive_core(rows, *i, builder.i64(), ignore_parser_error),
-            DataType::UInt8 => add_to_primitive_core(rows, *i, builder.u32(), ignore_parser_error),
-            DataType::UInt16 => add_to_primitive_core(rows, *i, builder.u32(), ignore_parser_error),
             DataType::UInt32 => add_to_primitive_core(rows, *i, builder.u32(), ignore_parser_error),
             DataType::UInt64 => add_to_primitive_core(rows, *i, builder.u64(), ignore_parser_error),
             DataType::Float32 => {
@@ -310,12 +304,10 @@ pub(crate) fn finish_builder(
 
 pub(crate) enum Builder {
     Boolean(BooleanChunkedBuilder),
-    Int16(PrimitiveChunkedBuilder<Int16Type>),
     Int32(PrimitiveChunkedBuilder<Int32Type>),
     Int64(PrimitiveChunkedBuilder<Int64Type>),
     UInt64(PrimitiveChunkedBuilder<UInt64Type>),
     UInt32(PrimitiveChunkedBuilder<UInt32Type>),
-    UInt16(PrimitiveChunkedBuilder<UInt16Type>),
     Float32(PrimitiveChunkedBuilder<Float32Type>),
     Float64(PrimitiveChunkedBuilder<Float64Type>),
     Utf8(Utf8ChunkedBuilder),
@@ -375,10 +367,8 @@ impl Builder {
         use Builder::*;
         match self {
             Utf8(b) => b.finish().into_series(),
-            Int16(b) => b.finish().into_series(),
             Int32(b) => b.finish().into_series(),
             Int64(b) => b.finish().into_series(),
-            UInt16(b) => b.finish().into_series(),
             UInt32(b) => b.finish().into_series(),
             UInt64(b) => b.finish().into_series(),
             Float32(b) => b.finish().into_series(),

--- a/polars/polars-lazy/Cargo.toml
+++ b/polars/polars-lazy/Cargo.toml
@@ -15,6 +15,9 @@ temporal = ["polars-core/temporal"]
 # debugging purposesses
 fmt = ["polars-core/plain_fmt"]
 future = []
+dtype-i8 = []
+dtype-i16 = []
+dtype-date64 = []
 
 [dependencies]
 ahash = "0.7"

--- a/polars/polars-lazy/src/dsl.rs
+++ b/polars/polars-lazy/src/dsl.rs
@@ -1130,7 +1130,9 @@ macro_rules! make_literal {
 make_literal!(bool, Boolean);
 make_literal!(f32, Float32);
 make_literal!(f64, Float64);
+#[cfg(feature = "dtype-i8")]
 make_literal!(i8, Int8);
+#[cfg(feature = "dtype-i16")]
 make_literal!(i16, Int16);
 make_literal!(i32, Int32);
 make_literal!(i64, Int64);
@@ -1139,14 +1141,14 @@ make_literal!(u16, UInt16);
 make_literal!(u32, UInt32);
 make_literal!(u64, UInt64);
 
-#[cfg(feature = "temporal")]
+#[cfg(all(feature = "temporal", feature = "dtype-date64"))]
 impl Literal for NaiveDateTime {
     fn lit(self) -> Expr {
         Expr::Literal(LiteralValue::DateTime(self))
     }
 }
 
-#[cfg(feature = "temporal")]
+#[cfg(all(feature = "temporal", feature = "dtype-date64"))]
 impl Literal for NaiveDate {
     fn lit(self) -> Expr {
         Expr::Literal(LiteralValue::DateTime(self.and_hms(0, 0, 0)))

--- a/polars/polars-lazy/src/logical_plan/mod.rs
+++ b/polars/polars-lazy/src/logical_plan/mod.rs
@@ -68,8 +68,10 @@ pub enum LiteralValue {
     /// An unsigned 64-bit integer number.
     UInt64(u64),
     /// An 8-bit integer number.
+    #[cfg(feature = "dtype-i8")]
     Int8(i8),
     /// A 16-bit integer number.
+    #[cfg(feature = "dtype-i16")]
     Int16(i16),
     /// A 32-bit integer number.
     Int32(i32),
@@ -84,7 +86,7 @@ pub enum LiteralValue {
         high: i64,
         data_type: DataType,
     },
-    #[cfg(feature = "temporal")]
+    #[cfg(all(feature = "temporal", feature = "dtype-date64"))]
     DateTime(NaiveDateTime),
 }
 
@@ -97,7 +99,9 @@ impl LiteralValue {
             LiteralValue::UInt16(_) => DataType::UInt16,
             LiteralValue::UInt32(_) => DataType::UInt32,
             LiteralValue::UInt64(_) => DataType::UInt64,
+            #[cfg(feature = "dtype-i8")]
             LiteralValue::Int8(_) => DataType::Int8,
+            #[cfg(feature = "dtype-i16")]
             LiteralValue::Int16(_) => DataType::Int16,
             LiteralValue::Int32(_) => DataType::Int32,
             LiteralValue::Int64(_) => DataType::Int64,
@@ -105,7 +109,7 @@ impl LiteralValue {
             LiteralValue::Float64(_) => DataType::Float64,
             LiteralValue::Utf8(_) => DataType::Utf8,
             LiteralValue::Range { data_type, .. } => data_type.clone(),
-            #[cfg(feature = "temporal")]
+            #[cfg(all(feature = "temporal", feature = "dtype-date64"))]
             LiteralValue::DateTime(_) => DataType::Date64,
             _ => panic!("Cannot treat {:?} as scalar value", self),
         }

--- a/polars/polars-lazy/src/logical_plan/optimizer/simplify_expr.rs
+++ b/polars/polars-lazy/src/logical_plan/optimizer/simplify_expr.rs
@@ -12,9 +12,11 @@ macro_rules! eval_binary_same_type {
             (LiteralValue::Float64(x), LiteralValue::Float64(y)) => {
                 Some(AExpr::Literal(LiteralValue::Float64(x $operand y)))
             }
+            #[cfg(feature = "dtype-i8")]
             (LiteralValue::Int8(x), LiteralValue::Int8(y)) => {
                 Some(AExpr::Literal(LiteralValue::Int8(x $operand y)))
             }
+            #[cfg(feature = "dtype-i16")]
             (LiteralValue::Int16(x), LiteralValue::Int16(y)) => {
                 Some(AExpr::Literal(LiteralValue::Int16(x $operand y)))
             }
@@ -54,9 +56,11 @@ macro_rules! eval_binary_bool_type {
             (LiteralValue::Float64(x), LiteralValue::Float64(y)) => {
                 Some(AExpr::Literal(LiteralValue::Boolean(x $operand y)))
             }
+            #[cfg(feature = "dtype-i8")]
             (LiteralValue::Int8(x), LiteralValue::Int8(y)) => {
                 Some(AExpr::Literal(LiteralValue::Boolean(x $operand y)))
             }
+            #[cfg(feature = "dtype-i16")]
             (LiteralValue::Int16(x), LiteralValue::Int16(y)) => {
                 Some(AExpr::Literal(LiteralValue::Boolean(x $operand y)))
             }

--- a/polars/polars-lazy/src/physical_plan/expressions.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions.rs
@@ -23,7 +23,9 @@ impl PhysicalExpr for LiteralExpr {
     fn evaluate(&self, _df: &DataFrame) -> Result<Series> {
         use LiteralValue::*;
         let s = match &self.0 {
+            #[cfg(feature = "dtype-i8")]
             Int8(v) => Int8Chunked::full("literal", *v, 1).into_series(),
+            #[cfg(feature = "dtype-i16")]
             Int16(v) => Int16Chunked::full("literal", *v, 1).into_series(),
             Int32(v) => Int32Chunked::full("literal", *v, 1).into_series(),
             Int64(v) => Int64Chunked::full("literal", *v, 1).into_series(),
@@ -70,7 +72,7 @@ impl PhysicalExpr for LiteralExpr {
                 }
             },
             Utf8(v) => Utf8Chunked::full("literal", v, 1).into_series(),
-            #[cfg(feature = "temporal")]
+            #[cfg(all(feature = "temporal", feature = "dtype-date64"))]
             DateTime(ndt) => {
                 use polars_core::chunked_array::temporal::conversion::*;
                 let timestamp = naive_datetime_to_date64(ndt);
@@ -84,7 +86,9 @@ impl PhysicalExpr for LiteralExpr {
         use LiteralValue::*;
         let name = "literal";
         let field = match &self.0 {
+            #[cfg(feature = "dtype-i8")]
             Int8(_) => Field::new(name, DataType::Int8),
+            #[cfg(feature = "dtype-i16")]
             Int16(_) => Field::new(name, DataType::Int16),
             Int32(_) => Field::new(name, DataType::Int32),
             Int64(_) => Field::new(name, DataType::Int64),
@@ -98,7 +102,7 @@ impl PhysicalExpr for LiteralExpr {
             Utf8(_) => Field::new(name, DataType::Utf8),
             Null => Field::new(name, DataType::Null),
             Range { data_type, .. } => Field::new(name, data_type.clone()),
-            #[cfg(feature = "temporal")]
+            #[cfg(all(feature = "temporal", feature = "dtype-date64"))]
             DateTime(_) => Field::new(name, DataType::Date64),
         };
         Ok(field)

--- a/polars/src/lib.rs
+++ b/polars/src/lib.rs
@@ -16,7 +16,35 @@
 //! * [ChunkedArray struct](crate::chunked_array::ChunkedArray)
 //!
 //! ### Lazy
+//! Unlock full potential with lazy computation. This allows query optimizations and provides Polars
+//! the full query context so that the fastest algorithm can be chosen.
 //! Read more in the [lazy](polars_lazy) module
+//!
+//! ## Compile times
+//! Polars [DataFrames](crate::frame::DataFrame) hold [Series](crate::series::Series). These `Series`
+//! are wrappers around [ChunkedArray<T>](crate::chunked_array::ChunkedArray) without the generic
+//! parameter `T`. To get rid of the generic parameter, all the possible value of `T` are compiled
+//! for `Series`. This gets more expensive the more types you want for a `Series`. In order to reduce
+//! the compile times, we have decided to default to a minimal set of types and make more `Series` types
+//! opt-in.
+//!
+//! Note that if you get strange compile time errors, you probably need to opt-in for that `Series` dtype.
+//! The opt-in dtypes are:
+//!
+//!     | data type               | feature flag      |
+//!     |-------------------------|-------------------|
+//!     | Time64NanoSecondType    | dtype-time64-ns   |
+//!     | DurationNanosecondType  | dtype-duration-ns |
+//!     | DurationMillisecondType | dtype-duration-ms |
+//!     | Date32Type              | dtype-date32      |
+//!     | Date64Type              | dtype-date64      |
+//!     | Int8Type                | dtype-i8          |
+//!     | Int16Type               | dtype-i16         |
+//!
+//!
+//! Or you can choose on of the preconfigured pre-sets.
+//!
+//! * `dtype-full` - all opt-in dtypes.
 //!
 //! ## Read and write CSV/ JSON
 //!

--- a/py-polars/Cargo.toml
+++ b/py-polars/Cargo.toml
@@ -12,7 +12,7 @@ homepage = "https://github.com/ritchie46/polars"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-polars = {path = "../polars", features = ["parquet", "simd", "lazy", "strings", "temporal", "random", "object", "ipc", "pretty_fmt", "mimalloc", "performant"]}
+polars = {path = "../polars", features = ["parquet", "simd", "lazy", "strings", "temporal", "random", "object", "ipc", "pretty_fmt", "mimalloc", "performant", "dtype-full"]}
 polars-core = {path = "../polars/polars-core", default-features = false}
 pyo3 = {version = "0.13", features = ["abi3-py36", "extension-module"] }
 libc = "0.2"


### PR DESCRIPTION
This will greatly reduce compile times by making the `Series` supported types opt-in. Will add more types to this PR.