### PR TITLE
Improve Multiple key hash join

### DIFF
--- a/polars/benches/groupby.rs
+++ b/polars/benches/groupby.rs
@@ -10,6 +10,8 @@ lazy_static! {
 
         let mut df = CsvReader::from_path(&path)
             .expect("could not read file")
+            // 1M rows
+            .with_stop_after_n_rows(Some(1000000))
             .finish()
             .unwrap();
         df.may_apply("id1", |s| s.cast::<CategoricalType>())
@@ -180,6 +182,6 @@ fn q10(c: &mut Criterion) {
 }
 
 criterion_group!(name = benches;
-config = Criterion::default().sample_size(10);
+config = Criterion::default().sample_size(100);
 targets = q1, q2, q3, q4, q5, q6, q7, q8, q9, q10);
 criterion_main!(benches);

--- a/polars/polars-core/src/chunked_array/cast.rs
+++ b/polars/polars-core/src/chunked_array/cast.rs
@@ -74,7 +74,8 @@ impl ChunkCast for CategoricalChunked {
                 Ok(ca)
             }
             DataType::UInt32 => {
-                let ca: ChunkedArray<N> = unsafe { std::mem::transmute(self.clone()) };
+                let mut ca: ChunkedArray<N> = unsafe { std::mem::transmute(self.clone()) };
+                ca.field = Arc::new(Field::new(ca.name(), DataType::UInt32));
                 Ok(ca)
             }
             _ => cast_ca(self),
@@ -94,7 +95,8 @@ where
         use DataType::*;
         let ca = match (T::get_dtype(), N::get_dtype()) {
             (UInt32, Categorical) => {
-                let ca: ChunkedArray<N> = unsafe { std::mem::transmute(self.clone()) };
+                let mut ca: ChunkedArray<N> = unsafe { std::mem::transmute(self.clone()) };
+                ca.field = Arc::new(Field::new(ca.name(), DataType::Categorical));
                 return Ok(ca);
             }
             // underlying type: i64

--- a/polars/polars-core/src/chunked_array/comparison.rs
+++ b/polars/polars-core/src/chunked_array/comparison.rs
@@ -687,8 +687,8 @@ impl BooleanChunked {
 // private
 pub(crate) trait ChunkEqualElement {
     /// Check if element in self is equal to element in other, assumes same dtypes
-    /// # Safety:
-    ///     No bounds checks and not type checks.
+    /// # Safety
+    ///     No bounds checks and no type checks.
     unsafe fn equal_element(&self, _idx_self: usize, _idx_other: usize, _other: &Series) -> bool {
         unimplemented!()
     }

--- a/polars/polars-core/src/chunked_array/comparison.rs
+++ b/polars/polars-core/src/chunked_array/comparison.rs
@@ -687,8 +687,10 @@ impl BooleanChunked {
 // private
 pub(crate) trait ChunkEqualElement {
     /// Check if element in self is equal to element in other, assumes same dtypes
+    ///
     /// # Safety
-    ///     No bounds checks and no type checks.
+    ///
+    /// No bounds checks and no type checks.
     unsafe fn equal_element(&self, _idx_self: usize, _idx_other: usize, _other: &Series) -> bool {
         unimplemented!()
     }

--- a/polars/polars-core/src/chunked_array/comparison.rs
+++ b/polars/polars-core/src/chunked_array/comparison.rs
@@ -664,67 +664,8 @@ impl Not for BooleanChunked {
     }
 }
 
-pub trait CompToSeries {
-    fn lt_series(&self, _rhs: &Series) -> BooleanChunked {
-        unimplemented!()
-    }
-
-    fn gt_series(&self, _rhs: &Series) -> BooleanChunked {
-        unimplemented!()
-    }
-
-    fn gt_eq_series(&self, _rhs: &Series) -> BooleanChunked {
-        unimplemented!()
-    }
-
-    fn lt_eq_series(&self, _rhs: &Series) -> BooleanChunked {
-        unimplemented!()
-    }
-
-    fn eq_series(&self, _rhs: &Series) -> BooleanChunked {
-        unimplemented!()
-    }
-
-    fn neq_series(&self, _rhs: &Series) -> BooleanChunked {
-        unimplemented!()
-    }
-}
-
-impl<T> CompToSeries for ChunkedArray<T>
-where
-    T: PolarsSingleType,
-    ChunkedArray<T>: IntoSeries,
-{
-    fn lt_series(&self, rhs: &Series) -> BooleanChunked {
-        ChunkCompare::<&Series>::lt(&self.clone().into_series(), rhs)
-    }
-
-    fn gt_series(&self, rhs: &Series) -> BooleanChunked {
-        ChunkCompare::<&Series>::gt(&self.clone().into_series(), rhs)
-    }
-
-    fn gt_eq_series(&self, rhs: &Series) -> BooleanChunked {
-        ChunkCompare::<&Series>::gt_eq(&self.clone().into_series(), rhs)
-    }
-
-    fn lt_eq_series(&self, rhs: &Series) -> BooleanChunked {
-        ChunkCompare::<&Series>::lt_eq(&self.clone().into_series(), rhs)
-    }
-
-    fn eq_series(&self, rhs: &Series) -> BooleanChunked {
-        ChunkCompare::<&Series>::eq(&self.clone().into_series(), rhs)
-    }
-
-    fn neq_series(&self, rhs: &Series) -> BooleanChunked {
-        ChunkCompare::<&Series>::neq(&self.clone().into_series(), rhs)
-    }
-}
-
-impl CompToSeries for ListChunked {}
-#[cfg(feature = "object")]
-impl<T> CompToSeries for ObjectChunked<T> {}
-
 impl BooleanChunked {
+    /// Check if all values are true
     pub fn all_true(&self) -> bool {
         match self.sum() {
             None => false,
@@ -734,6 +675,7 @@ impl BooleanChunked {
 }
 
 impl BooleanChunked {
+    /// Check if all values are false
     pub fn all_false(&self) -> bool {
         match self.sum() {
             None => false,
@@ -746,15 +688,16 @@ impl BooleanChunked {
 pub(crate) trait ChunkEqualElement {
     /// Check if element in self is equal to element in other, assumes same dtypes
     /// # Safety:
-    ///     no bounds checks
+    ///     No bounds checks and not type checks.
     unsafe fn equal_element(&self, _idx_self: usize, _idx_other: usize, _other: &Series) -> bool {
         unimplemented!()
     }
 }
 
 impl<T> ChunkEqualElement for ChunkedArray<T>
-where T: PolarsNumericType,
-    T::Native: PartialEq
+where
+    T: PolarsNumericType,
+    T::Native: PartialEq,
 {
     unsafe fn equal_element(&self, idx_self: usize, idx_other: usize, other: &Series) -> bool {
         let ca_other = other.as_ref().as_ref();
@@ -764,8 +707,7 @@ where T: PolarsNumericType,
     }
 }
 
-impl ChunkEqualElement for BooleanChunked
-{
+impl ChunkEqualElement for BooleanChunked {
     unsafe fn equal_element(&self, idx_self: usize, idx_other: usize, other: &Series) -> bool {
         let ca_other = other.as_ref().as_ref();
         debug_assert!(self.dtype() == other.dtype());
@@ -774,8 +716,7 @@ impl ChunkEqualElement for BooleanChunked
     }
 }
 
-impl ChunkEqualElement for Utf8Chunked
-{
+impl ChunkEqualElement for Utf8Chunked {
     unsafe fn equal_element(&self, idx_self: usize, idx_other: usize, other: &Series) -> bool {
         let ca_other = other.as_ref().as_ref();
         debug_assert!(self.dtype() == other.dtype());

--- a/polars/polars-core/src/chunked_array/ops/mod.rs
+++ b/polars/polars-core/src/chunked_array/ops/mod.rs
@@ -41,10 +41,13 @@ pub trait ChunkCumAgg<T> {
     }
 }
 
+/// Traverse and collect every nth element
 pub trait ChunkTakeEvery<T> {
+    /// Traverse and collect every nth element in a new array.
     fn take_every(&self, n: usize) -> ChunkedArray<T>;
 }
 
+/// Explode/ flatten a
 pub trait ChunkExplode {
     fn explode(&self) -> Result<Series> {
         self.explode_and_offsets().map(|t| t.0)
@@ -56,6 +59,7 @@ pub trait ChunkBytes {
     fn to_byte_slices(&self) -> Vec<&[u8]>;
 }
 
+/// Rolling window functions
 pub trait ChunkWindow {
     /// apply a rolling sum (moving sum) over the values in this array.
     /// a window of length `window_size` will traverse the array. the values that fill this window
@@ -172,6 +176,7 @@ pub trait ChunkWindow {
     }
 }
 
+/// Custom rolling window functions
 pub trait ChunkWindowCustom<T> {
     /// Apply a rolling aggregation over the values in this array.
     ///
@@ -867,6 +872,7 @@ pub trait ChunkApplyKernel<A> {
         S: PolarsDataType;
 }
 
+/// Find local minima/ maxima
 pub trait ChunkPeaks {
     /// Get a boolean mask of the local maximum peaks.
     fn peak_max(&self) -> BooleanChunked {
@@ -879,6 +885,7 @@ pub trait ChunkPeaks {
     }
 }
 
+/// Check if element is member of list array
 pub trait IsIn {
     /// Check if the element of this array is in the elements of the list array
     fn is_in(&self, _list_array: &ListChunked) -> Result<BooleanChunked> {
@@ -886,10 +893,13 @@ pub trait IsIn {
     }
 }
 
+/// Argmin/ Argmax
 pub trait ArgAgg {
+    /// Get the index of the minimal value
     fn arg_min(&self) -> Option<usize> {
         None
     }
+    /// Get the index of the maximal value
     fn arg_max(&self) -> Option<usize> {
         None
     }

--- a/polars/polars-core/src/fmt.rs
+++ b/polars/polars-core/src/fmt.rs
@@ -616,7 +616,7 @@ impl<T> FmtList for ObjectChunked<T> {
     }
 }
 
-#[cfg(all(test, feature = "temporal"))]
+#[cfg(all(test, feature = "temporal", feature="dtype-date32", feature = "dtype-date64"))]
 mod test {
     use crate::prelude::*;
     use polars_arrow::prelude::PrimitiveArrayBuilder;

--- a/polars/polars-core/src/fmt.rs
+++ b/polars/polars-core/src/fmt.rs
@@ -616,7 +616,12 @@ impl<T> FmtList for ObjectChunked<T> {
     }
 }
 
-#[cfg(all(test, feature = "temporal", feature="dtype-date32", feature = "dtype-date64"))]
+#[cfg(all(
+    test,
+    feature = "temporal",
+    feature = "dtype-date32",
+    feature = "dtype-date64"
+))]
 mod test {
     use crate::prelude::*;
     use polars_arrow::prelude::PrimitiveArrayBuilder;

--- a/polars/polars-core/src/frame/explode.rs
+++ b/polars/polars-core/src/frame/explode.rs
@@ -198,7 +198,7 @@ mod test {
     use crate::prelude::*;
 
     #[test]
-    #[cfg(feature="dtype-i8")]
+    #[cfg(feature = "dtype-i8")]
     fn test_explode() {
         let s0 = Series::new("a", &[1i8, 2, 3]);
         let s1 = Series::new("b", &[1i8, 1, 1]);

--- a/polars/polars-core/src/frame/explode.rs
+++ b/polars/polars-core/src/frame/explode.rs
@@ -198,6 +198,7 @@ mod test {
     use crate::prelude::*;
 
     #[test]
+    #[cfg(feature="dtype-i8")]
     fn test_explode() {
         let s0 = Series::new("a", &[1i8, 2, 3]);
         let s1 = Series::new("b", &[1i8, 1, 1]);

--- a/polars/polars-core/src/frame/groupby/mod.rs
+++ b/polars/polars-core/src/frame/groupby/mod.rs
@@ -241,7 +241,7 @@ where
 pub(crate) unsafe fn compare_df_rows(keys: &DataFrame, idx_a: usize, idx_b: usize) -> bool {
     for s in keys.get_columns() {
         if !s.equal_element(idx_a, idx_b, s) {
-            return false
+            return false;
         }
     }
     true
@@ -2011,7 +2011,7 @@ mod test {
     use crate::utils::split_ca;
 
     #[test]
-    #[cfg(feature="dtype-date32")]
+    #[cfg(feature = "dtype-date32")]
     fn test_group_by() {
         let s0 = Date32Chunked::parse_from_str_slice(
             "date",

--- a/polars/polars-core/src/frame/groupby/mod.rs
+++ b/polars/polars-core/src/frame/groupby/mod.rs
@@ -2225,12 +2225,14 @@ mod test {
                     "ham" => ["a", "a", "b", "b", "c"],
                     "bar" => [1, 1, 1, 1, 1]
         }
+        .unwrap();
+
+        df.apply("foo", |s| s.cast::<CategoricalType>().unwrap())
             .unwrap();
 
-        df.apply("foo", |s| s.cast::<CategoricalType>().unwrap());
-
         // check multiple keys and categorical
-        let res = df.groupby_stable(&["foo", "ham"])
+        let res = df
+            .groupby_stable(&["foo", "ham"])
             .unwrap()
             .select("bar")
             .sum()
@@ -2240,7 +2242,6 @@ mod test {
             Vec::from(res.column("bar_sum").unwrap().i32().unwrap()),
             &[Some(2), Some(2), Some(1)]
         );
-
     }
 
     #[test]

--- a/polars/polars-core/src/frame/groupby/mod.rs
+++ b/polars/polars-core/src/frame/groupby/mod.rs
@@ -2220,6 +2220,30 @@ mod test {
     }
 
     #[test]
+    fn test_groupby_categorical() {
+        let mut df = df! {"foo" => ["a", "a", "b", "b", "c"],
+                    "ham" => ["a", "a", "b", "b", "c"],
+                    "bar" => [1, 1, 1, 1, 1]
+        }
+            .unwrap();
+
+        df.apply("foo", |s| s.cast::<CategoricalType>().unwrap());
+
+        // check multiple keys and categorical
+        let res = df.groupby_stable(&["foo", "ham"])
+            .unwrap()
+            .select("bar")
+            .sum()
+            .unwrap();
+
+        assert_eq!(
+            Vec::from(res.column("bar_sum").unwrap().i32().unwrap()),
+            &[Some(2), Some(2), Some(1)]
+        );
+
+    }
+
+    #[test]
     fn test_groupby_apply() {
         let df = df! {
             "a" => [1, 1, 2, 2, 2],

--- a/polars/polars-core/src/frame/groupby/mod.rs
+++ b/polars/polars-core/src/frame/groupby/mod.rs
@@ -242,8 +242,6 @@ pub(crate) unsafe fn compare_df_rows(keys: &DataFrame, idx_a: u32, idx_b: u32) -
     let idx_a = idx_a as usize;
     let idx_b = idx_b as usize;
     for s in keys.get_columns() {
-        dbg!(idx_a, idx_b, s.get_unchecked(idx_a), s.get_unchecked(idx_b));
-
         if !(s.get_unchecked(idx_a) == s.get_unchecked(idx_b)) {
             return false;
         }

--- a/polars/polars-core/src/frame/groupby/mod.rs
+++ b/polars/polars-core/src/frame/groupby/mod.rs
@@ -238,12 +238,10 @@ where
 ///
 /// # Safety
 /// Doesn't check any bounds
-pub(crate) unsafe fn compare_df_rows(keys: &DataFrame, idx_a: u32, idx_b: u32) -> bool {
-    let idx_a = idx_a as usize;
-    let idx_b = idx_b as usize;
+pub(crate) unsafe fn compare_df_rows(keys: &DataFrame, idx_a: usize, idx_b: usize) -> bool {
     for s in keys.get_columns() {
-        if !(s.get_unchecked(idx_a) == s.get_unchecked(idx_b)) {
-            return false;
+        if !s.equal_element(idx_a, idx_b, s) {
+            return false
         }
     }
     true
@@ -280,7 +278,7 @@ pub(crate) fn populate_multiple_key_hashmap<V, H, F, G>(
             let key_idx = idx_hash.idx;
             // Safety:
             // indices in a groupby operation are always in bounds.
-            unsafe { compare_df_rows(keys, key_idx, idx) }
+            unsafe { compare_df_rows(keys, key_idx as usize, idx as usize) }
         });
     match entry {
         RawEntryMut::Vacant(entry) => {
@@ -2013,6 +2011,7 @@ mod test {
     use crate::utils::split_ca;
 
     #[test]
+    #[cfg(feature="dtype-date32")]
     fn test_group_by() {
         let s0 = Date32Chunked::parse_from_str_slice(
             "date",

--- a/polars/polars-core/src/frame/hash_join/mod.rs
+++ b/polars/polars-core/src/frame/hash_join/mod.rs
@@ -1,3 +1,5 @@
+mod multiple_keys;
+
 use crate::frame::select::Selection;
 use crate::prelude::*;
 use crate::utils::{split_ca, NoNull};

--- a/polars/polars-core/src/frame/hash_join/multiple_keys.rs
+++ b/polars/polars-core/src/frame/hash_join/multiple_keys.rs
@@ -1,0 +1,138 @@
+use crate::frame::groupby::populate_multiple_key_hashmap;
+use crate::frame::hash_join::n_join_threads;
+use crate::prelude::*;
+use crate::utils::split_df;
+use crate::vector_hasher::{
+    df_rows_to_hashes, df_rows_to_hashes_threaded, this_thread, IdBuildHasher, IdxHash,
+};
+use crate::POOL;
+use ahash::RandomState;
+use hashbrown::HashMap;
+use rayon::prelude::*;
+
+fn create_build_table(
+    hashes: &[UInt64Chunked],
+    keys: &DataFrame,
+) -> Vec<HashMap<IdxHash, Vec<u32>, IdBuildHasher>> {
+    // POOL.install(|| {
+    //     hashes.into_par_iter()
+    // })
+    // let mut tbl = HashMap::with_capacity_and_hasher(hashes, IdBuildHasher::default());
+    let n_threads = hashes.len();
+    let size = hashes.iter().fold(0, |acc, v| acc + v.len());
+
+    // We will create a hashtable in every thread.
+    // We use the hash to partition the keys to the matching hashtable.
+    // Every thread traverses all keys/hashes and ignores the ones that doesn't fall in that partition.
+    POOL.install(|| {
+        (0..n_threads).into_par_iter().map(|thread_no| {
+            let thread_no = thread_no as u64;
+            // TODO:: benchmark size
+            let mut hash_tbl: HashMap<IdxHash, Vec<u32>, IdBuildHasher> =
+                HashMap::with_capacity_and_hasher(size / (5 * n_threads), IdBuildHasher::default());
+
+            let n_threads = n_threads as u64;
+            let mut offset = 0;
+            for hashes in hashes {
+                for hashes in hashes.data_views() {
+                    let len = hashes.len();
+                    let mut idx = 0;
+                    hashes.iter().for_each(|h| {
+                        // partition hashes by thread no.
+                        // So only a part of the hashes go to this hashmap
+                        if this_thread(*h, thread_no, n_threads) {
+                            let idx = idx + offset;
+                            populate_multiple_key_hashmap(
+                                &mut hash_tbl,
+                                idx,
+                                *h,
+                                keys,
+                                vec![idx],
+                                |v| v.push(idx),
+                            )
+                        }
+                        idx += 1;
+                    });
+
+                    offset += len as u32;
+                }
+            }
+            hash_tbl
+        })
+    })
+    .collect()
+}
+
+fn inner_join_multiple_keys(left: &DataFrame, right: &DataFrame, swap: bool) {
+    // we assume that the left DataFrame is the shorter relation.
+    // left will be used for the build phase.
+
+    let n_threads = n_join_threads();
+    let left_dfs = split_df(&left, n_threads).unwrap();
+    let right_dfs = split_df(&right, n_threads).unwrap();
+
+    let (build_hashes, random_state) = df_rows_to_hashes_threaded(&left_dfs, None);
+    let (probe_hashes, random_state) = df_rows_to_hashes_threaded(&right_dfs, Some(random_state));
+
+    todo!()
+
+    // let n_tables = hash_tbls.len() as u64;
+    // let offsets = probe_hashes
+    //     .iter()
+    //     .map(|ph| ph.len())
+    //     .scan(0, |state, val| {
+    //         let out = *state;
+    //         *state += val;
+    //         Some(out)
+    //     })
+    //     .collect::<Vec<_>>();
+    // // next we probe the other relation
+    // // code duplication is because we want to only do the swap check once
+    // POOL.install(|| {
+    //     probe_hashes
+    //         .into_par_iter()
+    //         .zip(offsets)
+    //         .map(|(probe_hashes, offset)| {
+    //             // local reference
+    //             let hash_tbls = &hash_tbls;
+    //             let mut results =
+    //                 Vec::with_capacity(probe_hashes.len() / POOL.current_num_threads());
+    //             let local_offset = offset;
+    //             // code duplication is to hoist swap out of the inner loop.
+    //             if swap {
+    //                 probe_hashes.iter().enumerate().for_each(|(idx_a, (h, k))| {
+    //                     let idx_a = (idx_a + local_offset) as u32;
+    //                     // probe table that contains the hashed value
+    //                     let current_probe_table = unsafe { get_hash_tbl(*h, hash_tbls, n_tables) };
+    //
+    //                     let entry = current_probe_table
+    //                         .raw_entry()
+    //                         .from_key_hashed_nocheck(*h, k);
+    //
+    //                     if let Some((_, indexes_b)) = entry {
+    //                         let tuples = indexes_b.iter().map(|&idx_b| (idx_b, idx_a));
+    //                         results.extend(tuples);
+    //                     }
+    //                 });
+    //             } else {
+    //                 probe_hashes.iter().enumerate().for_each(|(idx_a, (h, k))| {
+    //                     let idx_a = (idx_a + local_offset) as u32;
+    //                     // probe table that contains the hashed value
+    //                     let current_probe_table = unsafe { get_hash_tbl(*h, hash_tbls, n_tables) };
+    //
+    //                     let entry = current_probe_table
+    //                         .raw_entry()
+    //                         .from_key_hashed_nocheck(*h, k);
+    //
+    //                     if let Some((_, indexes_b)) = entry {
+    //                         let tuples = indexes_b.iter().map(|&idx_b| (idx_a, idx_b));
+    //                         results.extend(tuples);
+    //                     }
+    //                 });
+    //             }
+    //
+    //             results
+    //         })
+    //         .flatten()
+    //         .collect()
+}

--- a/polars/polars-core/src/frame/hash_join/multiple_keys.rs
+++ b/polars/polars-core/src/frame/hash_join/multiple_keys.rs
@@ -14,10 +14,6 @@ fn create_build_table(
     hashes: &[UInt64Chunked],
     keys: &DataFrame,
 ) -> Vec<HashMap<IdxHash, Vec<u32>, IdBuildHasher>> {
-    // POOL.install(|| {
-    //     hashes.into_par_iter()
-    // })
-    // let mut tbl = HashMap::with_capacity_and_hasher(hashes, IdBuildHasher::default());
     let n_threads = hashes.len();
     let size = hashes.iter().fold(0, |acc, v| acc + v.len());
 
@@ -74,7 +70,11 @@ fn inner_join_multiple_keys(left: &DataFrame, right: &DataFrame, swap: bool) {
     let (build_hashes, random_state) = df_rows_to_hashes_threaded(&left_dfs, None);
     let (probe_hashes, random_state) = df_rows_to_hashes_threaded(&right_dfs, Some(random_state));
 
-    todo!()
+    let hash_tbls = create_build_table(&build_hashes, left);
+    // early drop to reduce memory pressure
+    drop(build_hashes);
+
+    todo!();
 
     // let n_tables = hash_tbls.len() as u64;
     // let offsets = probe_hashes
@@ -86,8 +86,8 @@ fn inner_join_multiple_keys(left: &DataFrame, right: &DataFrame, swap: bool) {
     //         Some(out)
     //     })
     //     .collect::<Vec<_>>();
-    // // next we probe the other relation
-    // // code duplication is because we want to only do the swap check once
+    // next we probe the other relation
+    // code duplication is because we want to only do the swap check once
     // POOL.install(|| {
     //     probe_hashes
     //         .into_par_iter()

--- a/polars/polars-core/src/frame/hash_join/multiple_keys.rs
+++ b/polars/polars-core/src/frame/hash_join/multiple_keys.rs
@@ -1,14 +1,26 @@
 use crate::frame::groupby::populate_multiple_key_hashmap;
-use crate::frame::hash_join::n_join_threads;
+use crate::frame::hash_join::{get_hash_tbl_threaded_join, n_join_threads};
 use crate::prelude::*;
 use crate::utils::split_df;
-use crate::vector_hasher::{
-    df_rows_to_hashes, df_rows_to_hashes_threaded, this_thread, IdBuildHasher, IdxHash,
-};
+use crate::vector_hasher::{df_rows_to_hashes_threaded, this_thread, IdBuildHasher, IdxHash};
 use crate::POOL;
-use ahash::RandomState;
 use hashbrown::HashMap;
 use rayon::prelude::*;
+
+/// Compare the rows of two DataFrames
+unsafe fn compare_df_rows2(
+    left: &DataFrame,
+    right: &DataFrame,
+    left_idx: usize,
+    right_idx: usize,
+) -> bool {
+    for (l, r) in left.get_columns().iter().zip(right.get_columns()) {
+        if !(l.get_unchecked(left_idx) == r.get_unchecked(right_idx)) {
+            return false;
+        }
+    }
+    true
+}
 
 fn create_build_table(
     hashes: &[UInt64Chunked],
@@ -43,7 +55,7 @@ fn create_build_table(
                                 idx,
                                 *h,
                                 keys,
-                                vec![idx],
+                                || vec![idx],
                                 |v| v.push(idx),
                             )
                         }
@@ -59,80 +71,111 @@ fn create_build_table(
     .collect()
 }
 
-fn inner_join_multiple_keys(left: &DataFrame, right: &DataFrame, swap: bool) {
-    // we assume that the left DataFrame is the shorter relation.
-    // left will be used for the build phase.
+/// Probe the build table and add tuples to the results (inner join)
+fn probe_inner<F>(
+    probe_hashes: &UInt64Chunked,
+    hash_tbls: &[HashMap<IdxHash, Vec<u32>, IdBuildHasher>],
+    results: &mut Vec<(u32, u32)>,
+    local_offset: usize,
+    n_tables: u64,
+    left: &DataFrame,
+    right: &DataFrame,
+    swap_fn: F,
+) where
+    F: Fn(u32, u32) -> (u32, u32),
+{
+    let mut idx_a = local_offset as u32;
+    for probe_hashes in probe_hashes.data_views() {
+        for &h in probe_hashes {
+            // probe table that contains the hashed value
+            let current_probe_table = unsafe { get_hash_tbl_threaded_join(h, hash_tbls, n_tables) };
+
+            let entry = current_probe_table.raw_entry().from_hash(h, |idx_hash| {
+                let idx_b = idx_hash.idx;
+                // Safety:
+                // indices in a join operation are always in bounds.
+                unsafe { compare_df_rows2(left, right, idx_a as usize, idx_b as usize) }
+            });
+
+            if let Some((_, indexes_b)) = entry {
+                let tuples = indexes_b.iter().map(|&idx_b| swap_fn(idx_a, idx_b));
+                results.extend(tuples);
+            }
+            idx_a += 1;
+        }
+    }
+}
+
+pub(crate) fn inner_join_multiple_keys(
+    a: &DataFrame,
+    b: &DataFrame,
+    swap: bool,
+) -> Vec<(u32, u32)> {
+    // we assume that the right DataFrame is the shorter relation.
+    // b will be used for the build phase.
 
     let n_threads = n_join_threads();
-    let left_dfs = split_df(&left, n_threads).unwrap();
-    let right_dfs = split_df(&right, n_threads).unwrap();
+    let dfs_a = split_df(&a, n_threads).unwrap();
+    let dfs_b = split_df(&b, n_threads).unwrap();
 
-    let (build_hashes, random_state) = df_rows_to_hashes_threaded(&left_dfs, None);
-    let (probe_hashes, random_state) = df_rows_to_hashes_threaded(&right_dfs, Some(random_state));
+    let (build_hashes, random_state) = df_rows_to_hashes_threaded(&dfs_b, None);
+    let (probe_hashes, _) = df_rows_to_hashes_threaded(&dfs_a, Some(random_state));
 
-    let hash_tbls = create_build_table(&build_hashes, left);
+    let hash_tbls = create_build_table(&build_hashes, b);
     // early drop to reduce memory pressure
     drop(build_hashes);
 
-    todo!();
+    let n_tables = hash_tbls.len() as u64;
+    let offsets = probe_hashes
+        .iter()
+        .map(|ph| ph.len())
+        .scan(0, |state, val| {
+            let out = *state;
+            *state += val;
+            Some(out)
+        })
+        .collect::<Vec<_>>();
 
-    // let n_tables = hash_tbls.len() as u64;
-    // let offsets = probe_hashes
-    //     .iter()
-    //     .map(|ph| ph.len())
-    //     .scan(0, |state, val| {
-    //         let out = *state;
-    //         *state += val;
-    //         Some(out)
-    //     })
-    //     .collect::<Vec<_>>();
     // next we probe the other relation
     // code duplication is because we want to only do the swap check once
-    // POOL.install(|| {
-    //     probe_hashes
-    //         .into_par_iter()
-    //         .zip(offsets)
-    //         .map(|(probe_hashes, offset)| {
-    //             // local reference
-    //             let hash_tbls = &hash_tbls;
-    //             let mut results =
-    //                 Vec::with_capacity(probe_hashes.len() / POOL.current_num_threads());
-    //             let local_offset = offset;
-    //             // code duplication is to hoist swap out of the inner loop.
-    //             if swap {
-    //                 probe_hashes.iter().enumerate().for_each(|(idx_a, (h, k))| {
-    //                     let idx_a = (idx_a + local_offset) as u32;
-    //                     // probe table that contains the hashed value
-    //                     let current_probe_table = unsafe { get_hash_tbl(*h, hash_tbls, n_tables) };
-    //
-    //                     let entry = current_probe_table
-    //                         .raw_entry()
-    //                         .from_key_hashed_nocheck(*h, k);
-    //
-    //                     if let Some((_, indexes_b)) = entry {
-    //                         let tuples = indexes_b.iter().map(|&idx_b| (idx_b, idx_a));
-    //                         results.extend(tuples);
-    //                     }
-    //                 });
-    //             } else {
-    //                 probe_hashes.iter().enumerate().for_each(|(idx_a, (h, k))| {
-    //                     let idx_a = (idx_a + local_offset) as u32;
-    //                     // probe table that contains the hashed value
-    //                     let current_probe_table = unsafe { get_hash_tbl(*h, hash_tbls, n_tables) };
-    //
-    //                     let entry = current_probe_table
-    //                         .raw_entry()
-    //                         .from_key_hashed_nocheck(*h, k);
-    //
-    //                     if let Some((_, indexes_b)) = entry {
-    //                         let tuples = indexes_b.iter().map(|&idx_b| (idx_a, idx_b));
-    //                         results.extend(tuples);
-    //                     }
-    //                 });
-    //             }
-    //
-    //             results
-    //         })
-    //         .flatten()
-    //         .collect()
+    POOL.install(|| {
+        probe_hashes
+            .into_par_iter()
+            .zip(offsets)
+            .map(|(probe_hashes, offset)| {
+                // local reference
+                let hash_tbls = &hash_tbls;
+                let mut results =
+                    Vec::with_capacity(probe_hashes.len() / POOL.current_num_threads());
+                let local_offset = offset;
+                // code duplication is to hoist swap out of the inner loop.
+                if swap {
+                    probe_inner(
+                        &probe_hashes,
+                        hash_tbls,
+                        &mut results,
+                        local_offset,
+                        n_tables,
+                        a,
+                        b,
+                        |idx_a, idx_b| (idx_b, idx_a),
+                    )
+                } else {
+                    probe_inner(
+                        &probe_hashes,
+                        hash_tbls,
+                        &mut results,
+                        local_offset,
+                        n_tables,
+                        a,
+                        b,
+                        |idx_a, idx_b| (idx_a, idx_b),
+                    )
+                }
+
+                results
+            })
+            .flatten()
+            .collect()
+    })
 }

--- a/polars/polars-core/src/prelude.rs
+++ b/polars/polars-core/src/prelude.rs
@@ -7,7 +7,7 @@ pub use crate::{
             ListPrimitiveChunkedBuilder, ListUtf8ChunkedBuilder, NewChunkedArray,
             PrimitiveChunkedBuilder, Utf8ChunkedBuilder,
         },
-        comparison::{CompToSeries, NumComp},
+        comparison::NumComp,
         iterator::{IntoNoNullIterator, PolarsIterator},
         ops::{
             aggregate::*,

--- a/polars/polars-core/src/series/implementations/dates.rs
+++ b/polars/polars-core/src/series/implementations/dates.rs
@@ -10,6 +10,7 @@ use super::private;
 use super::IntoSeries;
 use super::SeriesTrait;
 use super::SeriesWrap;
+use crate::chunked_array::comparison::*;
 use crate::chunked_array::AsSinglePtr;
 use crate::fmt::FmtList;
 #[cfg(feature = "pivot")]
@@ -19,7 +20,6 @@ use crate::prelude::*;
 use ahash::RandomState;
 use arrow::array::{ArrayData, ArrayRef};
 use arrow::buffer::Buffer;
-use crate::chunked_array::comparison::*;
 
 impl<T> ChunkedArray<T> {
     /// get the physical memory type of a date type
@@ -105,7 +105,12 @@ macro_rules! impl_dyn_series {
         }
 
         impl private::PrivateSeries for SeriesWrap<$ca> {
-            unsafe fn equal_element(&self, idx_self: usize, idx_other: usize, other: &Series) -> bool {
+            unsafe fn equal_element(
+                &self,
+                idx_self: usize,
+                idx_other: usize,
+                other: &Series,
+            ) -> bool {
                 self.0.equal_element(idx_self, idx_other, other)
             }
 

--- a/polars/polars-core/src/series/implementations/dates.rs
+++ b/polars/polars-core/src/series/implementations/dates.rs
@@ -19,6 +19,7 @@ use crate::prelude::*;
 use ahash::RandomState;
 use arrow::array::{ArrayData, ArrayRef};
 use arrow::buffer::Buffer;
+use crate::chunked_array::comparison::*;
 
 impl<T> ChunkedArray<T> {
     /// get the physical memory type of a date type
@@ -104,6 +105,10 @@ macro_rules! impl_dyn_series {
         }
 
         impl private::PrivateSeries for SeriesWrap<$ca> {
+            unsafe fn equal_element(&self, idx_self: usize, idx_other: usize, other: &Series) -> bool {
+                self.0.equal_element(idx_self, idx_other, other)
+            }
+
             fn zip_with_same_type(&self, mask: &BooleanChunked, other: &Series) -> Result<Series> {
                 try_physical_dispatch!(self, zip_with_same_type, mask, other)
             }

--- a/polars/polars-core/src/series/implementations/mod.rs
+++ b/polars/polars-core/src/series/implementations/mod.rs
@@ -12,6 +12,7 @@ pub mod object;
 use super::private;
 use super::IntoSeries;
 use super::SeriesTrait;
+use crate::chunked_array::comparison::*;
 use crate::chunked_array::{
     ops::aggregate::{ChunkAggSeries, VarAggSeries},
     AsSinglePtr,
@@ -27,7 +28,6 @@ use arrow::array::{ArrayData, ArrayRef};
 use arrow::buffer::Buffer;
 use std::borrow::Cow;
 use std::ops::Deref;
-use crate::chunked_array::comparison::*;
 
 // Utility wrapper struct
 pub(crate) struct SeriesWrap<T>(pub T);
@@ -55,8 +55,12 @@ macro_rules! impl_dyn_series {
         }
 
         impl private::PrivateSeries for SeriesWrap<$ca> {
-
-            unsafe fn equal_element(&self, idx_self: usize, idx_other: usize, other: &Series) -> bool {
+            unsafe fn equal_element(
+                &self,
+                idx_self: usize,
+                idx_other: usize,
+                other: &Series,
+            ) -> bool {
                 self.0.equal_element(idx_self, idx_other, other)
             }
 

--- a/polars/polars-core/src/series/implementations/mod.rs
+++ b/polars/polars-core/src/series/implementations/mod.rs
@@ -27,6 +27,7 @@ use arrow::array::{ArrayData, ArrayRef};
 use arrow::buffer::Buffer;
 use std::borrow::Cow;
 use std::ops::Deref;
+use crate::chunked_array::comparison::*;
 
 // Utility wrapper struct
 pub(crate) struct SeriesWrap<T>(pub T);
@@ -54,6 +55,11 @@ macro_rules! impl_dyn_series {
         }
 
         impl private::PrivateSeries for SeriesWrap<$ca> {
+
+            unsafe fn equal_element(&self, idx_self: usize, idx_other: usize, other: &Series) -> bool {
+                self.0.equal_element(idx_self, idx_other, other)
+            }
+
             fn zip_with_same_type(&self, mask: &BooleanChunked, other: &Series) -> Result<Series> {
                 ChunkZip::zip_with(&self.0, mask, other.as_ref().as_ref())
                     .map(|ca| ca.into_series())

--- a/polars/polars-core/src/series/mod.rs
+++ b/polars/polars-core/src/series/mod.rs
@@ -36,6 +36,9 @@ pub(crate) mod private {
     use ahash::RandomState;
 
     pub trait PrivateSeries {
+        unsafe fn equal_element(&self, _idx_self: usize, _idx_other: usize, _other: &Series) -> bool {
+            unimplemented!()
+        }
         fn vec_hash(&self, _random_state: RandomState) -> UInt64Chunked {
             unimplemented!()
         }

--- a/polars/polars-core/src/series/mod.rs
+++ b/polars/polars-core/src/series/mod.rs
@@ -36,7 +36,12 @@ pub(crate) mod private {
     use ahash::RandomState;
 
     pub trait PrivateSeries {
-        unsafe fn equal_element(&self, _idx_self: usize, _idx_other: usize, _other: &Series) -> bool {
+        unsafe fn equal_element(
+            &self,
+            _idx_self: usize,
+            _idx_other: usize,
+            _other: &Series,
+        ) -> bool {
             unimplemented!()
         }
         fn vec_hash(&self, _random_state: RandomState) -> UInt64Chunked {

--- a/polars/polars-core/src/vector_hasher.rs
+++ b/polars/polars-core/src/vector_hasher.rs
@@ -38,6 +38,7 @@ impl Default for IdHasher {
 
 pub(crate) type IdBuildHasher = BuildHasherDefault<IdHasher>;
 
+#[derive(Debug)]
 pub(crate) struct IdxHash {
     // idx in row of Series, DataFrame
     pub(crate) idx: u32,

--- a/polars/polars-io/src/csv_core/parser.rs
+++ b/polars/polars-io/src/csv_core/parser.rs
@@ -7,7 +7,7 @@ use polars_core::prelude::*;
 /// credits to csv-core
 pub(crate) fn skip_bom(input: &[u8]) -> &[u8] {
     if input.len() >= 3 && &input[0..3] == b"\xef\xbb\xbf" {
-        &input[..3]
+        &input[3..]
     } else {
         input
     }


### PR DESCRIPTION
This PR removes the multiple key join limits of maximal 6 keys and makes the multiple keys join multi-threaded.

TODO:
* [x] inner join
* [x] left join
* [x] outer join
* [ ] opt-in feature
* [x] Series / Chunkedarray index key comparisson to speedup [this function](https://github.com/ritchie46/polars/blob/a416b68eef6a09359880b698659ab2fac692a63c/polars/polars-core/src/frame/groupby/mod.rs#L241) and [this function](https://github.com/ritchie46/polars/blob/a416b68eef6a09359880b698659ab2fac692a63c/polars/polars-core/src/frame/hash_join/multiple_keys.rs#L11) so that we don't need to build an `AnyValue` enum. This will also speedup the groupby.