### PR TITLE
Fix typos

### DIFF
--- a/examples/lazy_py-polars.ipynb
+++ b/examples/lazy_py-polars.ipynb
@@ -19,9 +19,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Lazyness\n",
+    "# Laziness\n",
     "\n",
-    "Py-polars has a lazy API that supports a subset of the eager API. Lazyness means that operations aren't executed until you ask for them. Let's start with a short example..\n",
+    "Py-polars has a lazy API that supports a subset of the eager API. Laziness means that operations aren't executed until you ask for them. Let's start with a short example..\n",
     "\n",
     "Below we'll create a DataFrame in an eager fashion (meaning that the creation of the DataFrame is executed at once)."
    ]
@@ -171,7 +171,7 @@
    "metadata": {},
    "source": [
     "# Why lazy?\n",
-    "This lazyness opens up quite some cool possibitlies from an optimization perspective. \n",
+    "This laziness opens up quite some cool possibitlies from an optimization perspective. \n",
     "It allows polars to modify the query right before executing it and make suboptimal queries more performant. Let's show this using various operations, comparing lazy execution with eager execution in both Polars and Pandas.\n",
     "\n",
     "Let's create 2 DataFrames with quite some columns and rows."
@@ -363,7 +363,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "~The peformance stays approximatly the same with more columns Here we observe that with 30 columns, polars is still **~1.2x** slower.~\n",
+    "~The performance stays approximatly the same with more columns Here we observe that with 30 columns, polars is still **~1.2x** slower.~\n",
     "* Pandas has great row-wise filtering due to the block-manager (with unexpected performance hits)\n",
     "* Polars has great row-wise filtering due to embarissingly parallelization."
    ]
@@ -499,7 +499,7 @@
    "source": [
     "# Query optimization\n",
     "Filtering a DataFrame leads to a new allocation. An often sub-optimal query is doing multiple queries at once.\n",
-    "Let's see if lazyness can help optimize that."
+    "Let's see if laziness can help optimize that."
    ]
   },
   {
@@ -967,7 +967,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Udf (User defined fucntions <3 Lazyness)\n",
+    "## Udf (User defined functions <3 Laziness)\n",
     "The lazy api also has access to all the `eager` operations on `Series` because there are udf's with almost no overhead (no serializing or pickling). Below we'll add a column `\"udf\"` with a `lambda` and help of the eager api. It still needs some polishing, as we need to make sure that we don't modify the dtypes. I hope you can imagine that this can be very powerful! :)\n"
    ]
   },

--- a/polars/polars-arrow/src/bit_util.rs
+++ b/polars/polars-arrow/src/bit_util.rs
@@ -1,6 +1,6 @@
 /// Forked from Arrow until their API stabilizes.
 ///
-/// Note taht the bound checks are optimized away.
+/// Note that the bound checks are optimized away.
 ///
 
 #[cfg(feature = "simd")]

