### PR TITLE
Refactor lazy namespace

### DIFF
--- a/py-polars/polars/__init__.py
+++ b/py-polars/polars/__init__.py
@@ -6,7 +6,6 @@
 from .series import Series, wrap_s
 from .frame import DataFrame, wrap_df, StringCache
 from .functions import *
-from .lazy import *
 from .datatypes import *
 
 # during docs building the binary code is not yet available

--- a/py-polars/tests/test_db_benchmark.py
+++ b/py-polars/tests/test_db_benchmark.py
@@ -41,5 +41,5 @@ x["id3"] = x["id3"].cast(pl.Categorical)
 x = x.lazy()
 
 question = "sum v1 by id1"  # q1
-ans = x.groupby("id1").agg(pl.sum("v1")).collect()
+ans = x.groupby("id1").agg(pl.lazy.sum("v1")).collect()
 print(ans.shape, flush=True)

--- a/py-polars/tests/test_lazy.py
+++ b/py-polars/tests/test_lazy.py
@@ -88,8 +88,12 @@ def test_apply_custom_function():
         .groupby("fruits")
         .agg(
             [
-                pl.lazy.col("cars").apply(lambda groups: groups.len()).alias("custom_1"),
-                pl.lazy.col("cars").apply(lambda groups: groups.len()).alias("custom_2"),
+                pl.lazy.col("cars")
+                .apply(lambda groups: groups.len())
+                .alias("custom_1"),
+                pl.lazy.col("cars")
+                .apply(lambda groups: groups.len())
+                .alias("custom_2"),
                 pl.lazy.count("cars"),
             ]
         )

--- a/py-polars/tests/test_lazy.py
+++ b/py-polars/tests/test_lazy.py
@@ -33,13 +33,13 @@ def test_agg():
 
 def test_fold():
     df = DataFrame({"a": [1, 2, 3], "b": [1.0, 2.0, 3.0]})
-    out = df.lazy().select(pl.sum(["a", "b"])).collect()
+    out = df.lazy().select(pl.lazy.sum(["a", "b"])).collect()
     assert out["sum"].series_equal(Series("sum", [2, 4, 6]))
 
 
 def test_or():
     df = DataFrame({"a": [1, 2, 3], "b": [1.0, 2.0, 3.0]})
-    out = df.lazy().filter((pl.col("a") == 1) | (pl.col("b") > 2)).collect()
+    out = df.lazy().filter((pl.lazy.col("a") == 1) | (pl.lazy.col("b") > 2)).collect()
     assert out.shape[0] == 2
 
 
@@ -69,7 +69,7 @@ def test_filter_str():
     )
     q = df.lazy()
     # last row based on a filter
-    q.filter(pl.col("bools")).select(pl.last("*"))
+    q.filter(pl.lazy.col("bools")).select(pl.lazy.last("*"))
 
 
 def test_apply_custom_function():
@@ -88,9 +88,9 @@ def test_apply_custom_function():
         .groupby("fruits")
         .agg(
             [
-                pl.col("cars").apply(lambda groups: groups.len()).alias("custom_1"),
-                pl.col("cars").apply(lambda groups: groups.len()).alias("custom_2"),
-                pl.count("cars"),
+                pl.lazy.col("cars").apply(lambda groups: groups.len()).alias("custom_1"),
+                pl.lazy.col("cars").apply(lambda groups: groups.len()).alias("custom_2"),
+                pl.lazy.count("cars"),
             ]
         )
         .sort("custom_1", reverse=True)
@@ -109,7 +109,7 @@ def test_apply_custom_function():
 
 def test_groupby():
     df = pl.DataFrame({"a": [1.0, None, 3.0, 4.0], "groups": ["a", "a", "b", "b"]})
-    out = df.lazy().groupby("groups").agg(pl.mean("a")).collect()
+    out = df.lazy().groupby("groups").agg(pl.lazy.mean("a")).collect()
 
 
 def test_shift_and_fill():


### PR DESCRIPTION
@ritchie46 Here's a PR splitting off a possible lazy namespace refactor (requiring import from `polars.lazy` for any lazy functions). However, note that when I try to apply this to https://github.com/ritchie46/polars/pull/489 it does _not_ fix the circular import issue we were seeing there and raises errors like this:
```
_____________________________________________________________________ ERROR collecting tests/test_db_benchmark.py _____________________________________________________________________
ImportError while importing test module '/Users/danielsaxton/polars/py-polars/tests/test_db_benchmark.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
tests/test_db_benchmark.py:3: in <module>
    import polars as pl
../venv/lib/python3.8/site-packages/polars/__init__.py:12: in <module>
    from .functions import *
../venv/lib/python3.8/site-packages/polars/functions.py:22: in <module>
    from .lazy import LazyFrame
../venv/lib/python3.8/site-packages/polars/lazy/__init__.py:14: in <module>
    from polars import (
E   ImportError: cannot import name 'Series' from partially initialized module 'polars' (most likely due to a circular import) (/Users/danielsaxton/polars/venv/lib/python3.8/site-packages/polars/__init__.py)
```
 Let me know if given that you'd prefer we not make this change and I can close.