### PR TITLE
Add isort lint check

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -52,13 +52,13 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install maturin pytest black==20.8b1 pdoc3 numpy ghp-import pandas flake8
+          pip install maturin pytest black==20.8b1 pdoc3 numpy ghp-import pandas flake8 isort
       - name: Run formatting checks
         run: |
           black --check .
       - name: Run linting
         run: |
-          cd py-polars && flake8 && cd ..
+          cd py-polars && flake8 && isort --check-only . && cd ..
       - name: Run tests
         run: |
           cd py-polars && ./tasks.sh build-run-tests && cd ..

--- a/py-polars/.isort.cfg
+++ b/py-polars/.isort.cfg
@@ -1,0 +1,8 @@
+[settings]
+line_length = 88
+multi_line_output = 3
+include_trailing_comma = True
+force_grid_wrap = True
+use_parentheses = True
+ensure_newline_before_comments = True
+combine_as_imports = True

--- a/py-polars/build.requirements.txt
+++ b/py-polars/build.requirements.txt
@@ -1,3 +1,4 @@
+isort==5.8.0
 maturin==0.8.1
 pytest==5.3.1
 black==20.8b1

--- a/py-polars/polars/__init__.py
+++ b/py-polars/polars/__init__.py
@@ -3,11 +3,18 @@
 .. include:: ./index.md
 """
 
-from .series import Series, wrap_s
-from .frame import DataFrame, wrap_df, StringCache
+from .datatypes import *
+from .frame import (
+    DataFrame,
+    StringCache,
+    wrap_df,
+)
 from .functions import *
 from .lazy import *
-from .datatypes import *
+from .series import (
+    Series,
+    wrap_s,
+)
 
 # during docs building the binary code is not yet available
 try:

--- a/py-polars/polars/_html.py
+++ b/py-polars/polars/_html.py
@@ -8,6 +8,7 @@ from typing import (
     List,
     Optional,
 )
+
 import polars as pl
 
 

--- a/py-polars/polars/ffi.py
+++ b/py-polars/polars/ffi.py
@@ -1,8 +1,9 @@
+import ctypes
+from typing import Any
+
 import numpy as np
 import numpy.core
 from numpy import ctypeslib
-import ctypes
-from typing import Any
 
 # https://stackoverflow.com/questions/4355524/getting-data-from-ctypes-array-into-numpy
 

--- a/py-polars/polars/frame.py
+++ b/py-polars/polars/frame.py
@@ -11,30 +11,37 @@ except ImportError:
     warnings.warn("binary files missing")
     __pdoc__ = {"wrap_df": False}
 
+import os
+from pathlib import Path
 from typing import (
-    Dict,
-    Sequence,
-    List,
-    Tuple,
-    Optional,
-    Union,
-    TextIO,
+    TYPE_CHECKING,
+    Any,
     BinaryIO,
     Callable,
-    Any,
+    Dict,
+    List,
+    Optional,
+    Sequence,
+    TextIO,
+    Tuple,
+    Union,
 )
-from .series import Series, wrap_s
-from . import datatypes
-from .datatypes import DataType, pytype_to_polars_type
-from ._html import NotebookFormatter
+
+import numpy as np
 import pyarrow as pa
 import pyarrow.compute
 import pyarrow.parquet
-import numpy as np
-import os
-from pathlib import Path
 
-from typing import TYPE_CHECKING
+from . import datatypes
+from ._html import NotebookFormatter
+from .datatypes import (
+    DataType,
+    pytype_to_polars_type,
+)
+from .series import (
+    Series,
+    wrap_s,
+)
 
 if TYPE_CHECKING:
     from .lazy import LazyFrame

--- a/py-polars/polars/functions.py
+++ b/py-polars/polars/functions.py
@@ -1,19 +1,26 @@
-from typing import Union, TextIO, Optional, List, BinaryIO
-import numpy as np
-from pathlib import Path
-from .frame import DataFrame
-from .series import Series
-from .lazy import LazyFrame
-import pyarrow as pa
-import pyarrow.parquet
-import pyarrow.csv
-import pyarrow.compute
 import builtins
-import urllib.request
 import io
+import urllib.request
+from pathlib import Path
+from typing import (
+    BinaryIO,
+    Dict,
+    List,
+    Optional,
+    TextIO,
+    Union,
+)
 
-from typing import Dict
+import numpy as np
+import pyarrow as pa
+import pyarrow.compute
+import pyarrow.csv
+import pyarrow.parquet
+
 from .datatypes import DataType
+from .frame import DataFrame
+from .lazy import LazyFrame
+from .series import Series
 
 
 def _process_http_file(path: str) -> io.BytesIO:

--- a/py-polars/polars/lazy/__init__.py
+++ b/py-polars/polars/lazy/__init__.py
@@ -1,29 +1,39 @@
-from typing import Union, List, Callable, Optional, Dict
-
-from polars import Series
-from polars.frame import DataFrame, wrap_df
-from polars import datatypes
-from polars.datatypes import DataType
 import os
-import tempfile
-import subprocess
 import shutil
+import subprocess
+import tempfile
 from datetime import datetime
+from typing import (
+    Callable,
+    Dict,
+    List,
+    Optional,
+    Union,
+)
+
+from polars import (
+    Series,
+    datatypes,
+)
+from polars.datatypes import DataType
+from polars.frame import (
+    DataFrame,
+    wrap_df,
+)
 
 try:
     from ..polars import (
-        PyLazyFrame,
-        col as pycol,
-        lit as pylit,
-        # binary_expr,
-        binary_function as pybinary_function,
-        pearson_corr as pypearson_corr,
-        cov as pycov,
         PyExpr,
+        PyLazyFrame,
         PyLazyGroupBy,
-        when as pywhen,
+        binary_function as pybinary_function,
+        col as pycol,
+        cov as pycov,
         except_ as pyexcept,
+        lit as pylit,
+        pearson_corr as pypearson_corr,
         range as pyrange,
+        when as pywhen,
     )
 except ImportError:
     import warnings
@@ -139,8 +149,8 @@ class LazyFrame:
         raw_output: bool = False,
     ) -> "Optional[str]":
         try:
-            import matplotlib.pyplot as plt
             import matplotlib.image as mpimg
+            import matplotlib.pyplot as plt
         except ImportError:
             raise ImportError(
                 "graphviz dot binary should be on your PATH and matplotlib should be installed to show graph"

--- a/py-polars/polars/series.py
+++ b/py-polars/polars/series.py
@@ -10,35 +10,45 @@ except ImportError:
         "out_to_dtype": False,
         "get_ffi_func": False,
     }
+from numbers import Number
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    List,
+    Optional,
+    Sequence,
+    Tuple,
+    Union,
+)
+
 import numpy as np
-from typing import Optional, List, Sequence, Union, Any, Callable, Tuple
-from .ffi import _ptr_to_numpy
+import pyarrow as pa
+
+import polars
+
 from .datatypes import (
-    Utf8,
-    Int64,
-    UInt64,
-    UInt32,
-    dtypes,
-    Boolean,
-    Float32,
-    Float64,
     DTYPE_TO_FFINAME,
-    dtype_to_primitive,
-    UInt8,
-    dtype_to_ctype,
+    Boolean,
     DataType,
     Date32,
     Date64,
-    Int32,
-    Int16,
+    Float32,
+    Float64,
     Int8,
+    Int16,
+    Int32,
+    Int64,
+    UInt8,
     UInt16,
+    UInt32,
+    UInt64,
+    Utf8,
+    dtype_to_ctype,
+    dtype_to_primitive,
+    dtypes,
 )
-from numbers import Number
-import polars
-import pyarrow as pa
-
-from typing import TYPE_CHECKING
+from .ffi import _ptr_to_numpy
 
 if TYPE_CHECKING:
     from .frame import DataFrame

--- a/py-polars/tests/test_db_benchmark.py
+++ b/py-polars/tests/test_db_benchmark.py
@@ -1,5 +1,6 @@
-import polars as pl
 import io
+
+import polars as pl
 
 csv = rb"""id1,id2,id3,id4,id5,id6,v1,v2,v3
 id046,id007,id0000043878,51,10,59276,1,2,9.33179