--- a/polars/polars-arrow/src/builder.rs
+++ b/polars/polars-arrow/src/builder.rs
@@ -385,7 +385,7 @@ impl NoNullLargeStringBuilder {
         assert_eq!(buf_values.len(), buf_values.capacity());
         assert_eq!(buf_offsets.len(), buf_offsets.capacity());
 
-        // note that the arrays are already shrinked when transformed to an arrow buffer.
+        // note that the arrays are already shrunk when transformed to an arrow buffer.
         let arraydata = ArrayData::builder(DataType::LargeUtf8)
             .len(offsets_len)
             .add_buffer(buf_offsets)

--- a/polars/polars-core/src/chunked_array/iterator/mod.rs
+++ b/polars/polars-core/src/chunked_array/iterator/mod.rs
@@ -1919,7 +1919,7 @@ mod test {
             fn $test_name() {
                 let a = $ca_init_block;
 
-                // Consume first postion of iterator.
+                // Consume first position of iterator.
                 let mut it = a.into_iter();
                 assert_eq!(it.next(), Some($first_val));
 

--- a/polars/polars-core/src/chunked_array/iterator/par/boolean.rs
+++ b/polars/polars-core/src/chunked_array/iterator/par/boolean.rs
@@ -72,7 +72,7 @@ mod test {
             .collect()
     }
 
-    /// Implement a test which performs a map over a `ParallelIterator` and over its correspondant `Iterator`,
+    /// Implement a test which performs a map over a `ParallelIterator` and over its correspondent `Iterator`,
     /// and compares that the result of both iterators is the same. It performs over iterators which return
     /// Option<bool>.
     ///
@@ -86,25 +86,25 @@ mod test {
             fn $test_name() {
                 let a = $ca_init_block;
 
-                // Perform a parallel maping.
+                // Perform a parallel mapping.
                 let par_result = a
                     .into_par_iter()
                     .map(|opt_b| opt_b.map(|b| !b))
                     .collect::<Vec<_>>();
 
-                // Perform a sequetial maping.
+                // Perform a sequential mapping.
                 let seq_result = a
                     .into_iter()
                     .map(|opt_b| opt_b.map(|b| !b))
                     .collect::<Vec<_>>();
 
-                // Check sequetial and parallel results are equal.
+                // Check sequential and parallel results are equal.
                 assert_eq!(par_result, seq_result);
             }
         };
     }
 
-    /// Implement a test which performs a filter over a `ParallelIterator` and over its correspondant `Iterator`,
+    /// Implement a test which performs a filter over a `ParallelIterator` and over its correspondent `Iterator`,
     /// and compares that the result of both iterators is the same. It performs over iterators which return
     /// Option<bool>.
     ///
@@ -124,19 +124,19 @@ mod test {
                     .filter(|opt_b| opt_b.unwrap_or(false))
                     .collect::<Vec<_>>();
 
-                // Perform a sequetial filter.
+                // Perform a sequential filter.
                 let seq_result = a
                     .into_iter()
                     .filter(|opt_b| opt_b.unwrap_or(false))
                     .collect::<Vec<_>>();
 
-                // Check sequetial and parallel results are equal.
+                // Check sequential and parallel results are equal.
                 assert_eq!(par_result, seq_result);
             }
         };
     }
 
-    /// Implement a test which performs a fold over a `ParallelIterator` and over its correspondant `Iterator`,
+    /// Implement a test which performs a fold over a `ParallelIterator` and over its correspondent `Iterator`,
     /// and compares that the result of both iterators is the same. It performs over iterators which return
     /// Option<bool>.
     ///
@@ -172,7 +172,7 @@ mod test {
                     acc + val
                 });
 
-                // Check sequetial and parallel results are equal.
+                // Check sequential and parallel results are equal.
                 assert_eq!(par_result, seq_result);
             }
         };
@@ -299,7 +299,7 @@ mod test {
         }
     );
 
-    /// Implement a test which performs a map over a `ParallelIterator` and over its correspondant `Iterator`,
+    /// Implement a test which performs a map over a `ParallelIterator` and over its correspondent `Iterator`,
     /// and compares that the result of both iterators is the same. It performs over iterators which return
     /// &str.
     ///
@@ -313,19 +313,19 @@ mod test {
             fn $test_name() {
                 let a = $ca_init_block;
 
-                // Perform a parallel maping.
+                // Perform a parallel mapping.
                 let par_result = NoNull(&a).into_par_iter().map(|b| !b).collect::<Vec<_>>();
 
-                // Perform a sequetial maping.
+                // Perform a sequential mapping.
                 let seq_result = a.into_no_null_iter().map(|b| !b).collect::<Vec<_>>();
 
-                // Check sequetial and parallel results are equal.
+                // Check sequential and parallel results are equal.
                 assert_eq!(par_result, seq_result);
             }
         };
     }
 
-    /// Implement a test which performs a filter over a `ParallelIterator` and over its correspondant `Iterator`,
+    /// Implement a test which performs a filter over a `ParallelIterator` and over its correspondent `Iterator`,
     /// and compares that the result of both iterators is the same. It performs over iterators which return
     /// &str.
     ///
@@ -345,16 +345,16 @@ mod test {
                     .filter(|&b| b)
                     .collect::<Vec<_>>();
 
-                // Perform a sequetial filter.
+                // Perform a sequential filter.
                 let seq_result = a.into_no_null_iter().filter(|&b| b).collect::<Vec<_>>();
 
-                // Check sequetial and parallel results are equal.
+                // Check sequential and parallel results are equal.
                 assert_eq!(par_result, seq_result);
             }
         };
     }
 
-    /// Implement a test which performs a fold over a `ParallelIterator` and over its correspondant `Iterator`,
+    /// Implement a test which performs a fold over a `ParallelIterator` and over its correspondent `Iterator`,
     /// and compares that the result of both iterators is the same. It performs over iterators which return
     /// &str.
     ///
@@ -386,7 +386,7 @@ mod test {
                     acc + val
                 });
 
