### PR TITLE
Update sort algorithms

### DIFF
--- a/polars/polars-core/src/chunked_array/builder.rs
+++ b/polars/polars-core/src/chunked_array/builder.rs
@@ -273,6 +273,7 @@ impl Utf8ChunkedBuilder {
         self.builder.append_null().unwrap();
     }
 
+    #[inline]
     pub fn append_option<S: AsRef<str>>(&mut self, opt: Option<S>) {
         match opt {
             Some(s) => self.append_value(s.as_ref()),

--- a/polars/polars-core/src/chunked_array/cast.rs
+++ b/polars/polars-core/src/chunked_array/cast.rs
@@ -18,14 +18,6 @@ where
             Ok(ca)
         };
     };
-
-    // // only i32 can be cast to Date32
-    // if let DataType::Date32 = N::get_dtype() {
-    //     if T::get_dtype() != ArrowDataType::Int32 {
-    //         let casted_i32 = cast_ca::<Int32Type, _>(ca)?;
-    //         return cast_ca(&casted_i32);
-    //     }
-    // }
     let chunks = ca
         .chunks
         .iter()

--- a/polars/polars-core/src/error.rs
+++ b/polars/polars-core/src/error.rs
@@ -48,6 +48,8 @@ pub enum PolarsError {
     Regex(#[from] regex::Error),
     #[error("DuplicateError: {0}")]
     Duplicate(ErrString),
+    #[error("implementation error; this should not have happened.")]
+    ImplementationError,
 }
 
 pub type Result<T> = std::result::Result<T, PolarsError>;

--- a/polars/polars-core/src/frame/mod.rs
+++ b/polars/polars-core/src/frame/mod.rs
@@ -1705,6 +1705,7 @@ mod test {
     }
 
     #[test]
+    #[cfg(feature = "dtype-u8")]
     fn get_dummies() {
         let df = df! {
             "id" => &[1, 2, 3, 1, 2, 3, 1, 1],

--- a/polars/polars-core/src/series/mod.rs
+++ b/polars/polars-core/src/series/mod.rs
@@ -1513,7 +1513,7 @@ mod test {
 
     #[test]
     fn new_series_from_arrow_primitive_array() {
-        let array = UInt64Array::from(vec![1, 2, 3, 4, 5]);
+        let array = UInt32Array::from(vec![1, 2, 3, 4, 5]);
         let array_ref: ArrayRef = Arc::new(array);
 
         Series::try_from(("foo", array_ref)).unwrap();

--- a/polars/polars-lazy/src/dummies.rs
+++ b/polars/polars-lazy/src/dummies.rs
@@ -1,0 +1,35 @@
+use crate::dsl::{BinaryUdfOutputField, NoEq, SeriesBinaryUdf};
+use crate::logical_plan::Context;
+use crate::prelude::*;
+use polars_core::prelude::*;
+use std::sync::Arc;
+
+impl Default for NoEq<Arc<dyn SeriesBinaryUdf>> {
+    fn default() -> Self {
+        NoEq::new(Arc::new(|_, _| Err(PolarsError::ImplementationError)))
+    }
+}
+
+impl Default for NoEq<Arc<dyn BinaryUdfOutputField>> {
+    fn default() -> Self {
+        let output_field = move |_: &Schema, _: Context, _: &Field, _: &Field| None;
+        NoEq::new(Arc::new(output_field))
+    }
+}
+
+pub(crate) fn dummy_aexpr_binary_fn() -> AExpr {
+    AExpr::BinaryFunction {
+        input_a: Default::default(),
+        input_b: Default::default(),
+        function: Default::default(),
+        output_field: Default::default(),
+    }
+}
+
+pub(crate) fn dummy_aexpr_sort_by() -> AExpr {
+    AExpr::SortBy {
+        expr: Default::default(),
+        by: Default::default(),
+        reverse: Default::default(),
+    }
+}

--- a/polars/polars-lazy/src/frame.rs
+++ b/polars/polars-lazy/src/frame.rs
@@ -1871,4 +1871,28 @@ mod test {
             [Some(3), Some(5), Some(6)]
         );
     }
+
+    #[test]
+    fn test_lazy_groupby_sort_by() {
+        let df = df! {
+            "a" => ["a", "a", "a", "b", "b", "c"],
+            "b" => [1, 2, 3, 4, 5, 6],
+            "c" => [6, 1, 4, 3, 2, 1]
+        }
+        .unwrap();
+
+        let out = df
+            .lazy()
+            .groupby(vec![col("a")])
+            .agg(vec![col("b").sort_by(col("c"), true).first()])
+            .collect()
+            .unwrap()
+            .sort("a", false)
+            .unwrap();
+
+        assert_eq!(
+            Vec::from(out.column("b_first").unwrap().i32().unwrap()),
+            [Some(1), Some(4), Some(6)]
+        );
+    }
 }

--- a/polars/polars-lazy/src/lib.rs
+++ b/polars/polars-lazy/src/lib.rs
@@ -194,6 +194,7 @@
 //! ```
 #![cfg_attr(docsrs, feature(doc_cfg))]
 pub mod dsl;
+mod dummies;
 pub mod frame;
 pub mod functions;
 mod logical_plan;

--- a/polars/polars-lazy/src/logical_plan/iterator.rs
+++ b/polars/polars-lazy/src/logical_plan/iterator.rs
@@ -24,6 +24,10 @@ impl<'a> Iterator for ExprIter<'a> {
                 IsNotNull(e) => push(e),
                 Cast { expr, .. } => push(expr),
                 Sort { expr, .. } => push(expr),
+                SortBy { expr, by, .. } => {
+                    push(expr);
+                    push(by)
+                }
                 Agg(agg_e) => {
                     use AggExpr::*;
                     match agg_e {
@@ -112,6 +116,10 @@ impl AExpr {
             IsNotNull(e) => push(e),
             Cast { expr, .. } => push(expr),
             Sort { expr, .. } => push(expr),
+            SortBy { expr, by, .. } => {
+                push(expr);
+                push(by);
+            }
             Agg(agg_e) => {
                 use AAggExpr::*;
                 match agg_e {

--- a/polars/polars-lazy/src/logical_plan/mod.rs
+++ b/polars/polars-lazy/src/logical_plan/mod.rs
@@ -728,6 +728,11 @@ fn replace_wildcard_with_column(expr: Expr, column_name: Arc<String>) -> Expr {
             offset,
             length,
         },
+        Expr::SortBy { expr, by, reverse } => Expr::SortBy {
+            expr: Box::new(replace_wildcard_with_column(*expr, column_name)),
+            by,
+            reverse,
+        },
         Expr::Sort { expr, reverse } => Expr::Sort {
             expr: Box::new(replace_wildcard_with_column(*expr, column_name)),
             reverse,

--- a/py-polars/polars/lazy/__init__.py
+++ b/py-polars/polars/lazy/__init__.py
@@ -783,7 +783,33 @@ class Expr:
         return wrap_expr(self._pyexpr.cast(dtype))
 
     def sort(self, reverse: bool) -> "Expr":
+        """
+        Sort this column. In projection/ selection context the whole column is sorted.
+        If used in a groupby context, the groups are sorted.
+
+        Parameters
+        ----------
+        reverse
+            False -> order from small to large
+            True -> order from large to small
+        """
         return wrap_expr(self._pyexpr.sort(reverse))
+
+    def sort_by(self, by: "Expr", reverse: bool) -> "Expr":
+        """
+        Sort this column by the ordering of another column.
+        In projection/ selection context the whole column is sorted.
+        If used in a groupby context, the groups are sorted.
+
+        Parameters
+        ----------
+        by
+            The column used for sorting
+        reverse
+            False -> order from small to large
+            True -> order from large to small
+        """
+        return wrap_expr(self._pyexpr.sort_by(by, reverse))
 
     def shift(self, periods: int) -> "Expr":
         """

--- a/py-polars/src/lazy/dsl.rs
+++ b/py-polars/src/lazy/dsl.rs
@@ -138,6 +138,11 @@ impl PyExpr {
     pub fn sort(&self, reverse: bool) -> PyExpr {
         self.clone().inner.sort(reverse).into()
     }
+
+    pub fn sort_by(&self, by: PyExpr, reverse: bool) -> PyExpr {
+        self.clone().inner.sort_by(by.inner, reverse).into()
+    }
+
     pub fn shift(&self, periods: i64) -> PyExpr {
         self.clone().inner.shift(periods).into()
     }


### PR DESCRIPTION
It did a unnecessary copy by just using itertools native solution.
This PR also defaults to unstable sort for numeric types as that would not matter (for argsort it does).

Next it will honor the POLARS_PAR_SORT_BOUND env var in all branches. Closes #315 