### PR TITLE
Fix bug in threaded hasher

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,74 @@
+---
+name: Bug report
+about: An issue with rust polars or python polars
+title: ''
+labels: ''
+assignees: ''
+---
+
+#### Are you using Python or Rust?
+
+Replace this text with the **Rust** or **Python**.
+
+#### What version of polars are you using?
+
+Replace this text with the version.
+
+#### What operating system are you using polars on?
+
+Replace this text with your operating system and version.
+
+#### Describe your bug.
+
+Give a high level description of the bug.
+
+#### What are the steps to reproduce the behavior?
+
+If possible, please include a minimal example on a dataset that is create through code:
+
+Please use code instead of images, we don't like typing.
+
+If the example is large, put it in a gist: https://gist.github.com/
+
+If the example is small, put it in code fences:
+
+```
+your
+code
+goes
+here
+```
+
+**Example**
+
+```python
+import polars as pl
+import numpy as np
+
+# Create a simple dataset on which we can reproduce the bug.
+pl.DataFrame({
+    "foo": [None, 1, 2],
+    "bar": np.arange(3)
+})
+```
+
+If we cannot reproduce the bug, it is unlikely that we will be able fix it.
+
+#### What is the actual behavior?
+
+Show the query you ran and the actual output. 
+
+If the output is large, put it in a gist: https://gist.github.com/
+
+If the output is small, put it in code fences:
+
+```
+your
+output
+goes
+here
+```
+
+#### What is the expected behavior?
+
+What do you think polars should have done?

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,16 @@
+---
+name: Feature request
+about: Suggest a new feature for polars
+title: ''
+labels: ''
+assignees: ''
+---
+
+
+#### Describe your feature request
+
+Please describe the behavior you want and the motivation. Please also provide
+examples of how polars would be used if your feature request were added.
+
+If you're not sure what to write here, then try imagining what the ideal
+documentation of your new feature would look like Then try to write it.

--- a/polars/polars-core/src/chunked_array/comparison.rs
+++ b/polars/polars-core/src/chunked_array/comparison.rs
@@ -690,7 +690,7 @@ pub(crate) trait ChunkEqualElement {
     ///
     /// # Safety
     ///
-    /// No bounds checks and no type checks.
+    /// No type checks.
     unsafe fn equal_element(&self, _idx_self: usize, _idx_other: usize, _other: &Series) -> bool {
         unimplemented!()
     }
@@ -705,7 +705,8 @@ where
         let ca_other = other.as_ref().as_ref();
         debug_assert!(self.dtype() == other.dtype());
         let ca_other = &*(ca_other as *const ChunkedArray<T>);
-        self.get_unchecked(idx_self) == ca_other.get_unchecked(idx_other)
+        // Should be get and not get_unchecked, because there could be nulls
+        self.get(idx_self) == ca_other.get(idx_other)
     }
 }
 
@@ -714,7 +715,7 @@ impl ChunkEqualElement for BooleanChunked {
         let ca_other = other.as_ref().as_ref();
         debug_assert!(self.dtype() == other.dtype());
         let ca_other = &*(ca_other as *const BooleanChunked);
-        self.get_unchecked(idx_self) == ca_other.get_unchecked(idx_other)
+        self.get(idx_self) == ca_other.get(idx_other)
     }
 }
 
@@ -723,7 +724,7 @@ impl ChunkEqualElement for Utf8Chunked {
         let ca_other = other.as_ref().as_ref();
         debug_assert!(self.dtype() == other.dtype());
         let ca_other = &*(ca_other as *const Utf8Chunked);
-        self.get_unchecked(idx_self) == ca_other.get_unchecked(idx_other)
+        self.get(idx_self) == ca_other.get(idx_other)
     }
 }
 