-                // Check sequetial and parallel results are equal.
+                // Check sequential and parallel results are equal.
                 assert_eq!(par_result, seq_result);
             }
         };

--- a/polars/polars-core/src/chunked_array/iterator/par/macros.rs
+++ b/polars/polars-core/src/chunked_array/iterator/par/macros.rs
@@ -2,7 +2,7 @@
 
 /// Implement all parallel iterators and producers for a given chunked array. It also implements the
 /// `IntoParallelIterator` trait for `ca_type` and for `NoNull<ca_type>`.
-/// It will implement and iterator and a producer for the followin chunke arrays:
+/// It will implement and iterator and a producer for the following chunke arrays:
 /// - Chunked arrays with one chunk without null value, which returns the value wrapped in an `Option`.
 /// - Chunked arrays with one chunk with null values, which returns the value wrapped in an `Option`.
 /// - Chunked arrays with many chunks without null value, which returns the value wrapped in an `Option`.

--- a/polars/polars-core/src/chunked_array/iterator/par/mod.rs
+++ b/polars/polars-core/src/chunked_array/iterator/par/mod.rs
@@ -13,7 +13,7 @@ impl<T> ChunkedArray<T> {
     ///
     /// An iterator has two indexes, a left and a right index, which do not overlap as if both indexes point to the
     /// same index means that the iterator is consumed.
-    /// In order to avoid overlaping the right index is always one position ahead of the last chunk index, then:
+    /// In order to avoid overlapping the right index is always one position ahead of the last chunk index, then:
     /// - left chunk indexes: goes from 0 to `chunk.len() - 1`.
     /// - right chunk indexes: goes from 1 to `chunk.len()`.
     ///

--- a/polars/polars-core/src/chunked_array/iterator/par/numeric.rs
+++ b/polars/polars-core/src/chunked_array/iterator/par/numeric.rs
@@ -125,7 +125,7 @@ where
         let (chunk_idx_right, current_array_idx_right) = ca.right_index_to_chunked_index(idx_right);
 
         let (current_array_left_len, current_iter_right) = if chunk_idx_left == chunk_idx_right {
-            // If both iterators belong to the same chunk, then, only the left chunk is goin to be used
+            // If both iterators belong to the same chunk, then, only the left chunk is going to be used
             // and iterate from both sides. This iterator will be the left one and will go from
             // `current_array_idx_left` to `current_array_idx_right`.
             (len, None)
@@ -408,7 +408,7 @@ where
         let current_data_right = current_array_right.data();
 
         let (current_array_left_len, current_iter_right) = if chunk_idx_left == chunk_idx_right {
-            // If both iterators belong to the same chunk, then, only the left chunk is goin to be used
+            // If both iterators belong to the same chunk, then, only the left chunk is going to be used
             // and iterate from both sides. This iterator will be the left one and will go from
             // `current_array_idx_left` to `current_array_idx_right`.
             (prod.len, None)
@@ -840,7 +840,7 @@ mod test {
             .collect()
     }
 
-    /// Implement a test which performs a map over a `ParallelIterator` and over its correspondant `Iterator`,
+    /// Implement a test which performs a map over a `ParallelIterator` and over its correspondent `Iterator`,
     /// and compares that the result of both iterators is the same. It performs over iterators which return
     /// Option<u32>.
     ///
@@ -854,25 +854,25 @@ mod test {
             fn $test_name() {
                 let a = $ca_init_block;
 
-                // Perform a parallel maping.
+                // Perform a parallel mapping.
                 let par_result = a
                     .into_par_iter()
                     .map(|opt_u| opt_u.map(|u| u + 10))
                     .collect::<Vec<_>>();
 
-                // Perform a sequetial maping.
+                // Perform a sequential mapping.
                 let seq_result = a
                     .into_iter()
                     .map(|opt_u| opt_u.map(|u| u + 10))
                     .collect::<Vec<_>>();
 
-                // Check sequetial and parallel results are equal.
+                // Check sequential and parallel results are equal.
                 assert_eq!(par_result, seq_result);
             }
         };
     }
 
-    /// Implement a test which performs a filter over a `ParallelIterator` and over its correspondant `Iterator`,
+    /// Implement a test which performs a filter over a `ParallelIterator` and over its correspondent `Iterator`,
     /// and compares that the result of both iterators is the same. It performs over iterators which return
     /// Option<u32>.
     ///
@@ -896,7 +896,7 @@ mod test {
                     })
                     .collect::<Vec<_>>();
 
-                // Perform a sequetial filter.
+                // Perform a sequential filter.
                 let seq_result = a
                     .into_iter()
                     .filter(|opt_u| {
@@ -906,13 +906,13 @@ mod test {
                     })
                     .collect::<Vec<_>>();
 
-                // Check sequetial and parallel results are equal.
+                // Check sequential and parallel results are equal.
                 assert_eq!(par_result, seq_result);
             }
         };
     }
 
