### PR TITLE
Csv reader parse/cast categoricals

### DIFF
--- a/polars/polars-core/src/frame/mod.rs
+++ b/polars/polars-core/src/frame/mod.rs
@@ -135,7 +135,7 @@ impl DataFrame {
         }
     }
 
-    /// Get a reference to the DataFrame schema.
+    /// Get the DataFrame schema.
     pub fn schema(&self) -> Schema {
         let fields = Self::create_fields(&self.columns);
         Schema::new(fields)

--- a/polars/polars-io/src/csv_core/buffer.rs
+++ b/polars/polars-io/src/csv_core/buffer.rs
@@ -220,8 +220,7 @@ pub(crate) fn init_buffers(
             // we overallocate 20%
             if field.data_type() == &DataType::Utf8 {
                 str_capacity =
-                    // TODO! determine Ordering
-                    (str_capacities[str_index].load(Ordering::Relaxed) as f32 * 1.2) as usize;
+                    (str_capacities[str_index].load(Ordering::Acquire) as f32 * 1.2) as usize;
                 str_index += 1;
             }
 

--- a/py-polars/polars/lazy/__init__.py
+++ b/py-polars/polars/lazy/__init__.py
@@ -738,6 +738,19 @@ class Expr:
     def count(self) -> "Expr":
         return wrap_expr(self._pyexpr.count())
 
+    def slice(self, offset: int, length: int):
+        """
+        Slice the Series
+
+        Parameters
+        ----------
+        offset
+            Start index
+        length
+            Length of the slice
+        """
+        return wrap_expr(self._pyexpr.slice(offset, length))
+
     def cum_sum(self, reverse: bool):
         """
         Get an array with the cumulative sum computed at every element

--- a/py-polars/src/lazy/dsl.rs
+++ b/py-polars/src/lazy/dsl.rs
@@ -182,8 +182,13 @@ impl PyExpr {
     pub fn tail(&self, n: Option<usize>) -> PyExpr {
         self.clone().inner.tail(n).into()
     }
+
     pub fn head(&self, n: Option<usize>) -> PyExpr {
         self.clone().inner.head(n).into()
+    }
+
+    pub fn slice(&self, offset: i64, length: usize) -> PyExpr {
+        self.clone().inner.slice(offset, length).into()
     }
 
     pub fn is_duplicated(&self) -> PyExpr {

--- a/py-polars/tests/test_df.py
+++ b/py-polars/tests/test_df.py
@@ -443,3 +443,11 @@ def test_row_tuple():
     assert df.row(0) == ("foo", 1, 1.0)
     assert df.row(1) == ("bar", 2, 2.0)
     assert df.row(-1) == ("2", 3, 3.0)
+
+
+def test_read_csv_categorical():
+    f = BytesIO()
+    f.write(b"col1,col2,col3,col4,col5,col6\n'foo',2,3,4,5,6\n'bar',8,9,10,11,12")
+    f.seek(0)
+    df = pl.DataFrame.read_csv(f, has_headers=True, dtype={"col1": pl.Categorical})
+    assert df["col1"].dtype == pl.Categorical


### PR DESCRIPTION
This PR allows adding categorical types to the csv schema. The columns will  be parsed as utf8 and later implicitly cast to categorical dtype.