@@ -733,7 +734,7 @@ impl ChunkEqualElement for CategoricalChunked {
         let ca_other = other.as_ref().as_ref();
         debug_assert!(self.dtype() == other.dtype());
         let ca_other = &*(ca_other as *const CategoricalChunked);
-        self.get_unchecked(idx_self) == ca_other.get_unchecked(idx_other)
+        self.get(idx_self) == ca_other.get(idx_other)
     }
 }
 

--- a/polars/polars-core/src/chunked_array/ops/take_single.rs
+++ b/polars/polars-core/src/chunked_array/ops/take_single.rs
@@ -80,7 +80,7 @@ impl TakeRandom for BooleanChunked {
     #[inline]
     fn get(&self, index: usize) -> Option<Self::Item> {
         // Safety:
-        // Out of bounds is checkedn and downcast is of correct type
+        // Out of bounds is checked and downcast is of correct type
         unsafe { impl_take_random_get!(self, index, BooleanArray) }
     }
 
@@ -108,7 +108,7 @@ impl<'a> TakeRandom for &'a Utf8Chunked {
     #[inline]
     fn get(&self, index: usize) -> Option<Self::Item> {
         // Safety:
-        // Out of bounds is checkedn and downcast is of correct type
+        // Out of bounds is checked and downcast is of correct type
         unsafe { impl_take_random_get!(self, index, LargeStringArray) }
     }
 

--- a/polars/polars-core/src/frame/groupby/mod.rs
+++ b/polars/polars-core/src/frame/groupby/mod.rs
@@ -48,94 +48,58 @@ where
     T::Native: Hash,
 {
     fn vec_hash(&self, random_state: RandomState) -> UInt64Chunked {
-        if self.null_count() == 0 {
-            self.apply_cast_numeric(|v| {
-                let mut hasher = random_state.build_hasher();
-                v.hash(&mut hasher);
-                hasher.finish()
-            })
-        } else {
-            self.branch_apply_cast_numeric_no_null(|opt_v| {
-                let mut hasher = random_state.build_hasher();
-                opt_v.hash(&mut hasher);
-                hasher.finish()
-            })
-        }
+        // Note that we don't use the no null branch! This can break in unexpected ways.
+        // for instance with threading we split an array in n_threads, this may lead to
+        // splits that have no nulls and splits that have nulls. Then one array is hashed with
+        // Option<T> and the other array with T.
+        // Meaning that they cannot be compared. By always hashing on Option<T> the random_state is
+        // the only deterministic seed.
+        self.branch_apply_cast_numeric_no_null(|opt_v| {
+            let mut hasher = random_state.build_hasher();
+            opt_v.hash(&mut hasher);
+            hasher.finish()
+        })
     }
 }
 
 impl VecHash for Utf8Chunked {
     fn vec_hash(&self, random_state: RandomState) -> UInt64Chunked {
-        if self.null_count() == 0 {
-            self.apply_cast_numeric(|v| {
-                let mut hasher = random_state.build_hasher();
-                v.hash(&mut hasher);
-                hasher.finish()
-            })
-        } else {
-            self.branch_apply_cast_numeric_no_null(|opt_v| {
-                let mut hasher = random_state.build_hasher();
-                opt_v.hash(&mut hasher);
-                hasher.finish()
-            })
-        }
+        self.branch_apply_cast_numeric_no_null(|opt_v| {
+            let mut hasher = random_state.build_hasher();
+            opt_v.hash(&mut hasher);
+            hasher.finish()
+        })
     }
 }
 
 impl VecHash for BooleanChunked {
     fn vec_hash(&self, random_state: RandomState) -> UInt64Chunked {
-        if self.null_count() == 0 {
-            self.apply_cast_numeric(|v| {
-                let mut hasher = random_state.build_hasher();
-                v.hash(&mut hasher);
-                hasher.finish()
-            })
-        } else {
-            self.branch_apply_cast_numeric_no_null(|opt_v| {
-                let mut hasher = random_state.build_hasher();
-                opt_v.hash(&mut hasher);
-                hasher.finish()
-            })
-        }
+        self.branch_apply_cast_numeric_no_null(|opt_v| {
+            let mut hasher = random_state.build_hasher();
+            opt_v.hash(&mut hasher);
+            hasher.finish()
+        })
     }
 }
 
 impl VecHash for Float32Chunked {
     fn vec_hash(&self, random_state: RandomState) -> UInt64Chunked {
-        if self.null_count() == 0 {
-            self.apply_cast_numeric(|v| {
-                let v = v.to_bits();
-                let mut hasher = random_state.build_hasher();
-                v.hash(&mut hasher);
-                hasher.finish()
-            })
-        } else {
-            self.branch_apply_cast_numeric_no_null(|opt_v| {
-                let opt_v = opt_v.map(|v| v.to_bits());
-                let mut hasher = random_state.build_hasher();
-                opt_v.hash(&mut hasher);
-                hasher.finish()
-            })
-        }
+        self.branch_apply_cast_numeric_no_null(|opt_v| {
+            let opt_v = opt_v.map(|v| v.to_bits());
+            let mut hasher = random_state.build_hasher();
+            opt_v.hash(&mut hasher);
+            hasher.finish()
+        })
     }
 }
 impl VecHash for Float64Chunked {
     fn vec_hash(&self, random_state: RandomState) -> UInt64Chunked {
-        if self.null_count() == 0 {
-            self.apply_cast_numeric(|v| {
-                let v = v.to_bits();
-                let mut hasher = random_state.build_hasher();
-                v.hash(&mut hasher);
-                hasher.finish()
-            })
-        } else {
-            self.branch_apply_cast_numeric_no_null(|opt_v| {
-                let opt_v = opt_v.map(|v| v.to_bits());
-                let mut hasher = random_state.build_hasher();
-                opt_v.hash(&mut hasher);
-                hasher.finish()
-            })
-        }
+        self.branch_apply_cast_numeric_no_null(|opt_v| {
+            let opt_v = opt_v.map(|v| v.to_bits());
+            let mut hasher = random_state.build_hasher();
+            opt_v.hash(&mut hasher);
+            hasher.finish()
+        })
     }
 }
 

--- a/polars/polars-core/src/vector_hasher.rs
+++ b/polars/polars-core/src/vector_hasher.rs
@@ -235,7 +235,12 @@ pub(crate) fn df_rows_to_hashes(
     let hashes: Vec<_> = keys
         .columns
         .iter()
-        .map(|s| s.vec_hash(random_state.clone()))
+        .map(|s| {
+            let h = s.vec_hash(random_state.clone());
+            // if this fails we have unexpected groupby results.
+            debug_assert_eq!(h.null_count(), 0);
+            h
+        })
         .collect();
 
     let mut iter = hashes.into_iter();

--- a/py-polars/CHANGELOG.md
+++ b/py-polars/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 The Rust crate `polars` has its own changelog.
 
+### polars 0.7.5
+* bug fix
+  - fix bug in vectorized hashing algorithm that affected groupbys with null values
+
+* feature
+  - use lazy groupby API/DSL in eager API #522
+  - make sort groupby-context aware #522
+
 ### polars 0.7.4
 * performance
   - \[python | rust\] multi-threaded outer join
@@ -14,7 +22,7 @@ The Rust crate `polars` has its own changelog.
 * feature
   - \[python | rust\] Downsample by week
   - \[python | rust\] join by unlimited columns
-  - \[python\] Create a list Series directly.
+  - \[python\] ~Create a list Series directly.~
   - \[python\] Create DataFrame from np.ndarray
   
 


### PR DESCRIPTION
The vectorized hasher splitted an array in chunks. This could lead to chunks have no null values, and other chunks that had null values. The `vec_hash` method branched on this. If there were no null values `T` was hashed, otherwise `Option<T>` was hashed.

This lead to the same `T` values coming from the same array (before splitting), having different hashes. Clearly this is wrong.