### PR TITLE
Floor divide buckets in downsample operation

### DIFF
--- a/polars/polars-core/src/datatypes.rs
+++ b/polars/polars-core/src/datatypes.rs
@@ -306,7 +306,11 @@ pub enum DataType {
     Float32,
     Float64,
     Utf8,
+    /// A 32-bit date representing the elapsed time since UNIX epoch (1970-01-01)
+    /// in days (32 bits).
     Date32,
+    /// A 64-bit date representing the elapsed time since UNIX epoch (1970-01-01)
+    /// in milliseconds (64 bits).
     Date64,
     Time64(TimeUnit),
     List(ArrowDataType),

--- a/polars/polars-core/src/frame/groupby/resample.rs
+++ b/polars/polars-core/src/frame/groupby/resample.rs
@@ -117,7 +117,7 @@ impl DataFrame {
             Week(n) => {
                 // We floor divide to create a bucket.
                 let mut week = (&key.week()? / n).into_series();
-                week.rename(day_c);
+                week.rename(week_c);
 
                 df.hstack_mut(&[year, week])?;
 


### PR DESCRIPTION
By doing a floor divide, it is more clear which sizes the buckets are. Also fixed a bug in resample by week. #474 