### PR TITLE
fix: empty csv to dataframe

### DIFF
--- a/polars/polars-io/src/csv.rs
+++ b/polars/polars-io/src/csv.rs
@@ -674,4 +674,24 @@ id090,id048,id0000067778,24,2,51862,4,9,"#;
         let file = Cursor::new(s);
         let _df = CsvReader::new(file).has_header(true).finish().unwrap();
     }
+
+    #[test]
+    fn test_empty_bytes_to_dataframe() {
+        let fields = vec![Field::new("test_field", DataType::Utf8)];
+        let schema = Schema::new(fields);
+        let file = Cursor::new(vec![]);
+
+        let result = CsvReader::new(file)
+            .has_header(false)
+            .with_columns(Some(
+                schema
+                    .fields()
+                    .into_iter()
+                    .map(|s| s.name().to_string())
+                    .collect(),
+            ))
+            .with_schema(Arc::new(schema))
+            .finish();
+        assert!(result.is_ok())
+    }
 }

--- a/polars/polars-io/src/csv_core/csv.rs
+++ b/polars/polars-io/src/csv_core/csv.rs
@@ -403,7 +403,7 @@ impl<R: Read + Sync + Send> SequentialReader<R> {
                     let mut r = std::mem::take(&mut self.record_iter).unwrap().into_reader();
                     let mut bytes = Vec::with_capacity(1024 * 128);
                     r.get_mut().read_to_end(&mut bytes)?;
-                    if bytes[bytes.len() - 1] != b'\n' || bytes[bytes.len() - 1] != b'\r' {
+                    if !bytes.is_empty() && (bytes[bytes.len() - 1] != b'\n' || bytes[bytes.len() - 1] != b'\r') {
                         bytes.push(b'\n')
                     }
                     self.parse_csv_fast(n_threads, &bytes)?

--- a/polars/polars-io/src/csv_core/csv.rs
+++ b/polars/polars-io/src/csv_core/csv.rs
@@ -403,7 +403,9 @@ impl<R: Read + Sync + Send> SequentialReader<R> {
                     let mut r = std::mem::take(&mut self.record_iter).unwrap().into_reader();
                     let mut bytes = Vec::with_capacity(1024 * 128);
                     r.get_mut().read_to_end(&mut bytes)?;
-                    if !bytes.is_empty() && (bytes[bytes.len() - 1] != b'\n' || bytes[bytes.len() - 1] != b'\r') {
+                    if !bytes.is_empty()
+                        && (bytes[bytes.len() - 1] != b'\n' || bytes[bytes.len() - 1] != b'\r')
+                    {
                         bytes.push(b'\n')
                     }
                     self.parse_csv_fast(n_threads, &bytes)?


### PR DESCRIPTION
This fix checks if we got empty bytes from csv with predefined schema (with non-defined schema we have a separate check) to avoid wrapping around on subtraction.