### PR TITLE
fix #484; Rolling mean

### DIFF
--- a/polars/polars-core/src/chunked_array/ops/mod.rs
+++ b/polars/polars-core/src/chunked_array/ops/mod.rs
@@ -72,7 +72,7 @@ pub trait ChunkWindow {
     ///                     `false` -> Any Null in the window leads to a Null in the aggregation result.
     fn rolling_sum(
         &self,
-        _window_size: usize,
+        _window_size: u32,
         _weight: Option<&[f64]>,
         _ignore_null: bool,
         _min_periods: u32,
@@ -100,7 +100,7 @@ pub trait ChunkWindow {
     /// * `min_periods` -  Amount of elements in the window that should be filled before computing a result.
     fn rolling_mean(
         &self,
-        _window_size: usize,
+        _window_size: u32,
         _weight: Option<&[f64]>,
         _ignore_null: bool,
         _min_periods: u32,
@@ -129,7 +129,7 @@ pub trait ChunkWindow {
     /// * `min_periods` -  Amount of elements in the window that should be filled before computing a result.
     fn rolling_min(
         &self,
-        _window_size: usize,
+        _window_size: u32,
         _weight: Option<&[f64]>,
         _ignore_null: bool,
         _min_periods: u32,
@@ -158,7 +158,7 @@ pub trait ChunkWindow {
     /// * `min_periods` -  Amount of elements in the window that should be filled before computing a result.
     fn rolling_max(
         &self,
-        _window_size: usize,
+        _window_size: u32,
         _weight: Option<&[f64]>,
         _ignore_null: bool,
         _min_periods: u32,
@@ -191,7 +191,7 @@ pub trait ChunkWindowCustom<T> {
     /// * `min_periods` -  Amount of elements in the window that should be filled before computing a result.
     fn rolling_custom<F>(
         &self,
-        _window_size: usize,
+        _window_size: u32,
         _weight: Option<&[f64]>,
         _fold_fn: F,
         _init_fold: InitFold,

--- a/polars/polars-core/src/chunked_array/ops/window.rs
+++ b/polars/polars-core/src/chunked_array/ops/window.rs
@@ -1,6 +1,6 @@
 use crate::prelude::*;
-use num::{Bounded, NumCast, Zero};
-use std::ops::{Add, Div, Mul};
+use num::{Bounded, NumCast, One, Zero};
+use std::ops::{Add, Div, Mul, Sub};
 
 /// a fold function to compute the sum. Returns a Null if there is a single null in the window
 fn sum_fold<T>(acc: Option<T>, opt_v: Option<T>) -> Option<T>
@@ -76,6 +76,20 @@ where
     }
 }
 
+/// a fold function to compute the window size. The null values are ignored.
+fn window_size_fold_ignore_null<T>(acc: Option<T>, opt_v: Option<T>) -> Option<T>
+where
+    T: Add<Output = T> + Copy + One,
+{
+    match acc {
+        None => Some(T::one()),
+        Some(acc) => match opt_v {
+            None => Some(acc),
+            _ => Some(acc + T::one()),
+        },
+    }
+}
+
 fn rescale_window<T>(window: &[Option<T>], weight: &[T]) -> Vec<Option<T>>
 where
     T: Mul<Output = T> + Copy,
@@ -89,23 +103,25 @@ where
 
 // the state holds the window and the current idx of the operation.
 // The value at the end of the window is not always the latest value (i.e. the value at the idx)
-// otherwise we have to move all the values if we push one to the window
+// otherwise we have to move all the values if we push one to the window.
+// Instead we use a ring buffer
 // Therefore the oldest value in the window gets replaced by the new value and is determined by:
 // current_idx % window_size
+//
 //
 // the latest state values is the amount of Some<T> values in the window
 fn update_state<T>(
     // (window , oldest_value_idx, amount_Some)
-    state: &mut (Vec<Option<T>>, usize, u32),
+    state: &mut (Vec<Option<T>>, u32, u32),
     // count of the loop
-    idx_count: usize,
+    idx_count: u32,
     // new value
     opt_v: Option<T>,
     // size of the window
-    window_size: usize,
-) -> usize {
+    window_size: u32,
+) -> u32 {
     let (window, idx, _) = state;
-    let old_value = &mut window[*idx];
+    let old_value = &mut window[*idx as usize];
     let mut new_val = opt_v;
 
     if new_val.is_some() {
@@ -158,7 +174,7 @@ fn weight_to_native<Native: NumCast>(weight: &[f64]) -> Vec<Native> {
 fn finish_rolling_method<T, F>(
     ca: &ChunkedArray<T>,
     fold_fn: F,
-    window_size: usize,
+    window_size: u32,
     weight: Option<&[f64]>,
     init_fold: InitFold,
     min_periods: u32,
@@ -175,11 +191,11 @@ where
     F: Fn(Option<T::Native>, Option<T::Native>) -> Option<T::Native> + Copy,
 {
     let weight: Option<Vec<T::Native>> = weight.map(weight_to_native);
-    let window = vec![None; window_size];
+    let window = vec![None; window_size as usize];
     let mut idx_count = 0;
     if ca.null_count() == 0 {
         ca.into_no_null_iter()
-            .scan((window, 0usize, 0u32), |state, v| {
+            .scan((window, 0u32, 0u32), |state, v| {
                 idx_count = update_state(state, idx_count, Some(v), window_size);
                 let (window, _, some_count) = state;
                 if *some_count < min_periods {
@@ -192,7 +208,7 @@ where
             .collect()
     } else {
         ca.into_iter()
-            .scan((window, 0usize, 0u32), |state, opt_v| {
+            .scan((window, 0u32, 0u32), |state, opt_v| {
                 idx_count = update_state(state, idx_count, opt_v, window_size);
                 let (window, _, some_count) = state;
                 if *some_count < min_periods {
@@ -215,21 +231,25 @@ pub enum InitFold {
 impl<T> ChunkWindow for ChunkedArray<T>
 where
     T: PolarsNumericType,
-    T::Native: Zero
+    T::Native: Add<Output = T::Native>
+        + Sub<Output = T::Native>
+        + Mul<Output = T::Native>
+        + Div<Output = T::Native>
+        + Zero
         + Bounded
         + NumCast
-        + Div<Output = T::Native>
-        + Mul<Output = T::Native>
         + PartialOrd
+        + One
         + Copy,
 {
     fn rolling_sum(
         &self,
-        window_size: usize,
+        window_size: u32,
         weight: Option<&[f64]>,
         ignore_null: bool,
         min_periods: u32,
     ) -> Result<Self> {
+        check_input(window_size, min_periods)?;
         let fold_fn = if ignore_null {
             sum_fold_ignore_null::<T::Native>
         } else {
@@ -248,22 +268,25 @@ where
 
     fn rolling_mean(
         &self,
-        window_size: usize,
+        window_size: u32,
         weight: Option<&[f64]>,
         ignore_null: bool,
         min_periods: u32,
     ) -> Result<Self> {
+        check_input(window_size, min_periods)?;
+        let rolling_window_size = self.window_size(window_size, None, min_periods);
         let ca = self.rolling_sum(window_size, weight, ignore_null, min_periods)?;
-        Ok(&ca / window_size)
+        Ok((&ca).div(&rolling_window_size))
     }
 
     fn rolling_min(
         &self,
-        window_size: usize,
+        window_size: u32,
         weight: Option<&[f64]>,
         ignore_null: bool,
         min_periods: u32,
     ) -> Result<Self> {
+        check_input(window_size, min_periods)?;
         let fold_fn = if ignore_null {
             min_fold_ignore_null::<T::Native>
         } else {
@@ -282,11 +305,12 @@ where
 
     fn rolling_max(
         &self,
-        window_size: usize,
+        window_size: u32,
         weight: Option<&[f64]>,
         ignore_null: bool,
         min_periods: u32,
     ) -> Result<Self> {
+        check_input(window_size, min_periods)?;
         let fold_fn = if ignore_null {
             max_fold_ignore_null::<T::Native>
         } else {
@@ -313,11 +337,12 @@ where
         + Div<Output = T::Native>
         + Mul<Output = T::Native>
         + PartialOrd
+        + One
         + Copy,
 {
     fn rolling_custom<F>(
         &self,
-        window_size: usize,
+        window_size: u32,
         weight: Option<&[f64]>,
         fold_fn: F,
         init_fold: InitFold,
@@ -334,6 +359,39 @@ where
             init_fold,
             min_periods,
         ))
+    }
+}
+
+/// utility
+fn check_input(window_size: u32, min_periods: u32) -> Result<()> {
+    if min_periods > window_size {
+        Err(PolarsError::ValueError(
+            "`windows_size` should be >= `min_periods`".into(),
+        ))
+    } else {
+        Ok(())
+    }
+}
+
+impl<T> ChunkedArray<T>
+where
+    T: PolarsNumericType,
+    T::Native: Zero
+        + Bounded
+        + NumCast
+        + Div<Output = T::Native>
+        + Mul<Output = T::Native>
+        + PartialOrd
+        + One
+        + Copy,
+{
+    /// Compute the window size during traversion of the array.
+    /// The window size may be less than `window_size` at the edges, or when null values should be ignored.
+    fn window_size(&self, window_size: u32, weight: Option<&[f64]>, min_periods: u32) -> Self {
+        let fold_fn = window_size_fold_ignore_null::<T::Native>;
+        let init_fold = InitFold::Zero;
+
+        finish_rolling_method(self, fold_fn, window_size, weight, init_fold, min_periods)
     }
 }
 
@@ -387,5 +445,39 @@ mod test {
         let ca = Int32Chunked::new_from_slice("foo", &[1, 2, 3, 2, 1]);
         let a = ca.rolling_max(2, None, true, 2).unwrap();
         assert_eq!(Vec::from(&a), &[None, Some(2), Some(3), Some(3), Some(2)]);
+    }
+
+    #[test]
+    fn test_rolling_mean() {
+        let ca = Float64Chunked::new_from_opt_slice(
+            "foo",
+            &[
+                Some(0.0),
+                Some(1.0),
+                Some(2.0),
+                None,
+                None,
+                Some(5.0),
+                Some(6.0),
+            ],
+        );
+
+        // check err on wrong input
+        assert!(ca.rolling_mean(1, None, true, 2).is_err());
+
+        // validate that we divide by the proper window length. (same as pandas)
+        let a = ca.rolling_mean(3, None, true, 1).unwrap();
+        assert_eq!(
+            Vec::from(&a),
+            &[
+                Some(0.0),
+                Some(0.5),
+                Some(1.0),
+                Some(1.5),
+                Some(2.0),
+                Some(5.0),
+                Some(5.5)
+            ]
+        );
     }
 }

--- a/polars/polars-core/src/series/implementations.rs
+++ b/polars/polars-core/src/series/implementations.rs
@@ -774,7 +774,7 @@ macro_rules! impl_dyn_series {
             }
             fn rolling_mean(
                 &self,
-                window_size: usize,
+                window_size: u32,
                 weight: Option<&[f64]>,
                 ignore_null: bool,
                 min_periods: u32,
@@ -784,7 +784,7 @@ macro_rules! impl_dyn_series {
             }
             fn rolling_sum(
                 &self,
-                window_size: usize,
+                window_size: u32,
                 weight: Option<&[f64]>,
                 ignore_null: bool,
                 min_periods: u32,
@@ -794,7 +794,7 @@ macro_rules! impl_dyn_series {
             }
             fn rolling_min(
                 &self,
-                window_size: usize,
+                window_size: u32,
                 weight: Option<&[f64]>,
                 ignore_null: bool,
                 min_periods: u32,
@@ -804,7 +804,7 @@ macro_rules! impl_dyn_series {
             }
             fn rolling_max(
                 &self,
-                window_size: usize,
+                window_size: u32,
                 weight: Option<&[f64]>,
                 ignore_null: bool,
                 min_periods: u32,

--- a/polars/polars-core/src/series/mod.rs
+++ b/polars/polars-core/src/series/mod.rs
@@ -692,7 +692,7 @@ pub trait SeriesTrait: Send + Sync + private::PrivateSeries {
     /// [ChunkedArray::rolling_mean](crate::prelude::ChunkWindow::rolling_mean).
     fn rolling_mean(
         &self,
-        _window_size: usize,
+        _window_size: u32,
         _weight: Option<&[f64]>,
         _ignore_null: bool,
         _min_periods: u32,
@@ -703,7 +703,7 @@ pub trait SeriesTrait: Send + Sync + private::PrivateSeries {
     /// [ChunkedArray::rolling_mean](crate::prelude::ChunkWindow::rolling_sum).
     fn rolling_sum(
         &self,
-        _window_size: usize,
+        _window_size: u32,
         _weight: Option<&[f64]>,
         _ignore_null: bool,
         _min_periods: u32,
@@ -714,7 +714,7 @@ pub trait SeriesTrait: Send + Sync + private::PrivateSeries {
     /// [ChunkedArray::rolling_mean](crate::prelude::ChunkWindow::rolling_min).
     fn rolling_min(
         &self,
-        _window_size: usize,
+        _window_size: u32,
         _weight: Option<&[f64]>,
         _ignore_null: bool,
         _min_periods: u32,
@@ -725,7 +725,7 @@ pub trait SeriesTrait: Send + Sync + private::PrivateSeries {
     /// [ChunkedArray::rolling_mean](crate::prelude::ChunkWindow::rolling_max).
     fn rolling_max(
         &self,
-        _window_size: usize,
+        _window_size: u32,
         _weight: Option<&[f64]>,
         _ignore_null: bool,
         _min_periods: u32,

--- a/py-polars/polars/series.py
+++ b/py-polars/polars/series.py
@@ -1310,7 +1310,7 @@ class Series:
         self,
         window_size: int,
         weight: "Optional[List[float]]" = None,
-        ignore_null: bool = False,
+        ignore_null: bool = True,
         min_periods: "Optional[int]" = None,
     ) -> "Series":
         """
@@ -1342,7 +1342,7 @@ class Series:
         self,
         window_size: int,
         weight: "Optional[List[float]]" = None,
-        ignore_null: bool = False,
+        ignore_null: bool = True,
         min_periods: "Optional[int]" = None,
     ) -> "Series":
         """
@@ -1374,7 +1374,7 @@ class Series:
         self,
         window_size: int,
         weight: "Optional[List[float]]" = None,
-        ignore_null: bool = False,
+        ignore_null: bool = True,
         min_periods: "Optional[int]" = None,
     ) -> "Series":
         """
@@ -1406,7 +1406,7 @@ class Series:
         self,
         window_size: int,
         weight: "Optional[List[float]]" = None,
-        ignore_null: bool = False,
+        ignore_null: bool = True,
         min_periods: "Optional[int]" = None,
     ) -> "Series":
         """

--- a/py-polars/src/series.rs
+++ b/py-polars/src/series.rs
@@ -926,7 +926,7 @@ impl PySeries {
     }
     pub fn rolling_sum(
         &self,
-        window_size: usize,
+        window_size: u32,
         weight: Option<Vec<f64>>,
         ignore_null: bool,
         min_periods: u32,
@@ -940,7 +940,7 @@ impl PySeries {
 
     pub fn rolling_mean(
         &self,
-        window_size: usize,
+        window_size: u32,
         weight: Option<Vec<f64>>,
         ignore_null: bool,
         min_periods: u32,
@@ -954,7 +954,7 @@ impl PySeries {
 
     pub fn rolling_max(
         &self,
-        window_size: usize,
+        window_size: u32,
         weight: Option<Vec<f64>>,
         ignore_null: bool,
         min_periods: u32,
@@ -967,7 +967,7 @@ impl PySeries {
     }
     pub fn rolling_min(
         &self,
-        window_size: usize,
+        window_size: u32,
         weight: Option<Vec<f64>>,
         ignore_null: bool,
         min_periods: u32,


### PR DESCRIPTION
The rolling mean did a naive rolling_sum / window_size.

The window size however is also dependent on the rolling operation.
It should be decremented per Null value and by the effect at the
edges of the array.