-    /// Implement a test which performs a fold over a `ParallelIterator` and over its correspondant `Iterator`,
+    /// Implement a test which performs a fold over a `ParallelIterator` and over its correspondent `Iterator`,
     /// and compares that the result of both iterators is the same. It performs over iterators which return
     /// Option<u32>.
     ///
@@ -944,7 +944,7 @@ mod test {
                     acc + val
                 });
 
-                // Check sequetial and parallel results are equal.
+                // Check sequential and parallel results are equal.
                 assert_eq!(par_result, seq_result);
             }
         };
@@ -1071,7 +1071,7 @@ mod test {
         }
     );
 
-    /// Implement a test which performs a map over a `ParallelIterator` and over its correspondant `Iterator`,
+    /// Implement a test which performs a map over a `ParallelIterator` and over its correspondent `Iterator`,
     /// and compares that the result of both iterators is the same. It performs over iterators which return
     /// u32.
     ///
@@ -1085,22 +1085,22 @@ mod test {
             fn $test_name() {
                 let a = $ca_init_block;
 
-                // Perform a parallel maping.
+                // Perform a parallel mapping.
                 let par_result = NoNull(&a)
                     .into_par_iter()
                     .map(|u| u + 10)
                     .collect::<Vec<_>>();
 
-                // Perform a sequetial maping.
+                // Perform a sequential mapping.
                 let seq_result = a.into_no_null_iter().map(|u| u + 10).collect::<Vec<_>>();
 
-                // Check sequetial and parallel results are equal.
+                // Check sequential and parallel results are equal.
                 assert_eq!(par_result, seq_result);
             }
         };
     }
 
-    /// Implement a test which performs a filter over a `ParallelIterator` and over its correspondant `Iterator`,
+    /// Implement a test which performs a filter over a `ParallelIterator` and over its correspondent `Iterator`,
     /// and compares that the result of both iterators is the same. It performs over iterators which return
     /// u32.
     ///
@@ -1120,19 +1120,19 @@ mod test {
                     .filter(|u| u % 10 == 0)
                     .collect::<Vec<_>>();
 
-                // Perform a sequetial filter.
+                // Perform a sequential filter.
                 let seq_result = a
                     .into_no_null_iter()
                     .filter(|u| u % 10 == 0)
                     .collect::<Vec<_>>();
 
-                // Check sequetial and parallel results are equal.
+                // Check sequential and parallel results are equal.
                 assert_eq!(par_result, seq_result);
             }
         };
     }
 
-    /// Implement a test which performs a fold over a `ParallelIterator` and over its correspondant `Iterator`,
+    /// Implement a test which performs a fold over a `ParallelIterator` and over its correspondent `Iterator`,
     /// and compares that the result of both iterators is the same. It performs over iterators which return
     /// u32.
     ///
@@ -1155,7 +1155,7 @@ mod test {
                 // Perform a sequential sum of length.
                 let seq_result = a.into_no_null_iter().fold(0u64, |acc, u| acc + u as u64);
 
-                // Check sequetial and parallel results are equal.
+                // Check sequential and parallel results are equal.
                 assert_eq!(par_result, seq_result);
             }
         };

--- a/polars/polars-core/src/chunked_array/iterator/par/utf8.rs
+++ b/polars/polars-core/src/chunked_array/iterator/par/utf8.rs
@@ -75,7 +75,7 @@ mod test {
             .collect()
     }
 
-    /// Implement a test which performs a map over a `ParallelIterator` and over its correspondant `Iterator`,
+    /// Implement a test which performs a map over a `ParallelIterator` and over its correspondent `Iterator`,
     /// and compares that the result of both iterators is the same. It performs over iterators which return
     /// Option<&str>.
     ///