--- a/py-polars/tests/test_df.py
+++ b/py-polars/tests/test_df.py
@@ -1,16 +1,20 @@
-from polars import DataFrame, Series
+from builtins import range
+from io import BytesIO
+
+import numpy as np
+import pandas as pd
+import pyarrow as pa
+import pytest
+from utils import get_complete_df
+
+import polars as pl
+from polars import (
+    DataFrame,
+    Series,
+    functions,
+)
 from polars.datatypes import *
 from polars.lazy import *
-from polars import functions
-import pytest
-from io import BytesIO
-import numpy as np
-from builtins import range
-import pyarrow as pa
-import polars as pl
-import pandas as pd
-
-from utils import get_complete_df
 
 
 def test_version():

--- a/py-polars/tests/test_io.py
+++ b/py-polars/tests/test_io.py
@@ -1,5 +1,7 @@
 import io
+
 from utils import get_complete_df
+
 import polars as pl
 
 

--- a/py-polars/tests/test_lazy.py
+++ b/py-polars/tests/test_lazy.py
@@ -1,8 +1,12 @@
-from polars import DataFrame, Series
-from polars.lazy import *
-from polars.datatypes import *
-import polars as pl
 import pytest
+
+import polars as pl
+from polars import (
+    DataFrame,
+    Series,
+)
+from polars.datatypes import *
+from polars.lazy import *
 
 
 def test_lazy():

--- a/py-polars/tests/test_pandas.py
+++ b/py-polars/tests/test_pandas.py
@@ -1,5 +1,7 @@
-import pandas as pd
 import datetime
+
+import pandas as pd
+
 import polars as pl
 
 

--- a/py-polars/tests/test_series.py
+++ b/py-polars/tests/test_series.py
@@ -1,9 +1,10 @@
+import numpy as np
+import pyarrow as pa
+import pytest
+
+import polars as pl
 from polars import Series
 from polars.datatypes import *
-import polars as pl
-import numpy as np
-import pytest
-import pyarrow as pa
 
 
 def create_series() -> "Series":


### PR DESCRIPTION
This adds an isort lint check in case that's something you'd like to include.

I think it can be helpful in making imports easier to find as well as never having to think about where to import something again. Most of the [config options](https://pycqa.github.io/isort/docs/configuration/options/) added are to keep it from fighting with black.