### PR TITLE
Bump maturin version in build.requirements.txt

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -52,7 +52,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install maturin pytest black==20.8b1 pdoc3 numpy ghp-import pandas flake8
+          pip install -r py-polars/build.requirements.txt
       - name: Run formatting checks
         run: |
           black --check .

--- a/py-polars/build.requirements.txt
+++ b/py-polars/build.requirements.txt
@@ -1,3 +1,8 @@
 maturin==0.9.4
 pytest==5.3.1
 black==20.8b1
+pdoc3
+numpy
+ghp-import
+pandas
+flake8

--- a/py-polars/build.requirements.txt
+++ b/py-polars/build.requirements.txt
@@ -1,3 +1,3 @@
-maturin==0.8.1
+maturin==0.9.4
 pytest==5.3.1
 black==20.8b1


### PR DESCRIPTION
Looks like the contributing guidelines do mention this version, but just in case someone goes off of this instead when setting up their environment.

~Actually, it looks like this file isn't used in CI to set up the environment either; does it make sense to update this file with all requirements (it seems things are installed in the GitHub Action that aren't listed here) and then reference it in `build-test.yaml`?~

EDIT: Also updated to include all packages being installed in CI and referenced the file there.