### PR TITLE
Remove redundant collect

### DIFF
--- a/polars/polars-core/src/chunked_array/arithmetic.rs
+++ b/polars/polars-core/src/chunked_array/arithmetic.rs
@@ -73,7 +73,6 @@ where
             let (lhs, rhs) = align_chunks_binary(lhs, rhs);
             let chunks = lhs
                 .downcast_chunks()
-                .iter()
                 .zip(rhs.downcast_chunks())
                 .map(|(lhs, rhs)| Arc::new(kernel(lhs, rhs).expect("output")) as ArrayRef)
                 .collect();

--- a/polars/polars-core/src/chunked_array/arithmetic.rs
+++ b/polars/polars-core/src/chunked_array/arithmetic.rs
@@ -72,8 +72,8 @@ where
         (a, b) if a == b => {
             let (lhs, rhs) = align_chunks_binary(lhs, rhs);
             let chunks = lhs
-                .downcast_chunks()
-                .zip(rhs.downcast_chunks())
+                .downcast_iter()
+                .zip(rhs.downcast_iter())
                 .map(|(lhs, rhs)| Arc::new(kernel(lhs, rhs).expect("output")) as ArrayRef)
                 .collect();
             lhs.copy_with_chunks(chunks)

--- a/polars/polars-core/src/chunked_array/cast.rs
+++ b/polars/polars-core/src/chunked_array/cast.rs
@@ -30,7 +30,7 @@ where
 macro_rules! cast_from_dtype {
     ($self: expr, $kernel:expr, $dtype: expr) => {{
         let chunks = $self
-            .downcast_chunks()
+            .downcast_iter()
             .into_iter()
             .map(|arr| $kernel(arr, $dtype))
             .collect();

--- a/polars/polars-core/src/chunked_array/comparison.rs
+++ b/polars/polars-core/src/chunked_array/comparison.rs
@@ -21,8 +21,8 @@ where
         operator: impl Fn(&PrimitiveArray<T>, &PrimitiveArray<T>) -> arrow::error::Result<BooleanArray>,
     ) -> Result<BooleanChunked> {
         let chunks = self
-            .downcast_chunks()
-            .zip(rhs.downcast_chunks())
+            .downcast_iter()
+            .zip(rhs.downcast_iter())
             .map(|(left, right)| {
                 let arr_res = operator(left, right);
                 let arr = match arr_res {
@@ -570,8 +570,8 @@ impl BooleanChunked {
         operator: impl Fn(&BooleanArray, &BooleanArray) -> arrow::error::Result<BooleanArray>,
     ) -> Result<BooleanChunked> {
         let chunks = self
-            .downcast_chunks()
-            .zip(rhs.downcast_chunks())
+            .downcast_iter()
+            .zip(rhs.downcast_iter())
             .map(|(left, right)| {
                 let arr_res = operator(left, right);
                 let arr = match arr_res {
@@ -643,7 +643,7 @@ impl Not for &BooleanChunked {
 
     fn not(self) -> Self::Output {
         let chunks = self
-            .downcast_chunks()
+            .downcast_iter()
             .map(|a| {
                 let arr = compute::not(a).expect("should not fail");
                 Arc::new(arr) as ArrayRef

--- a/polars/polars-core/src/chunked_array/comparison.rs
+++ b/polars/polars-core/src/chunked_array/comparison.rs
@@ -22,7 +22,6 @@ where
     ) -> Result<BooleanChunked> {
         let chunks = self
             .downcast_chunks()
-            .iter()
             .zip(rhs.downcast_chunks())
             .map(|(left, right)| {
                 let arr_res = operator(left, right);
@@ -572,7 +571,6 @@ impl BooleanChunked {
     ) -> Result<BooleanChunked> {
         let chunks = self
             .downcast_chunks()
-            .iter()
             .zip(rhs.downcast_chunks())
             .map(|(left, right)| {
                 let arr_res = operator(left, right);
@@ -646,7 +644,6 @@ impl Not for &BooleanChunked {
     fn not(self) -> Self::Output {
         let chunks = self
             .downcast_chunks()
-            .iter()
             .map(|a| {
                 let arr = compute::not(a).expect("should not fail");
                 Arc::new(arr) as ArrayRef

--- a/polars/polars-core/src/chunked_array/iterator/mod.rs
+++ b/polars/polars-core/src/chunked_array/iterator/mod.rs
@@ -1,5 +1,5 @@
-use crate::datatypes::CategoricalChunked;
 use crate::chunked_array::ops::downcast::Chunks;
+use crate::datatypes::CategoricalChunked;
 use crate::prelude::{
     BooleanChunked, ChunkedArray, ListChunked, PolarsNumericType, Series, UnsafeValue, Utf8Chunked,
 };
@@ -406,7 +406,7 @@ where
     }
 
     fn new(ca: &'a ChunkedArray<T>) -> Self {
-        let chunks= ca.downcast_chunks();
+        let chunks = ca.downcast_chunks();
         let arr_left = chunks.get(0).unwrap();
         let current_iter_left = arr_left.values().iter().copied();
         let current_data_left = arr_left.data();

--- a/polars/polars-core/src/chunked_array/iterator/par/macros.rs
+++ b/polars/polars-core/src/chunked_array/iterator/par/macros.rs
@@ -94,7 +94,7 @@ macro_rules! impl_all_parallel_iterators {
         // The methods are the same for the `ReturnOption` and `ReturnUnwrap` variant.
         impl<$( $lifetime )?> $seq_iter_single_chunk {
             fn from_parts(ca: $ca_type, offset: usize, len: usize) -> Self {
-                let chunks = ca.downcast_chunks();
+                let chunks = ca.downcast_iter();
                 let current_array = chunks[0];
                 let idx_left = offset;
                 let idx_right = offset + len;
@@ -110,7 +110,7 @@ macro_rules! impl_all_parallel_iterators {
         impl<$( $lifetime )?> $seq_iter_many_chunk {
             fn from_parts(ca: $ca_type, offset: usize, len: usize) -> Self {
                 let ca = ca;
-                let chunks = ca.downcast_chunks();
+                let chunks = ca.downcast_iter();
                 let idx_left = offset;
                 let (chunk_idx_left, current_array_idx_left) = ca.index_to_chunked_index(idx_left);
                 let current_array_left = chunks[chunk_idx_left];
@@ -190,7 +190,7 @@ macro_rules! impl_all_parallel_iterators {
             for $seq_iter_single_chunk_null_check
         {
             fn from(prod: $producer_single_chunk_null_check_return_option<$( $lifetime )?>) -> Self {
-                let chunks = prod.ca.downcast_chunks();
+                let chunks = prod.ca.downcast_iter();
                 let current_array = chunks[0];
                 let current_data = current_array.data();
                 let idx_left = prod.offset;
@@ -270,7 +270,7 @@ macro_rules! impl_all_parallel_iterators {
         {
             fn from(prod: $producer_many_chunk_null_check_return_option<$( $lifetime )?>) -> Self {
                 let ca = prod.ca;
-                let chunks = ca.downcast_chunks();
+                let chunks = ca.downcast_iter();
 
                 // Compute left chunk indexes.
                 let idx_left = prod.offset;
@@ -554,7 +554,7 @@ macro_rules! impl_into_par_iter {
             type Item = Option<$iter_item>;
 
             fn into_par_iter(self) -> Self::Iter {
-                let chunks = self.downcast_chunks();
+                let chunks = self.downcast_iter();
                 match chunks.len() {
                     1 => {
                         if self.null_count() == 0 {
@@ -688,7 +688,7 @@ macro_rules! impl_into_no_null_par_iter {
 
             fn into_par_iter(self) -> Self::Iter {
                 let ca = self.0;
-                let chunks = ca.downcast_chunks();
+                let chunks = ca.downcast_iter();
                 match chunks.len() {
                     1 => $dispatcher::SingleChunk(
                         <$single_chunk_return_unwrapped>::new(ca),

--- a/polars/polars-core/src/chunked_array/iterator/par/numeric.rs
+++ b/polars/polars-core/src/chunked_array/iterator/par/numeric.rs
@@ -100,7 +100,7 @@ where
     T: PolarsNumericType + Send + Sync,
 {
     fn from_parts(ca: &'a ChunkedArray<T>, offset: usize, len: usize) -> Self {
-        let chunk = ca.downcast_chunks()[0];
+        let chunk = ca.downcast_iter()[0];
         let slice = &chunk.values()[offset..len];
         let iter = slice.iter().copied();
 
@@ -113,7 +113,7 @@ where
     T: PolarsNumericType + Send + Sync,
 {
     fn from_parts(ca: &'a ChunkedArray<T>, offset: usize, len: usize) -> Self {
-        let chunks = ca.downcast_chunks();
+        let chunks = ca.downcast_iter();
 
         // Compute left array indexes.
         let idx_left = offset;
@@ -256,7 +256,7 @@ where
     T: PolarsNumericType + Send + Sync,
 {
     fn from(prod: NumProducerSingleChunkNullCheckReturnOption<'a, T>) -> Self {
-        let chunks = prod.ca.downcast_chunks();
+        let chunks = prod.ca.downcast_iter();
         let arr = chunks[0];
         let idx_left = prod.offset;
         let idx_right = prod.offset + prod.len;
@@ -393,7 +393,7 @@ where
 {
     fn from(prod: NumProducerManyChunkNullCheckReturnOption<'a, T>) -> Self {
         let ca = prod.ca;
-        let chunks = prod.ca.downcast_chunks();
+        let chunks = prod.ca.downcast_iter();
 
         // Compute left array indexes and data.
         let idx_left = prod.offset;
@@ -632,7 +632,7 @@ where
     type Item = Option<T::Native>;
 
     fn into_par_iter(self) -> Self::Iter {
-        let chunks = self.downcast_chunks();
+        let chunks = self.downcast_iter();
         match chunks.len() {
             1 => {
                 if self.null_count() == 0 {
@@ -747,7 +747,7 @@ where
 
     fn into_par_iter(self) -> Self::Iter {
         let ca = self.0;
-        let chunks = ca.downcast_chunks();
+        let chunks = ca.downcast_iter();
         match chunks.len() {
             1 => NumNoNullParIterDispatcher::SingleChunk(
                 NumParIterSingleChunkReturnUnwrapped::new(ca),

--- a/polars/polars-core/src/chunked_array/mod.rs
+++ b/polars/polars-core/src/chunked_array/mod.rs
@@ -4,8 +4,8 @@ use crate::prelude::*;
 use arrow::{
     array::{
         ArrayRef, BooleanArray, Date64Array, Float32Array, Float64Array, Int16Array, Int32Array,
-        Int64Array, Int8Array, LargeStringArray, Time64NanosecondArray,
-        UInt16Array, UInt32Array, UInt64Array, UInt8Array,
+        Int64Array, Int8Array, LargeStringArray, Time64NanosecondArray, UInt16Array, UInt32Array,
+        UInt64Array, UInt8Array,
     },
     buffer::Buffer,
     datatypes::TimeUnit,
@@ -679,7 +679,7 @@ where
     fn as_single_ptr(&mut self) -> Result<usize> {
         let mut ca = self.rechunk();
         mem::swap(&mut ca, self);
-        let a = self.data_views()[0];
+        let a = self.data_views().next().unwrap();
         let ptr = a.as_ptr();
         Ok(ptr as usize)
     }
@@ -708,8 +708,8 @@ where
     /// Get slices of the underlying arrow data.
     /// NOTE: null values should be taken into account by the user of these slices as they are handled
     /// separately
-    pub fn data_views(&self) -> Vec<&[T::Native]> {
-        self.downcast_iter().map(|arr| arr.values()).collect()
+    pub fn data_views(&self) -> impl Iterator<Item = &[T::Native]> {
+        self.downcast_iter().map(|arr| arr.values())
     }
 
     /// If [cont_slice](#method.cont_slice) is successful a closure is mapped over the elements.

--- a/polars/polars-core/src/chunked_array/object/mod.rs
+++ b/polars/polars-core/src/chunked_array/object/mod.rs
@@ -117,10 +117,14 @@ impl<T> ObjectChunked<T>
 where
     T: Any + Debug + Clone + Send + Sync + Default,
 {
-    pub fn get_as_any(&self, index: usize) -> &dyn Any {
+    ///
+    /// # Safety
+    ///
+    /// No bounds checks
+    pub unsafe fn get_as_any(&self, index: usize) -> &dyn Any {
         let chunks = self.downcast_chunks();
         let (chunk_idx, idx) = self.index_to_chunked_index(index);
-        let arr = unsafe { *chunks.get_unchecked(chunk_idx) };
+        let arr = chunks.get_unchecked(chunk_idx);
         arr.value(idx)
     }
 }

--- a/polars/polars-core/src/chunked_array/ops/aggregate.rs
+++ b/polars/polars-core/src/chunked_array/ops/aggregate.rs
@@ -83,7 +83,7 @@ where
     T::Native: PartialOrd + Num + NumCast + Zero,
 {
     fn sum(&self) -> Option<T::Native> {
-        self.downcast_chunks()
+        self.downcast_iter()
             .map(|a| compute::sum(a))
             .fold(None, |acc, v| match v {
                 Some(v) => match acc {
@@ -99,7 +99,7 @@ where
             DataType::Float32 => agg_float_with_nans!(self, min, f32),
             DataType::Float64 => agg_float_with_nans!(self, min, f64),
             _ => self
-                .downcast_chunks()
+                .downcast_iter()
                 .filter_map(|a| compute::min(a))
                 .fold_first_(|acc, v| if acc < v { acc } else { v }),
         }
@@ -110,7 +110,7 @@ where
             DataType::Float32 => agg_float_with_nans!(self, max, f32),
             DataType::Float64 => agg_float_with_nans!(self, max, f64),
             _ => self
-                .downcast_chunks()
+                .downcast_iter()
                 .filter_map(|a| compute::max(a))
                 .fold_first_(|acc, v| if acc > v { acc } else { v }),
         }

--- a/polars/polars-core/src/chunked_array/ops/aggregate.rs
+++ b/polars/polars-core/src/chunked_array/ops/aggregate.rs
@@ -84,8 +84,7 @@ where
 {
     fn sum(&self) -> Option<T::Native> {
         self.downcast_chunks()
-            .iter()
-            .map(|&a| compute::sum(a))
+            .map(|a| compute::sum(a))
             .fold(None, |acc, v| match v {
                 Some(v) => match acc {
                     None => Some(v),
@@ -101,8 +100,7 @@ where
             DataType::Float64 => agg_float_with_nans!(self, min, f64),
             _ => self
                 .downcast_chunks()
-                .iter()
-                .filter_map(|&a| compute::min(a))
+                .filter_map(|a| compute::min(a))
                 .fold_first_(|acc, v| if acc < v { acc } else { v }),
         }
     }
@@ -113,8 +111,7 @@ where
             DataType::Float64 => agg_float_with_nans!(self, max, f64),
             _ => self
                 .downcast_chunks()
-                .iter()
-                .filter_map(|&a| compute::max(a))
+                .filter_map(|a| compute::max(a))
                 .fold_first_(|acc, v| if acc > v { acc } else { v }),
         }
     }

--- a/polars/polars-core/src/chunked_array/ops/apply.rs
+++ b/polars/polars-core/src/chunked_array/ops/apply.rs
@@ -57,7 +57,7 @@ where
         S: PolarsNumericType,
     {
         let chunks = self
-            .downcast_chunks()
+            .downcast_iter()
             .into_iter()
             .map(|array| {
                 let av: AlignedVec<_> = if array.null_count() == 0 {
@@ -165,7 +165,7 @@ impl<'a> ChunkApply<'a, &'a str, Cow<'a, str>> for Utf8Chunked {
         S: PolarsNumericType,
     {
         let chunks = self
-            .downcast_chunks()
+            .downcast_iter()
             .into_iter()
             .map(|array| {
                 let av: AlignedVec<_> = (0..array.len())
@@ -184,7 +184,7 @@ impl<'a> ChunkApply<'a, &'a str, Cow<'a, str>> for Utf8Chunked {
         S: PolarsNumericType,
     {
         let chunks = self
-            .downcast_chunks()
+            .downcast_iter()
             .into_iter()
             .map(|array| {
                 let av: AlignedVec<_> = array.into_iter().map(f).collect();
@@ -222,7 +222,7 @@ impl ChunkApplyKernel<BooleanArray> for BooleanChunked {
         F: Fn(&BooleanArray) -> ArrayRef,
     {
         let chunks = self
-            .downcast_chunks()
+            .downcast_iter()
             .into_iter()
             .map(|array| f(array))
             .collect();
@@ -235,7 +235,7 @@ impl ChunkApplyKernel<BooleanArray> for BooleanChunked {
         S: PolarsDataType,
     {
         let chunks = self
-            .downcast_chunks()
+            .downcast_iter()
             .into_iter()
             .map(|array| f(array))
             .collect();
@@ -258,7 +258,7 @@ where
         F: Fn(&PrimitiveArray<T>) -> ArrayRef,
         S: PolarsDataType,
     {
-        let chunks = self.downcast_chunks().into_iter().map(f).collect();
+        let chunks = self.downcast_iter().into_iter().map(f).collect();
         ChunkedArray::new_from_chunks(self.name(), chunks)
     }
 }
@@ -276,7 +276,7 @@ impl ChunkApplyKernel<LargeStringArray> for Utf8Chunked {
         F: Fn(&LargeStringArray) -> ArrayRef,
         S: PolarsDataType,
     {
-        let chunks = self.downcast_chunks().into_iter().map(f).collect();
+        let chunks = self.downcast_iter().into_iter().map(f).collect();
         ChunkedArray::new_from_chunks(self.name(), chunks)
     }
 }
@@ -288,7 +288,7 @@ impl<'a> ChunkApply<'a, Series, Series> for ListChunked {
         S: PolarsNumericType,
     {
         let chunks = self
-            .downcast_chunks()
+            .downcast_iter()
             .into_iter()
             .map(|array| {
                 let av: AlignedVec<_> = (0..array.len())
@@ -311,7 +311,7 @@ impl<'a> ChunkApply<'a, Series, Series> for ListChunked {
         S: PolarsNumericType,
     {
         let chunks = self
-            .downcast_chunks()
+            .downcast_iter()
             .into_iter()
             .map(|array| {
                 let av: AlignedVec<_> = (0..array.len())

--- a/polars/polars-core/src/chunked_array/ops/chunkops.rs
+++ b/polars/polars-core/src/chunked_array/ops/chunkops.rs
@@ -103,7 +103,7 @@ where
             self.clone()
         } else {
             let mut builder = ObjectChunkedBuilder::new(self.name(), self.len());
-            let chunks = self.downcast_chunks();
+            let chunks = self.downcast_iter();
 
             // todo! use iterators once implemented
             // no_null path

--- a/polars/polars-core/src/chunked_array/ops/chunkops.rs
+++ b/polars/polars-core/src/chunked_array/ops/chunkops.rs
@@ -108,19 +108,19 @@ where
             // todo! use iterators once implemented
             // no_null path
             if self.null_count() == 0 {
-                for idx in 0..self.len() {
-                    let (chunk_idx, idx) = self.index_to_chunked_index(idx);
-                    let arr = unsafe { &**chunks.get_unchecked(chunk_idx) };
-                    builder.append_value(arr.value(idx).clone())
+                for arr in chunks {
+                    for idx in 0..arr.len() {
+                        builder.append_value(arr.value(idx).clone())
+                    }
                 }
             } else {
-                for idx in 0..self.len() {
-                    let (chunk_idx, idx) = self.index_to_chunked_index(idx);
-                    let arr = unsafe { &**chunks.get_unchecked(chunk_idx) };
-                    if arr.is_valid(idx) {
-                        builder.append_value(arr.value(idx).clone())
-                    } else {
-                        builder.append_null()
+                for arr in chunks {
+                    for idx in 0..arr.len() {
+                        if arr.is_valid(idx) {
+                            builder.append_value(arr.value(idx).clone())
+                        } else {
+                            builder.append_null()
+                        }
                     }
                 }
             }

--- a/polars/polars-core/src/chunked_array/ops/downcast.rs
+++ b/polars/polars-core/src/chunked_array/ops/downcast.rs
@@ -1,0 +1,105 @@
+#[cfg(feature = "object")]
+use crate::chunked_array::object::ObjectArray;
+use crate::prelude::*;
+use arrow::array::{
+    Array, ArrayRef, BooleanArray, LargeListArray, LargeStringArray, PrimitiveArray
+};
+use std::marker::PhantomData;
+
+pub struct Chunks<'a, T> {
+    chunks: &'a [ArrayRef],
+    phantom: PhantomData<T>,
+}
+
+impl<'a, T> Chunks<'a, T> {
+    fn new(chunks: &'a [ArrayRef]) -> Self {
+        Chunks {
+            chunks,
+            phantom: PhantomData,
+        }
+    }
+
+    pub fn get(&self, index: usize) -> Option<&'a T> {
+        self.chunks.get(index).map(|arr| {
+            let arr = &**arr;
+            unsafe { &*(arr as *const dyn Array as *const T) }
+        })
+    }
+
+    pub unsafe fn get_unchecked(&self, index: usize) -> &'a T {
+        let arr = self.chunks.get_unchecked(index);
+        let arr = &**arr;
+        &*(arr as *const dyn Array as *const T)
+    }
+
+    pub fn len(&self) -> usize {
+        self.chunks.len()
+    }
+}
+
+impl<T> ChunkedArray<T>
+where
+    T: PolarsPrimitiveType,
+{
+    pub fn downcast_iter(&self) -> impl Iterator<Item = &PrimitiveArray<T>> + DoubleEndedIterator {
+        self.chunks.iter().map(|arr| {
+            let arr = &**arr;
+            unsafe { &*(arr as *const dyn Array as *const PrimitiveArray<T>) }
+        })
+    }
+    pub fn downcast_chunks(& self) -> Chunks<'_, PrimitiveArray<T>> {
+        Chunks::new(&self.chunks)
+    }
+}
+
+impl BooleanChunked {
+    pub fn downcast_iter(&self) -> impl Iterator<Item = &BooleanArray> + DoubleEndedIterator {
+        self.chunks.iter().map(|arr| {
+            let arr = &**arr;
+            unsafe { &*(arr as *const dyn Array as *const BooleanArray) }
+        })
+    }
+    pub fn downcast_chunks(& self) -> Chunks<'_, BooleanArray> {
+        Chunks::new(&self.chunks)
+    }
+}
+
+impl Utf8Chunked {
+    pub fn downcast_iter(&self) -> impl Iterator<Item = &LargeStringArray> + DoubleEndedIterator {
+        self.chunks.iter().map(|arr| {
+            let arr = &**arr;
+            unsafe { &*(arr as *const dyn Array as *const LargeStringArray) }
+        })
+    }
+    pub fn downcast_chunks(& self) -> Chunks<'_, LargeStringArray> {
+        Chunks::new(&self.chunks)
+    }
+}
+
+impl ListChunked {
+    pub fn downcast_iter(&self) -> impl Iterator<Item = &LargeListArray> + DoubleEndedIterator {
+        self.chunks.iter().map(|arr| {
+            let arr = &**arr;
+            unsafe { &*(arr as *const dyn Array as *const LargeListArray) }
+        })
+    }
+    pub fn downcast_chunks(&self) -> Chunks<'_, LargeListArray> {
+        Chunks::new(&self.chunks)
+    }
+}
+
+#[cfg(feature = "object")]
+impl<T> ObjectChunked<T>
+where
+    T: 'static + std::fmt::Debug + Clone + Send + Sync + Default,
+{
+    pub fn downcast_iter(&self) -> impl Iterator<Item = &ObjectArray<T>> + DoubleEndedIterator {
+        self.chunks.iter().map(|arr| {
+            let arr = &**arr;
+            unsafe { &*(arr as *const dyn Array as *const ObjectArray<T>) }
+        })
+    }
+    pub fn downcast_chunks(& self) -> Chunks<'_, ObjectArray<T>> {
+        Chunks::new(&self.chunks)
+    }
+}

--- a/polars/polars-core/src/chunked_array/ops/downcast.rs
+++ b/polars/polars-core/src/chunked_array/ops/downcast.rs
@@ -2,7 +2,7 @@
 use crate::chunked_array::object::ObjectArray;
 use crate::prelude::*;
 use arrow::array::{
-    Array, ArrayRef, BooleanArray, LargeListArray, LargeStringArray, PrimitiveArray
+    Array, ArrayRef, BooleanArray, LargeListArray, LargeStringArray, PrimitiveArray,
 };
 use std::marker::PhantomData;
 
@@ -47,7 +47,7 @@ where
             unsafe { &*(arr as *const dyn Array as *const PrimitiveArray<T>) }
         })
     }
-    pub fn downcast_chunks(& self) -> Chunks<'_, PrimitiveArray<T>> {
+    pub fn downcast_chunks(&self) -> Chunks<'_, PrimitiveArray<T>> {
         Chunks::new(&self.chunks)
     }
 }
@@ -59,7 +59,7 @@ impl BooleanChunked {
             unsafe { &*(arr as *const dyn Array as *const BooleanArray) }
         })
     }
-    pub fn downcast_chunks(& self) -> Chunks<'_, BooleanArray> {
+    pub fn downcast_chunks(&self) -> Chunks<'_, BooleanArray> {
         Chunks::new(&self.chunks)
     }
 }
@@ -71,7 +71,7 @@ impl Utf8Chunked {
             unsafe { &*(arr as *const dyn Array as *const LargeStringArray) }
         })
     }
-    pub fn downcast_chunks(& self) -> Chunks<'_, LargeStringArray> {
+    pub fn downcast_chunks(&self) -> Chunks<'_, LargeStringArray> {
         Chunks::new(&self.chunks)
     }
 }
@@ -99,7 +99,7 @@ where
             unsafe { &*(arr as *const dyn Array as *const ObjectArray<T>) }
         })
     }
-    pub fn downcast_chunks(& self) -> Chunks<'_, ObjectArray<T>> {
+    pub fn downcast_chunks(&self) -> Chunks<'_, ObjectArray<T>> {
         Chunks::new(&self.chunks)
     }
 }

--- a/polars/polars-core/src/chunked_array/ops/explode.rs
+++ b/polars/polars-core/src/chunked_array/ops/explode.rs
@@ -33,7 +33,10 @@ impl ChunkExplode for ListChunked {
         // of the list. And we also return a slice of the offsets. This slice can be used to find the old
         // list layout or indexes to expand the DataFrame in the same manner as the 'explode' operation
         let ca = self.rechunk();
-        let listarr: &LargeListArray = ca.downcast_chunks()[0];
+        let listarr: &LargeListArray = ca
+            .downcast_chunks()
+            .next()
+            .ok_or_else(|| PolarsError::NoData("cannot explode empty list".into()))?;
         let list_data = listarr.data();
         let values = listarr.values();
         let offset_ptr = list_data.buffers()[0].as_ptr() as *const i64;
@@ -51,7 +54,10 @@ impl ChunkExplode for Utf8Chunked {
         // of the list. And we also return a slice of the offsets. This slice can be used to find the old
         // list layout or indexes to expand the DataFrame in the same manner as the 'explode' operation
         let ca = self.rechunk();
-        let stringarr: &LargeStringArray = ca.downcast_chunks()[0];
+        let stringarr: &LargeStringArray = ca
+            .downcast_chunks()
+            .next()
+            .ok_or_else(|| PolarsError::NoData("cannot explode empty str".into()))?;
         let list_data = stringarr.data();
         let str_values_buf = stringarr.value_data();
 

--- a/polars/polars-core/src/chunked_array/ops/explode.rs
+++ b/polars/polars-core/src/chunked_array/ops/explode.rs
@@ -34,7 +34,7 @@ impl ChunkExplode for ListChunked {
         // list layout or indexes to expand the DataFrame in the same manner as the 'explode' operation
         let ca = self.rechunk();
         let listarr: &LargeListArray = ca
-            .downcast_chunks()
+            .downcast_iter()
             .next()
             .ok_or_else(|| PolarsError::NoData("cannot explode empty list".into()))?;
         let list_data = listarr.data();
@@ -55,7 +55,7 @@ impl ChunkExplode for Utf8Chunked {
         // list layout or indexes to expand the DataFrame in the same manner as the 'explode' operation
         let ca = self.rechunk();
         let stringarr: &LargeStringArray = ca
-            .downcast_chunks()
+            .downcast_iter()
             .next()
             .ok_or_else(|| PolarsError::NoData("cannot explode empty str".into()))?;
         let list_data = stringarr.data();

--- a/polars/polars-core/src/chunked_array/ops/filter.rs
+++ b/polars/polars-core/src/chunked_array/ops/filter.rs
@@ -42,8 +42,8 @@ where
         let (left, filter) = align_chunks_binary(self, filter);
 
         let chunks = left
-            .downcast_chunks()
-            .zip(filter.downcast_chunks())
+            .downcast_iter()
+            .zip(filter.downcast_iter())
             .map(|(left, mask)| filter_fn(left, mask).unwrap())
             .collect::<Vec<_>>();
         Ok(ChunkedArray::new_from_chunks(self.name(), chunks))
@@ -63,8 +63,8 @@ impl ChunkFilter<BooleanType> for BooleanChunked {
         let (left, filter) = align_chunks_binary(self, filter);
 
         let chunks = left
-            .downcast_chunks()
-            .zip(filter.downcast_chunks())
+            .downcast_iter()
+            .zip(filter.downcast_iter())
             .map(|(left, mask)| filter_fn(left, mask).unwrap())
             .collect::<Vec<_>>();
         Ok(ChunkedArray::new_from_chunks(self.name(), chunks))
@@ -84,8 +84,8 @@ impl ChunkFilter<Utf8Type> for Utf8Chunked {
         let (left, filter) = align_chunks_binary(self, filter);
 
         let chunks = left
-            .downcast_chunks()
-            .zip(filter.downcast_chunks())
+            .downcast_iter()
+            .zip(filter.downcast_iter())
             .map(|(left, mask)| filter_fn(left, mask).unwrap())
             .collect::<Vec<_>>();
         Ok(ChunkedArray::new_from_chunks(self.name(), chunks))
@@ -114,8 +114,8 @@ impl ChunkFilter<ListType> for ListChunked {
         let (left, filter) = align_chunks_binary(self, filter);
 
         let chunks = left
-            .downcast_chunks()
-            .zip(filter.downcast_chunks())
+            .downcast_iter()
+            .zip(filter.downcast_iter())
             .map(|(left, mask)| filter_fn(left, mask).unwrap())
             .collect::<Vec<_>>();
         Ok(ChunkedArray::new_from_chunks(self.name(), chunks))
@@ -143,7 +143,7 @@ where
                 "cannot filter empty object array".into(),
             ));
         }
-        let chunks = self.downcast_chunks().collect::<Vec<_>>();
+        let chunks = self.downcast_iter().collect::<Vec<_>>();
         let mut builder = ObjectChunkedBuilder::<T>::new(self.name(), self.len());
         for (idx, mask) in filter.into_iter().enumerate() {
             if mask.unwrap_or(false) {

--- a/polars/polars-core/src/chunked_array/ops/filter.rs
+++ b/polars/polars-core/src/chunked_array/ops/filter.rs
@@ -43,9 +43,8 @@ where
 
         let chunks = left
             .downcast_chunks()
-            .iter()
             .zip(filter.downcast_chunks())
-            .map(|(&left, mask)| filter_fn(left, mask).unwrap())
+            .map(|(left, mask)| filter_fn(left, mask).unwrap())
             .collect::<Vec<_>>();
         Ok(ChunkedArray::new_from_chunks(self.name(), chunks))
     }
@@ -65,9 +64,8 @@ impl ChunkFilter<BooleanType> for BooleanChunked {
 
         let chunks = left
             .downcast_chunks()
-            .iter()
             .zip(filter.downcast_chunks())
-            .map(|(&left, mask)| filter_fn(left, mask).unwrap())
+            .map(|(left, mask)| filter_fn(left, mask).unwrap())
             .collect::<Vec<_>>();
         Ok(ChunkedArray::new_from_chunks(self.name(), chunks))
     }
@@ -87,9 +85,8 @@ impl ChunkFilter<Utf8Type> for Utf8Chunked {
 
         let chunks = left
             .downcast_chunks()
-            .iter()
             .zip(filter.downcast_chunks())
-            .map(|(&left, mask)| filter_fn(left, mask).unwrap())
+            .map(|(left, mask)| filter_fn(left, mask).unwrap())
             .collect::<Vec<_>>();
         Ok(ChunkedArray::new_from_chunks(self.name(), chunks))
     }
@@ -118,9 +115,8 @@ impl ChunkFilter<ListType> for ListChunked {
 
         let chunks = left
             .downcast_chunks()
-            .iter()
             .zip(filter.downcast_chunks())
-            .map(|(&left, mask)| filter_fn(left, mask).unwrap())
+            .map(|(left, mask)| filter_fn(left, mask).unwrap())
             .collect::<Vec<_>>();
         Ok(ChunkedArray::new_from_chunks(self.name(), chunks))
     }
@@ -147,7 +143,7 @@ where
                 "cannot filter empty object array".into(),
             ));
         }
-        let chunks = self.downcast_chunks();
+        let chunks = self.downcast_chunks().collect::<Vec<_>>();
         let mut builder = ObjectChunkedBuilder::<T>::new(self.name(), self.len());
         for (idx, mask) in filter.into_iter().enumerate() {
             if mask.unwrap_or(false) {

--- a/polars/polars-core/src/chunked_array/ops/mod.rs
+++ b/polars/polars-core/src/chunked_array/ops/mod.rs
@@ -12,6 +12,7 @@ pub(crate) mod aggregate;
 pub(crate) mod apply;
 pub(crate) mod chunkops;
 pub(crate) mod cum_agg;
+pub(crate) mod downcast;
 pub(crate) mod explode;
 pub(crate) mod fill_none;
 pub(crate) mod filter;
@@ -266,7 +267,7 @@ pub type TakeIdxIterNull<'a, INull> = TakeIdx<'a, Dummy<usize>, INull>;
 impl<'a> From<&'a UInt32Chunked> for TakeIdx<'a, Dummy<usize>, Dummy<Option<usize>>> {
     fn from(ca: &'a UInt32Chunked) -> Self {
         if ca.chunks.len() == 1 {
-            TakeIdx::Array(ca.downcast_chunks().next().unwrap())
+            TakeIdx::Array(ca.downcast_iter().next().unwrap())
         } else {
             panic!("implementation error, should be transformed to an iterator by the caller")
         }

--- a/polars/polars-core/src/chunked_array/ops/mod.rs
+++ b/polars/polars-core/src/chunked_array/ops/mod.rs
@@ -266,7 +266,7 @@ pub type TakeIdxIterNull<'a, INull> = TakeIdx<'a, Dummy<usize>, INull>;
 impl<'a> From<&'a UInt32Chunked> for TakeIdx<'a, Dummy<usize>, Dummy<Option<usize>>> {
     fn from(ca: &'a UInt32Chunked) -> Self {
         if ca.chunks.len() == 1 {
-            TakeIdx::Array(ca.downcast_chunks()[0])
+            TakeIdx::Array(ca.downcast_chunks().next().unwrap())
         } else {
             panic!("implementation error, should be transformed to an iterator by the caller")
         }

--- a/polars/polars-core/src/chunked_array/ops/set.rs
+++ b/polars/polars-core/src/chunked_array/ops/set.rs
@@ -62,8 +62,11 @@ where
             if let Some(value) = value {
                 // fast path uses kernel
                 if self.chunks.len() == 1 {
-                    let arr =
-                        set_at_idx_no_null(self.downcast_chunks()[0], idx.into_iter(), value)?;
+                    let arr = set_at_idx_no_null(
+                        self.downcast_chunks().next().unwrap(),
+                        idx.into_iter(),
+                        value,
+                    )?;
                     return Ok(Self::new_from_chunks(self.name(), vec![Arc::new(arr)]));
                 }
                 // Other fast path. Slightly slower as it does not do a memcpy

--- a/polars/polars-core/src/chunked_array/ops/set.rs
+++ b/polars/polars-core/src/chunked_array/ops/set.rs
@@ -63,7 +63,7 @@ where
                 // fast path uses kernel
                 if self.chunks.len() == 1 {
                     let arr = set_at_idx_no_null(
-                        self.downcast_chunks().next().unwrap(),
+                        self.downcast_iter().next().unwrap(),
                         idx.into_iter(),
                         value,
                     )?;
@@ -110,9 +110,9 @@ where
 
                 // apply binary kernel.
                 let chunks = left
-                    .downcast_chunks()
+                    .downcast_iter()
                     .into_iter()
-                    .zip(mask.downcast_chunks())
+                    .zip(mask.downcast_iter())
                     .map(|(arr, mask)| {
                         let a = set_with_mask(arr, mask, value);
                         Arc::new(a) as ArrayRef

--- a/polars/polars-core/src/chunked_array/ops/take.rs
+++ b/polars/polars-core/src/chunked_array/ops/take.rs
@@ -51,15 +51,15 @@ where
         I: Iterator<Item = usize>,
         INulls: Iterator<Item = Option<usize>>,
     {
-        let chunks = self.downcast_chunks();
+        let mut chunks = self.downcast_chunks();
         match indices {
             TakeIdx::Array(array) => {
                 if self.is_empty() {
                     return Self::full_null(self.name(), array.len());
                 }
                 let array = match (self.null_count(), self.chunks.len()) {
-                    (0, 1) => take_no_null_primitive(chunks[0], array) as ArrayRef,
-                    (_, 1) => take(chunks[0], array, None).unwrap(),
+                    (0, 1) => take_no_null_primitive(chunks.next().unwrap(), array) as ArrayRef,
+                    (_, 1) => take(chunks.next().unwrap(), array, None).unwrap(),
                     _ => {
                         return if array.null_count() == 0 {
                             let iter = array.values().iter().map(|i| *i as usize);
@@ -83,8 +83,11 @@ where
                     return Self::full_null(self.name(), iter.size_hint().0);
                 }
                 let array = match (self.null_count(), self.chunks.len()) {
-                    (0, 1) => take_no_null_primitive_iter_unchecked(chunks[0], iter) as ArrayRef,
-                    (_, 1) => take_primitive_iter_unchecked(chunks[0], iter) as ArrayRef,
+                    (0, 1) => take_no_null_primitive_iter_unchecked(chunks.next().unwrap(), iter)
+                        as ArrayRef,
+                    (_, 1) => {
+                        take_primitive_iter_unchecked(chunks.next().unwrap(), iter) as ArrayRef
+                    }
                     _ => {
                         let mut ca = take_primitive_iter_n_chunks(self, iter);
                         ca.rename(self.name());
@@ -99,9 +102,12 @@ where
                 }
                 let array = match (self.null_count(), self.chunks.len()) {
                     (0, 1) => {
-                        take_no_null_primitive_opt_iter_unchecked(chunks[0], iter) as ArrayRef
+                        take_no_null_primitive_opt_iter_unchecked(chunks.next().unwrap(), iter)
+                            as ArrayRef
                     }
-                    (_, 1) => take_primitive_opt_iter_unchecked(chunks[0], iter) as ArrayRef,
+                    (_, 1) => {
+                        take_primitive_opt_iter_unchecked(chunks.next().unwrap(), iter) as ArrayRef
+                    }
                     _ => {
                         let mut ca = take_primitive_opt_iter_n_chunks(self, iter);
                         ca.rename(self.name());
@@ -119,14 +125,14 @@ where
         I: Iterator<Item = usize>,
         INulls: Iterator<Item = Option<usize>>,
     {
-        let chunks = self.downcast_chunks();
+        let mut chunks = self.downcast_chunks();
         match indices {
             TakeIdx::Array(array) => {
                 if self.is_empty() {
                     return Self::full_null(self.name(), array.len());
                 }
                 let array = match self.chunks.len() {
-                    1 => take(chunks[0], array, None).unwrap(),
+                    1 => take(chunks.next().unwrap(), array, None).unwrap(),
                     _ => {
                         let iter = array
                             .into_iter()
@@ -144,8 +150,8 @@ where
                     return Self::full_null(self.name(), iter.size_hint().0);
                 }
                 let array = match (self.null_count(), self.chunks.len()) {
-                    (0, 1) => take_no_null_primitive_iter(chunks[0], iter) as ArrayRef,
-                    (_, 1) => take_primitive_iter(chunks[0], iter) as ArrayRef,
+                    (0, 1) => take_no_null_primitive_iter(chunks.next().unwrap(), iter) as ArrayRef,
+                    (_, 1) => take_primitive_iter(chunks.next().unwrap(), iter) as ArrayRef,
                     _ => {
                         let mut ca = take_primitive_iter_n_chunks(self, iter);
                         ca.rename(self.name());
@@ -168,14 +174,14 @@ impl ChunkTake for BooleanChunked {
         I: Iterator<Item = usize>,
         INulls: Iterator<Item = Option<usize>>,
     {
-        let chunks = self.downcast_chunks();
+        let mut chunks = self.downcast_chunks();
         match indices {
             TakeIdx::Array(array) => {
                 if self.is_empty() {
                     return Self::full_null(self.name(), array.len());
                 }
                 let array = match self.chunks.len() {
-                    1 => take(chunks[0], array, None).unwrap(),
+                    1 => take(chunks.next().unwrap(), array, None).unwrap(),
                     _ => {
                         return if array.null_count() == 0 {
                             let iter = array.values().iter().map(|i| *i as usize);
@@ -199,8 +205,10 @@ impl ChunkTake for BooleanChunked {
                     return Self::full_null(self.name(), iter.size_hint().0);
                 }
                 let array = match (self.null_count(), self.chunks.len()) {
-                    (0, 1) => take_no_null_bool_iter_unchecked(chunks[0], iter) as ArrayRef,
-                    (_, 1) => take_bool_iter_unchecked(chunks[0], iter) as ArrayRef,
+                    (0, 1) => {
+                        take_no_null_bool_iter_unchecked(chunks.next().unwrap(), iter) as ArrayRef
+                    }
+                    (_, 1) => take_bool_iter_unchecked(chunks.next().unwrap(), iter) as ArrayRef,
                     _ => {
                         let mut ca: BooleanChunked = take_iter_n_chunks!(self, iter);
                         ca.rename(self.name());
@@ -214,8 +222,11 @@ impl ChunkTake for BooleanChunked {
                     return Self::full_null(self.name(), iter.size_hint().0);
                 }
                 let array = match (self.null_count(), self.chunks.len()) {
-                    (0, 1) => take_no_null_bool_opt_iter_unchecked(chunks[0], iter) as ArrayRef,
-                    (_, 1) => take_bool_opt_iter_unchecked(chunks[0], iter) as ArrayRef,
+                    (0, 1) => take_no_null_bool_opt_iter_unchecked(chunks.next().unwrap(), iter)
+                        as ArrayRef,
+                    (_, 1) => {
+                        take_bool_opt_iter_unchecked(chunks.next().unwrap(), iter) as ArrayRef
+                    }
                     _ => {
                         let mut ca: BooleanChunked = take_opt_iter_n_chunks!(self, iter);
                         ca.rename(self.name());
@@ -233,14 +244,14 @@ impl ChunkTake for BooleanChunked {
         I: Iterator<Item = usize>,
         INulls: Iterator<Item = Option<usize>>,
     {
-        let chunks = self.downcast_chunks();
+        let mut chunks = self.downcast_chunks();
         match indices {
             TakeIdx::Array(array) => {
                 if self.is_empty() {
                     return Self::full_null(self.name(), array.len());
                 }
                 let array = match self.chunks.len() {
-                    1 => take(chunks[0], array, None).unwrap(),
+                    1 => take(chunks.next().unwrap(), array, None).unwrap(),
                     _ => {
                         let iter = array.values().iter().map(|i| *i as usize);
                         let mut ca: BooleanChunked = take_iter_n_chunks!(self, iter);
@@ -255,8 +266,8 @@ impl ChunkTake for BooleanChunked {
                     return Self::full_null(self.name(), iter.size_hint().0);
                 }
                 let array = match (self.null_count(), self.chunks.len()) {
-                    (0, 1) => take_no_null_bool_iter(chunks[0], iter) as ArrayRef,
-                    (_, 1) => take_bool_iter(chunks[0], iter) as ArrayRef,
+                    (0, 1) => take_no_null_bool_iter(chunks.next().unwrap(), iter) as ArrayRef,
+                    (_, 1) => take_bool_iter(chunks.next().unwrap(), iter) as ArrayRef,
                     _ => {
                         let mut ca: BooleanChunked = take_iter_n_chunks!(self, iter);
                         ca.rename(self.name());
@@ -279,14 +290,14 @@ impl ChunkTake for Utf8Chunked {
         I: Iterator<Item = usize>,
         INulls: Iterator<Item = Option<usize>>,
     {
-        let chunks = self.downcast_chunks();
+        let mut chunks = self.downcast_chunks();
         match indices {
             TakeIdx::Array(array) => {
                 if self.is_empty() {
                     return Self::full_null(self.name(), array.len());
                 }
                 let array = match self.chunks.len() {
-                    1 => take_utf8(chunks[0], array) as ArrayRef,
+                    1 => take_utf8(chunks.next().unwrap(), array) as ArrayRef,
                     _ => {
                         return if array.null_count() == 0 {
                             let iter = array.values().iter().map(|i| *i as usize);
@@ -310,8 +321,10 @@ impl ChunkTake for Utf8Chunked {
                     return Self::full_null(self.name(), iter.size_hint().0);
                 }
                 let array = match (self.null_count(), self.chunks.len()) {
-                    (0, 1) => take_no_null_utf8_iter_unchecked(chunks[0], iter) as ArrayRef,
-                    (_, 1) => take_utf8_iter_unchecked(chunks[0], iter) as ArrayRef,
+                    (0, 1) => {
+                        take_no_null_utf8_iter_unchecked(chunks.next().unwrap(), iter) as ArrayRef
+                    }
+                    (_, 1) => take_utf8_iter_unchecked(chunks.next().unwrap(), iter) as ArrayRef,
                     _ => {
                         let mut ca: Utf8Chunked = take_iter_n_chunks!(self, iter);
                         ca.rename(self.name());
@@ -325,8 +338,11 @@ impl ChunkTake for Utf8Chunked {
                     return Self::full_null(self.name(), iter.size_hint().0);
                 }
                 let array = match (self.null_count(), self.chunks.len()) {
-                    (0, 1) => take_no_null_utf8_opt_iter_unchecked(chunks[0], iter) as ArrayRef,
-                    (_, 1) => take_utf8_opt_iter_unchecked(chunks[0], iter) as ArrayRef,
+                    (0, 1) => take_no_null_utf8_opt_iter_unchecked(chunks.next().unwrap(), iter)
+                        as ArrayRef,
+                    (_, 1) => {
+                        take_utf8_opt_iter_unchecked(chunks.next().unwrap(), iter) as ArrayRef
+                    }
                     _ => {
                         let mut ca: Utf8Chunked = take_opt_iter_n_chunks!(self, iter);
                         ca.rename(self.name());
@@ -344,14 +360,14 @@ impl ChunkTake for Utf8Chunked {
         I: Iterator<Item = usize>,
         INulls: Iterator<Item = Option<usize>>,
     {
-        let chunks = self.downcast_chunks();
+        let mut chunks = self.downcast_chunks();
         match indices {
             TakeIdx::Array(array) => {
                 if self.is_empty() {
                     return Self::full_null(self.name(), array.len());
                 }
                 let array = match self.chunks.len() {
-                    1 => take(chunks[0], array, None).unwrap() as ArrayRef,
+                    1 => take(chunks.next().unwrap(), array, None).unwrap() as ArrayRef,
                     _ => {
                         let iter = array.values().iter().map(|i| *i as usize);
                         let mut ca: Utf8Chunked = take_iter_n_chunks!(self, iter);
@@ -366,8 +382,8 @@ impl ChunkTake for Utf8Chunked {
                     return Self::full_null(self.name(), iter.size_hint().0);
                 }
                 let array = match (self.null_count(), self.chunks.len()) {
-                    (0, 1) => take_no_null_utf8_iter(chunks[0], iter) as ArrayRef,
-                    (_, 1) => take_utf8_iter(chunks[0], iter) as ArrayRef,
+                    (0, 1) => take_no_null_utf8_iter(chunks.next().unwrap(), iter) as ArrayRef,
+                    (_, 1) => take_utf8_iter(chunks.next().unwrap(), iter) as ArrayRef,
                     _ => {
                         let mut ca: Utf8Chunked = take_iter_n_chunks!(self, iter);
                         ca.rename(self.name());
@@ -399,14 +415,14 @@ impl ChunkTake for ListChunked {
         I: Iterator<Item = usize>,
         INulls: Iterator<Item = Option<usize>>,
     {
-        let chunks = self.downcast_chunks();
+        let mut chunks = self.downcast_chunks();
         match indices {
             TakeIdx::Array(array) => {
                 if self.is_empty() {
                     return Self::full_null(self.name(), array.len());
                 }
                 let array = match self.chunks.len() {
-                    1 => take(chunks[0], array, None).unwrap() as ArrayRef,
+                    1 => take(chunks.next().unwrap(), array, None).unwrap() as ArrayRef,
                     _ => {
                         let ca = self.rechunk();
                         return ca.take(indices);
@@ -501,11 +517,16 @@ pub trait IntoTakeRandom<'a> {
 /// Choose the Struct for multiple chunks or the struct for a single chunk.
 macro_rules! many_or_single {
     ($self:ident, $StructSingle:ident, $StructMany:ident) => {{
-        let chunks = $self.downcast_chunks();
-        if chunks.len() == 1 {
-            Box::new($StructSingle { arr: chunks[0] })
+        let mut chunks = $self.downcast_chunks();
+        if $self.chunks.len() == 1 {
+            Box::new($StructSingle {
+                arr: chunks.next().unwrap(),
+            })
         } else {
-            Box::new($StructMany { ca: $self, chunks })
+            Box::new($StructMany {
+                ca: $self,
+                chunks: chunks.collect(),
+            })
         }
     }};
 }
@@ -521,11 +542,16 @@ where
         match self.cont_slice() {
             Ok(slice) => Box::new(NumTakeRandomCont { slice }),
             _ => {
-                let chunks = self.downcast_chunks();
-                if chunks.len() == 1 {
-                    Box::new(NumTakeRandomSingleChunk { arr: chunks[0] })
+                let mut chunks = self.downcast_chunks();
+                if self.chunks.len() == 1 {
+                    Box::new(NumTakeRandomSingleChunk {
+                        arr: chunks.next().unwrap(),
+                    })
                 } else {
-                    Box::new(NumTakeRandomChunked { ca: self, chunks })
+                    Box::new(NumTakeRandomChunked {
+                        ca: self,
+                        chunks: chunks.collect(),
+                    })
                 }
             }
         }
@@ -555,14 +581,17 @@ impl<'a> IntoTakeRandom<'a> for &'a ListChunked {
     type TakeRandom = Box<dyn TakeRandom<Item = Self::Item> + 'a>;
 
     fn take_rand(&self) -> Self::TakeRandom {
-        let chunks = self.downcast_chunks();
-        if chunks.len() == 1 {
+        let mut chunks = self.downcast_chunks();
+        if self.chunks.len() == 1 {
             Box::new(ListTakeRandomSingleChunk {
-                arr: chunks[0],
+                arr: chunks.next().unwrap(),
                 name: self.name(),
             })
         } else {
-            Box::new(ListTakeRandom { ca: self, chunks })
+            Box::new(ListTakeRandom {
+                ca: self,
+                chunks: chunks.collect(),
+            })
         }
     }
 }

--- a/polars/polars-core/src/chunked_array/ops/zip.rs
+++ b/polars/polars-core/src/chunked_array/ops/zip.rs
@@ -63,10 +63,9 @@ where
             let (left, right, mask) = align_chunks_ternary(self, other, mask);
             let chunks = left
                 .downcast_chunks()
-                .iter()
-                .zip(&right.downcast_chunks())
-                .zip(&mask.downcast_chunks())
-                .map(|((&left_c, &right_c), mask_c)| {
+                .zip(right.downcast_chunks())
+                .zip(mask.downcast_chunks())
+                .map(|((left_c, right_c), mask_c)| {
                     let arr = zip(mask_c, left_c, right_c)?;
                     Ok(arr)
                 })
@@ -85,10 +84,9 @@ impl ChunkZip<BooleanType> for BooleanChunked {
             let (left, right, mask) = align_chunks_ternary(self, other, mask);
             let chunks = left
                 .downcast_chunks()
-                .iter()
-                .zip(&right.downcast_chunks())
-                .zip(&mask.downcast_chunks())
-                .map(|((&left_c, &right_c), mask_c)| {
+                .zip(right.downcast_chunks())
+                .zip(mask.downcast_chunks())
+                .map(|((left_c, right_c), mask_c)| {
                     let arr = zip(mask_c, left_c, right_c)?;
                     Ok(arr)
                 })
@@ -106,10 +104,9 @@ impl ChunkZip<Utf8Type> for Utf8Chunked {
             let (left, right, mask) = align_chunks_ternary(self, other, mask);
             let chunks = left
                 .downcast_chunks()
-                .iter()
-                .zip(&right.downcast_chunks())
-                .zip(&mask.downcast_chunks())
-                .map(|((&left_c, &right_c), mask_c)| {
+                .zip(right.downcast_chunks())
+                .zip(mask.downcast_chunks())
+                .map(|((left_c, right_c), mask_c)| {
                     let arr = zip(mask_c, left_c, right_c)?;
                     Ok(arr)
                 })
@@ -127,10 +124,9 @@ impl ChunkZip<ListType> for ListChunked {
         let (left, right, mask) = align_chunks_ternary(self, other, mask);
         let chunks = left
             .downcast_chunks()
-            .iter()
-            .zip(&right.downcast_chunks())
-            .zip(&mask.downcast_chunks())
-            .map(|((&left_c, &right_c), mask_c)| {
+            .zip(right.downcast_chunks())
+            .zip(mask.downcast_chunks())
+            .map(|((left_c, right_c), mask_c)| {
                 let arr = zip(mask_c, left_c, right_c)?;
                 Ok(arr)
             })

--- a/polars/polars-core/src/chunked_array/ops/zip.rs
+++ b/polars/polars-core/src/chunked_array/ops/zip.rs
@@ -62,9 +62,9 @@ where
         } else {
             let (left, right, mask) = align_chunks_ternary(self, other, mask);
             let chunks = left
-                .downcast_chunks()
-                .zip(right.downcast_chunks())
-                .zip(mask.downcast_chunks())
+                .downcast_iter()
+                .zip(right.downcast_iter())
+                .zip(mask.downcast_iter())
                 .map(|((left_c, right_c), mask_c)| {
                     let arr = zip(mask_c, left_c, right_c)?;
                     Ok(arr)
@@ -83,9 +83,9 @@ impl ChunkZip<BooleanType> for BooleanChunked {
         } else {
             let (left, right, mask) = align_chunks_ternary(self, other, mask);
             let chunks = left
-                .downcast_chunks()
-                .zip(right.downcast_chunks())
-                .zip(mask.downcast_chunks())
+                .downcast_iter()
+                .zip(right.downcast_iter())
+                .zip(mask.downcast_iter())
                 .map(|((left_c, right_c), mask_c)| {
                     let arr = zip(mask_c, left_c, right_c)?;
                     Ok(arr)
@@ -103,9 +103,9 @@ impl ChunkZip<Utf8Type> for Utf8Chunked {
         } else {
             let (left, right, mask) = align_chunks_ternary(self, other, mask);
             let chunks = left
-                .downcast_chunks()
-                .zip(right.downcast_chunks())
-                .zip(mask.downcast_chunks())
+                .downcast_iter()
+                .zip(right.downcast_iter())
+                .zip(mask.downcast_iter())
                 .map(|((left_c, right_c), mask_c)| {
                     let arr = zip(mask_c, left_c, right_c)?;
                     Ok(arr)
@@ -123,9 +123,9 @@ impl ChunkZip<ListType> for ListChunked {
     ) -> Result<ChunkedArray<ListType>> {
         let (left, right, mask) = align_chunks_ternary(self, other, mask);
         let chunks = left
-            .downcast_chunks()
-            .zip(right.downcast_chunks())
-            .zip(mask.downcast_chunks())
+            .downcast_iter()
+            .zip(right.downcast_iter())
+            .zip(mask.downcast_iter())
             .map(|((left_c, right_c), mask_c)| {
                 let arr = zip(mask_c, left_c, right_c)?;
                 Ok(arr)

--- a/polars/polars-core/src/frame/groupby/mod.rs
+++ b/polars/polars-core/src/frame/groupby/mod.rs
@@ -781,7 +781,7 @@ where
                     match (self.null_count(), self.chunks.len()) {
                         (0, 1) => unsafe {
                             take_agg_no_null_primitive_iter_unchecked(
-                                self.downcast_chunks()[0],
+                                self.downcast_chunks().next().unwrap(),
                                 idx.iter().map(|i| *i as usize),
                                 |a, b| a + b,
                                 T::Native::zero(),
@@ -791,7 +791,7 @@ where
                         .map(|sum| sum / idx.len() as f64),
                         (_, 1) => unsafe {
                             take_agg_primitive_iter_unchecked(
-                                self.downcast_chunks()[0],
+                                self.downcast_chunks().next().unwrap(),
                                 idx.iter().map(|i| *i as usize),
                                 |a, b| a + b,
                                 T::Native::zero(),
@@ -823,7 +823,7 @@ where
                         match (self.null_count(), self.chunks.len()) {
                             (0, 1) => Some(unsafe {
                                 take_agg_no_null_primitive_iter_unchecked(
-                                    self.downcast_chunks()[0],
+                                    self.downcast_chunks().next().unwrap(),
                                     idx.iter().map(|i| *i as usize),
                                     |a, b| if a < b { a } else { b },
                                     T::Native::max_value(),
@@ -831,7 +831,7 @@ where
                             }),
                             (_, 1) => unsafe {
                                 take_agg_primitive_iter_unchecked(
-                                    self.downcast_chunks()[0],
+                                    self.downcast_chunks().next().unwrap(),
                                     idx.iter().map(|i| *i as usize),
                                     |a, b| if a < b { a } else { b },
                                     T::Native::max_value(),
@@ -862,7 +862,7 @@ where
                         match (self.null_count(), self.chunks.len()) {
                             (0, 1) => Some(unsafe {
                                 take_agg_no_null_primitive_iter_unchecked(
-                                    self.downcast_chunks()[0],
+                                    self.downcast_chunks().next().unwrap(),
                                     idx.iter().map(|i| *i as usize),
                                     |a, b| if a > b { a } else { b },
                                     T::Native::min_value(),
@@ -870,7 +870,7 @@ where
                             }),
                             (_, 1) => unsafe {
                                 take_agg_primitive_iter_unchecked(
-                                    self.downcast_chunks()[0],
+                                    self.downcast_chunks().next().unwrap(),
                                     idx.iter().map(|i| *i as usize),
                                     |a, b| if a > b { a } else { b },
                                     T::Native::min_value(),
@@ -901,7 +901,7 @@ where
                         match (self.null_count(), self.chunks.len()) {
                             (0, 1) => Some(unsafe {
                                 take_agg_no_null_primitive_iter_unchecked(
-                                    self.downcast_chunks()[0],
+                                    self.downcast_chunks().next().unwrap(),
                                     idx.iter().map(|i| *i as usize),
                                     |a, b| a + b,
                                     T::Native::zero(),
@@ -909,7 +909,7 @@ where
                             }),
                             (_, 1) => unsafe {
                                 take_agg_primitive_iter_unchecked(
-                                    self.downcast_chunks()[0],
+                                    self.downcast_chunks().next().unwrap(),
                                     idx.iter().map(|i| *i as usize),
                                     |a, b| a + b,
                                     T::Native::zero(),
@@ -1260,7 +1260,7 @@ where
                     let group_vals =
                         unsafe { self.take_unchecked(idx.iter().map(|i| *i as usize).into()) };
                     let sorted_idx_ca = group_vals.argsort(false);
-                    let sorted_idx = sorted_idx_ca.downcast_chunks()[0].values();
+                    let sorted_idx = sorted_idx_ca.downcast_chunks().next().unwrap().values();
                     let quant_idx = (quantile * (sorted_idx.len() - 1) as f64) as usize;
                     let value_idx = sorted_idx[quant_idx];
                     group_vals.get(value_idx as usize)

--- a/polars/polars-core/src/frame/groupby/mod.rs
+++ b/polars/polars-core/src/frame/groupby/mod.rs
@@ -398,14 +398,14 @@ where
                 if self.null_count() == 0 {
                     let iters = splitted
                         .iter()
-                        .map(|ca| ca.downcast_chunks().into_iter().map(|array| array.values()))
+                        .map(|ca| ca.downcast_iter().map(|array| array.values()))
                         .flatten()
                         .collect_vec();
                     groupby_threaded_flat(iters, group_size_hint)
                 } else {
                     let iters = splitted
                         .iter()
-                        .map(|ca| ca.downcast_chunks().into_iter())
+                        .map(|ca| ca.downcast_iter())
                         .flatten()
                         .collect_vec();
                     groupby_threaded_flat(iters, group_size_hint)
@@ -781,7 +781,7 @@ where
                     match (self.null_count(), self.chunks.len()) {
                         (0, 1) => unsafe {
                             take_agg_no_null_primitive_iter_unchecked(
-                                self.downcast_chunks().next().unwrap(),
+                                self.downcast_iter().next().unwrap(),
                                 idx.iter().map(|i| *i as usize),
                                 |a, b| a + b,
                                 T::Native::zero(),
@@ -791,7 +791,7 @@ where
                         .map(|sum| sum / idx.len() as f64),
                         (_, 1) => unsafe {
                             take_agg_primitive_iter_unchecked(
-                                self.downcast_chunks().next().unwrap(),
+                                self.downcast_iter().next().unwrap(),
                                 idx.iter().map(|i| *i as usize),
                                 |a, b| a + b,
                                 T::Native::zero(),
@@ -823,7 +823,7 @@ where
                         match (self.null_count(), self.chunks.len()) {
                             (0, 1) => Some(unsafe {
                                 take_agg_no_null_primitive_iter_unchecked(
-                                    self.downcast_chunks().next().unwrap(),
+                                    self.downcast_iter().next().unwrap(),
                                     idx.iter().map(|i| *i as usize),
                                     |a, b| if a < b { a } else { b },
                                     T::Native::max_value(),
@@ -831,7 +831,7 @@ where
                             }),
                             (_, 1) => unsafe {
                                 take_agg_primitive_iter_unchecked(
-                                    self.downcast_chunks().next().unwrap(),
+                                    self.downcast_iter().next().unwrap(),
                                     idx.iter().map(|i| *i as usize),
                                     |a, b| if a < b { a } else { b },
                                     T::Native::max_value(),
@@ -862,7 +862,7 @@ where
                         match (self.null_count(), self.chunks.len()) {
                             (0, 1) => Some(unsafe {
                                 take_agg_no_null_primitive_iter_unchecked(
-                                    self.downcast_chunks().next().unwrap(),
+                                    self.downcast_iter().next().unwrap(),
                                     idx.iter().map(|i| *i as usize),
                                     |a, b| if a > b { a } else { b },
                                     T::Native::min_value(),
@@ -870,7 +870,7 @@ where
                             }),
                             (_, 1) => unsafe {
                                 take_agg_primitive_iter_unchecked(
-                                    self.downcast_chunks().next().unwrap(),
+                                    self.downcast_iter().next().unwrap(),
                                     idx.iter().map(|i| *i as usize),
                                     |a, b| if a > b { a } else { b },
                                     T::Native::min_value(),
@@ -901,7 +901,7 @@ where
                         match (self.null_count(), self.chunks.len()) {
                             (0, 1) => Some(unsafe {
                                 take_agg_no_null_primitive_iter_unchecked(
-                                    self.downcast_chunks().next().unwrap(),
+                                    self.downcast_iter().next().unwrap(),
                                     idx.iter().map(|i| *i as usize),
                                     |a, b| a + b,
                                     T::Native::zero(),
@@ -909,7 +909,7 @@ where
                             }),
                             (_, 1) => unsafe {
                                 take_agg_primitive_iter_unchecked(
-                                    self.downcast_chunks().next().unwrap(),
+                                    self.downcast_iter().next().unwrap(),
                                     idx.iter().map(|i| *i as usize),
                                     |a, b| a + b,
                                     T::Native::zero(),
@@ -1260,7 +1260,7 @@ where
                     let group_vals =
                         unsafe { self.take_unchecked(idx.iter().map(|i| *i as usize).into()) };
                     let sorted_idx_ca = group_vals.argsort(false);
-                    let sorted_idx = sorted_idx_ca.downcast_chunks().next().unwrap().values();
+                    let sorted_idx = sorted_idx_ca.downcast_iter().next().unwrap().values();
                     let quant_idx = (quantile * (sorted_idx.len() - 1) as f64) as usize;
                     let value_idx = sorted_idx[quant_idx];
                     group_vals.get(value_idx as usize)

--- a/polars/polars-core/src/prelude.rs
+++ b/polars/polars-core/src/prelude.rs
@@ -16,7 +16,7 @@ pub use crate::{
             window::InitFold,
             *,
         },
-        ChunkedArray, Downcast, NoNull,
+        ChunkedArray, NoNull,
     },
     datatypes,
     datatypes::*,

--- a/polars/polars-core/src/series/implementations/object.rs
+++ b/polars/polars-core/src/series/implementations/object.rs
@@ -226,6 +226,7 @@ where
     }
 
     fn get_as_any(&self, index: usize) -> &dyn Any {
-        ObjectChunked::get_as_any(&self.0, index)
+        debug_assert!(index < self.0.len());
+        unsafe { ObjectChunked::get_as_any(&self.0, index) }
     }
 }

--- a/polars/polars-core/src/vector_hasher.rs
+++ b/polars/polars-core/src/vector_hasher.rs
@@ -252,9 +252,8 @@ pub(crate) fn df_rows_to_hashes(
         iter.fold(first, |acc, s| {
             let chunks = acc
                 .data_views()
-                .iter()
                 .zip(s.data_views())
-                .map(|(&array_left, array_right)| {
+                .map(|(array_left, array_right)| {
                     let av: AlignedVec<_> = array_left
                         .iter()
                         .zip(array_right)

--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -1106,7 +1106,7 @@ dependencies = [
 
 [[package]]
 name = "py-polars"
-version = "0.7.6-beta.1"
+version = "0.7.6-beta.2"
 dependencies = [
  "libc",
  "ndarray",

--- a/py-polars/Cargo.toml
+++ b/py-polars/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "py-polars"
-version = "0.7.6-beta.1"
+version = "0.7.6-beta.2"
 authors = ["ritchie46 <ritchie46@gmail.com>"]
 edition = "2018"
 readme = "README.md"


### PR DESCRIPTION
`downcast_chunks` was used a lot throughout the code base. This method collected to a `Vec<_>`, which was redundant. 