@@ -89,25 +89,25 @@ mod test {
             fn $test_name() {
                 let a = $ca_init_block;
 
-                // Perform a parallel maping.
+                // Perform a parallel mapping.
                 let par_result = a
                     .into_par_iter()
                     .map(|opt_s| opt_s.map(|s| s.replace("0", "a")))
                     .collect::<Vec<_>>();
 
-                // Perform a sequetial maping.
+                // Perform a sequential mapping.
                 let seq_result = a
                     .into_iter()
                     .map(|opt_s| opt_s.map(|s| s.replace("0", "a")))
                     .collect::<Vec<_>>();
 
-                // Check sequetial and parallel results are equal.
+                // Check sequential and parallel results are equal.
                 assert_eq!(par_result, seq_result);
             }
         };
     }
 
-    /// Implement a test which performs a filter over a `ParallelIterator` and over its correspondant `Iterator`,
+    /// Implement a test which performs a filter over a `ParallelIterator` and over its correspondent `Iterator`,
     /// and compares that the result of both iterators is the same. It performs over iterators which return
     /// Option<&str>.
     ///
@@ -131,7 +131,7 @@ mod test {
                     })
                     .collect::<Vec<_>>();
 
-                // Perform a sequetial filter.
+                // Perform a sequential filter.
                 let seq_result = a
                     .into_iter()
                     .filter(|opt_s| {
@@ -141,13 +141,13 @@ mod test {
                     })
                     .collect::<Vec<_>>();
 
-                // Check sequetial and parallel results are equal.
+                // Check sequential and parallel results are equal.
                 assert_eq!(par_result, seq_result);
             }
         };
     }
 
-    /// Implement a test which performs a fold over a `ParallelIterator` and over its correspondant `Iterator`,
+    /// Implement a test which performs a fold over a `ParallelIterator` and over its correspondent `Iterator`,
     /// and compares that the result of both iterators is the same. It performs over iterators which return
     /// Option<&str>.
     ///
@@ -183,7 +183,7 @@ mod test {
                     acc + len
                 });
 
-                // Check sequetial and parallel results are equal.
+                // Check sequential and parallel results are equal.
                 assert_eq!(par_result, seq_result);
             }
         };
@@ -282,7 +282,7 @@ mod test {
         }
     );
 
-    /// Implement a test which performs a map over a `ParallelIterator` and over its correspondant `Iterator`,
+    /// Implement a test which performs a map over a `ParallelIterator` and over its correspondent `Iterator`,
     /// and compares that the result of both iterators is the same. It performs over iterators which return
     /// &str.
     ///
@@ -296,25 +296,25 @@ mod test {
             fn $test_name() {
                 let a = $ca_init_block;
 
-                // Perform a parallel maping.
+                // Perform a parallel mapping.
                 let par_result = NoNull(&a)
                     .into_par_iter()
                     .map(|s| s.replace("0", "a"))
                     .collect::<Vec<_>>();
 
-                // Perform a sequetial maping.
+                // Perform a sequential mapping.
                 let seq_result = a
                     .into_no_null_iter()
                     .map(|s| s.replace("0", "a"))
                     .collect::<Vec<_>>();
 
-                // Check sequetial and parallel results are equal.
+                // Check sequential and parallel results are equal.
                 assert_eq!(par_result, seq_result);
             }
         };
     }
 
-    /// Implement a test which performs a filter over a `ParallelIterator` and over its correspondant `Iterator`,
+    /// Implement a test which performs a filter over a `ParallelIterator` and over its correspondent `Iterator`,
     /// and compares that the result of both iterators is the same. It performs over iterators which return
     /// &str.
     ///
@@ -334,19 +334,19 @@ mod test {
                     .filter(|s| s.contains("0"))
                     .collect::<Vec<_>>();
 
-                // Perform a sequetial filter.
+                // Perform a sequential filter.
                 let seq_result = a
                     .into_no_null_iter()
                     .filter(|s| s.contains("0"))
                     .collect::<Vec<_>>();
 
-                // Check sequetial and parallel results are equal.
+                // Check sequential and parallel results are equal.
                 assert_eq!(par_result, seq_result);
             }
         };
     }
 
-    /// Implement a test which performs a fold over a `ParallelIterator` and over its correspondant `Iterator`,
+    /// Implement a test which performs a fold over a `ParallelIterator` and over its correspondent `Iterator`,
     /// and compares that the result of both iterators is the same. It performs over iterators which return
     /// &str.
     ///
@@ -371,7 +371,7 @@ mod test {
                     .into_no_null_iter()
                     .fold(0u64, |acc, s| acc + s.len() as u64);
 
-                // Check sequetial and parallel results are equal.
+                // Check sequential and parallel results are equal.
                 assert_eq!(par_result, seq_result);
             }
         };

--- a/polars/polars-core/src/chunked_array/mod.rs
+++ b/polars/polars-core/src/chunked_array/mod.rs
@@ -69,7 +69,7 @@ fn create_chunk_id(chunks: &[ArrayRef]) -> Vec<usize> {
 /// # ChunkedArray
 ///
 /// Every Series contains a `ChunkedArray<T>`. Unlike Series, ChunkedArray's are typed. This allows
-/// us to apply closures to the data and collect the results to a `ChunkedArray` of te same type `T`.
+/// us to apply closures to the data and collect the results to a `ChunkedArray` of the same type `T`.
 /// Below we use an apply to use the cosine function to the values of a `ChunkedArray`.
 ///
 /// ```rust
@@ -121,7 +121,7 @@ fn create_chunk_id(chunks: &[ArrayRef]) -> Vec<usize> {
 ///
 /// `ChunkedArrays` fully support Rust native [Iterator](https://doc.rust-lang.org/std/iter/trait.Iterator.html)
 /// and [DoubleEndedIterator](https://doc.rust-lang.org/std/iter/trait.DoubleEndedIterator.html) traits, thereby
-/// giving access to all the excelent methods available for [Iterators](https://doc.rust-lang.org/std/iter/trait.Iterator.html).
+/// giving access to all the excellent methods available for [Iterators](https://doc.rust-lang.org/std/iter/trait.Iterator.html).
 ///
 /// ```rust
 /// # use polars_core::prelude::*;
@@ -141,7 +141,7 @@ fn create_chunk_id(chunks: &[ArrayRef]) -> Vec<usize> {
 /// # Memory layout
 ///
 /// `ChunkedArray`'s use [Apache Arrow](https://github.com/apache/arrow) as backend for the memory layout.
-/// Arrows memory is immutable which makes it possible to make mutliple zero copy (sub)-views from a single array.
+/// Arrows memory is immutable which makes it possible to make multiple zero copy (sub)-views from a single array.
 ///
 /// To be able to append data, Polars uses chunks to append new memory locations, hence the `ChunkedArray<T>` data structure.
 /// Appends are cheap, because it will not lead to a full reallocation of the whole array (as could be the case with a Rust Vec).
@@ -153,7 +153,7 @@ fn create_chunk_id(chunks: &[ArrayRef]) -> Vec<usize> {
 ///
 /// **The key takeaway is that by applying operations on a `ChunkArray` of multiple chunks, the results will converge to
 /// a `ChunkArray` of a single chunk!** It is recommended to leave them as is. If you want to have predictable performance
-/// (no unexpected re-allocation of memory), it is adviced to call the [rechunk](chunked_array/chunkops/trait.ChunkOps.html) after
+/// (no unexpected re-allocation of memory), it is advised to call the [rechunk](chunked_array/chunkops/trait.ChunkOps.html) after
 /// multiple append operations.
 pub struct ChunkedArray<T> {
     pub(crate) field: Arc<Field>,

--- a/polars/polars-core/src/chunked_array/ops/fill_none.rs
+++ b/polars/polars-core/src/chunked_array/ops/fill_none.rs
@@ -138,7 +138,7 @@ impl ChunkFillNone for BooleanChunked {
                     .ok_or_else(|| PolarsError::Other("Could not determine fill value".into()))?,
             ),
             FillNoneStrategy::Mean => Err(PolarsError::InvalidOperation(
-                "mean not suppoted on array of Boolean type".into(),
+                "mean not supported on array of Boolean type".into(),
             )),
         }
     }

--- a/polars/polars-core/src/doc/changelog/v0_7.rs
+++ b/polars/polars-core/src/doc/changelog/v0_7.rs
@@ -28,5 +28,5 @@
 //!         * (col, lit, lt, lt_eq, alias, etc.)
 //!         * arithmetic
 //!         * when / then /otherwise
-//! * 1.3-1.7 peformance increase of filter
+//! * 1.3-1.7 performance increase of filter
 //! * ChunkedArray/ Series creation speedup: No nulls: 10X speedup, Nulls: 1.1-2.2x speedup.

--- a/polars/polars-core/src/doc/time.rs
+++ b/polars/polars-core/src/doc/time.rs
@@ -38,10 +38,10 @@
 //!
 //! ## String formatting
 //!
-//! We can also directly parse strings given a predifined `fmt: &str`. This uses **chrono's**
+//! We can also directly parse strings given a predefined `fmt: &str`. This uses **chrono's**
 //! [NaiveTime::parse_from_str](https://docs.rs/chrono/0.4.15/chrono/naive/struct.NaiveTime.html#method.parse_from_str)
 //! under the hood. So look there for the different formatting options. If the string parsing is not
-//! succesful, the value will be `None`.
+//! successful, the value will be `None`.
 //!
 //! ### Examples
 //!

--- a/polars/polars-core/src/frame/group_by.rs
+++ b/polars/polars-core/src/frame/group_by.rs
@@ -336,7 +336,7 @@ fn groupby_threaded_multiple_keys_flat(keys: DataFrame, n_threads: usize) -> Gro
 /// Used to create the tuples for a groupby operation.
 pub trait IntoGroupTuples {
     /// Create the tuples need for a groupby operation.
-    ///     * The first value in te tuple is the first index of the group.
+    ///     * The first value in the tuple is the first index of the group.
     ///     * The second value in the tuple is are the indexes of the groups including the first value.
     fn group_tuples(&self, _multithreaded: bool) -> GroupTuples {
         unimplemented!()
@@ -1917,7 +1917,7 @@ impl<'df, 'selection_str> GroupBy<'df, 'selection_str> {
     /// * mean
     /// * median
     ///
-    /// The pivot operation consists of a group by one, or multiple collumns (these will be the new
+    /// The pivot operation consists of a group by one, or multiple columns (these will be the new
     /// y-axis), column that will be pivoted (this will be the new x-axis) and an aggregation.
     ///
     /// # Panics

--- a/polars/polars-core/src/frame/mod.rs
+++ b/polars/polars-core/src/frame/mod.rs
@@ -92,7 +92,7 @@ impl DataFrame {
 
             if names.contains(&name) {
                 return Err(PolarsError::Duplicate(
-                    format!("Column with name: '{}' has more than one occurences", name).into(),
+                    format!("Column with name: '{}' has more than one occurrences", name).into(),
                 ));
             }
 

--- a/polars/polars-io/src/csv.rs
+++ b/polars/polars-io/src/csv.rs
@@ -2,7 +2,7 @@
 //!
 //! ## Maximal performance
 //! Currently [CsvReader::new](CsvReader::new) has an extra copy. If you want optimal performance in CSV parsing/
-//! reading, it is adviced to use [CsvReader::from_path](CsvReader::from_path).
+//! reading, it is advised to use [CsvReader::from_path](CsvReader::from_path).
 //!
 //! ## Write a DataFrame to a csv file.
 //!
@@ -623,13 +623,13 @@ hello,","," ",world,"!""#;
     #[test]
     fn test_very_long_utf8() {
         let csv = r#"column_1,column_2,column_3
--86.64408227,"Lorem Ipsum is simply dummy text of the printing and typesetting 
+-86.64408227,"Lorem Ipsum is simply dummy text of the printing and typesetting
 industry. Lorem Ipsum has been the industry's standard dummy text ever since th
-e 1500s, when an unknown printer took a galley of type and scrambled it to make 
-a type specimen book. It has survived not only five centuries, but also the leap 
-into electronic typesetting, remaining essentially unchanged. It was popularised 
-in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, 
-and more recently with desktop publishing software like Aldus PageMaker including 
+e 1500s, when an unknown printer took a galley of type and scrambled it to make
+a type specimen book. It has survived not only five centuries, but also the leap
+into electronic typesetting, remaining essentially unchanged. It was popularised
+in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages,
+and more recently with desktop publishing software like Aldus PageMaker including
 versions of Lorem Ipsum.",11"#;
         let file = Cursor::new(csv);
         let df = CsvReader::new(file).finish().unwrap();
@@ -637,13 +637,13 @@ versions of Lorem Ipsum.",11"#;
         assert!(df.column("column_2").unwrap().series_equal(&Series::new(
             "column_2",
             &[
-                r#"Lorem Ipsum is simply dummy text of the printing and typesetting 
+                r#"Lorem Ipsum is simply dummy text of the printing and typesetting
 industry. Lorem Ipsum has been the industry's standard dummy text ever since th
-e 1500s, when an unknown printer took a galley of type and scrambled it to make 
-a type specimen book. It has survived not only five centuries, but also the leap 
-into electronic typesetting, remaining essentially unchanged. It was popularised 
-in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, 
-and more recently with desktop publishing software like Aldus PageMaker including 
+e 1500s, when an unknown printer took a galley of type and scrambled it to make
+a type specimen book. It has survived not only five centuries, but also the leap
+into electronic typesetting, remaining essentially unchanged. It was popularised
+in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages,
+and more recently with desktop publishing software like Aldus PageMaker including
 versions of Lorem Ipsum."#,
             ]
         )));

--- a/polars/polars-io/src/csv_core/utils.rs
+++ b/polars/polars-io/src/csv_core/utils.rs
@@ -93,7 +93,7 @@ pub(crate) fn parse_bytes_with_encoding(bytes: &[u8], encoding: CsvEncoding) -> 
 ///
 /// If `max_read_records` is not set, the whole file is read to infer its schema.
 ///
-/// Return infered schema and number of records used for inference.
+/// Return inferred schema and number of records used for inference.
 pub fn infer_file_schema<R: Read + Seek>(
     reader: &mut R,
     delimiter: u8,

--- a/polars/polars-lazy/src/dsl.rs
+++ b/polars/polars-lazy/src/dsl.rs
@@ -415,7 +415,7 @@ impl fmt::Debug for Expr {
                 order_by,
             } => write!(
                 f,
-                "{:?} OVER (PARTION BY {:?} ORDER BY {:?}",
+                "{:?} OVER (PARTITION BY {:?} ORDER BY {:?}",
                 function, partition_by, order_by
             ),
             IsUnique(expr) => write!(f, "UNIQUE {:?}", expr),

--- a/polars/polars-lazy/src/lib.rs
+++ b/polars/polars-lazy/src/lib.rs
@@ -125,7 +125,7 @@
 //!
 //! Below we lazily call a custom closure of type `Series => Result<Series>`. Because the closure
 //! changes the type/variant of the Series we also define the return type. This is important because
-//! due to the lazyness the types should be known beforehand. Note that by applying these custom
+//! due to the laziness the types should be known beforehand. Note that by applying these custom
 //! functions you have access the the whole **eager API** of the Series/ChunkedArrays.
 //!
 //!```rust

--- a/polars/polars-lazy/src/logical_plan/optimizer/predicate_pushdown.rs
+++ b/polars/polars-lazy/src/logical_plan/optimizer/predicate_pushdown.rs
@@ -600,7 +600,7 @@ impl PredicatePushDown {
                 }
 
                 // First we get all names of added columns in this HStack operation
-                // and then we remove the predicates from the elegible container if they are
+                // and then we remove the predicates from the eligible container if they are
                 // dependent on data we've added in this node.
 
                 // *use a vec instead of a set because of the low number of expected columns

--- a/py-polars/polars/frame.py
+++ b/py-polars/polars/frame.py
@@ -324,7 +324,7 @@ class DataFrame:
         delimiter: str = ",",
     ):
         """
-        Write Dataframe to comma-seperated values file (csv)
+        Write Dataframe to comma-separated values file (csv)
 
         Parameters
         ---

--- a/py-polars/polars/functions.py
+++ b/py-polars/polars/functions.py
@@ -85,7 +85,7 @@ def read_csv(
     projection
         Indexes of columns to select
     sep
-        Delimiter/ value seperator
+        Delimiter/ value separator
     columns
         Columns to project/ select
     rechunk

--- a/py-polars/polars/lazy/__init__.py
+++ b/py-polars/polars/lazy/__init__.py
@@ -1357,7 +1357,7 @@ def except_(name: str) -> "Expr":
         .select(["*", except_("foo")])
         .collect()
     ```
-    Ouputs:
+    Outputs:
 
     ```text
     ╭─────┬─────╮

--- a/py-polars/src/dispatch.rs
+++ b/py-polars/src/dispatch.rs
@@ -1026,7 +1026,7 @@ impl<'a> ApplyLambda<'a> for ListChunked {
                     let mut nulls = 0;
 
                     // use first values to get dtype and replace default builders
-                    // continue untill no null is found
+                    // continue until no null is found
                     while let Some(opt_series) = it.next() {
                         if let Some(series) = opt_series {
                             let out_series = call_series_lambda(pypolars, lambda, series)


### PR DESCRIPTION
More small typo fixes 😄. @ritchie46 there's a nice tool [codespell](https://github.com/codespell-project/codespell) for detecting these common errors. It has too many false positives IMO to be useful in CI out of the box (e.g., it thinks "crate" is misspelled by default), but nonetheless can help a lot in partially automating things.