### PR TITLE
improve performance ChunkedArray<Primitive>::no_null_iter

### DIFF
--- a/polars/polars-arrow/src/utils.rs
+++ b/polars/polars-arrow/src/utils.rs
@@ -7,6 +7,7 @@ impl<I, J> TrustMyLength<I, J>
 where
     I: Iterator<Item = J>,
 {
+    #[inline]
     pub fn new(iter: I, len: usize) -> Self {
         Self { iter, len }
     }
@@ -18,11 +19,24 @@ where
 {
     type Item = J;
 
+    #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         self.iter.next()
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
         (self.len, Some(self.len))
+    }
+}
+
+impl<I, J> ExactSizeIterator for TrustMyLength<I, J> where I: Iterator<Item = J> {}
+
+impl<I, J> DoubleEndedIterator for TrustMyLength<I, J>
+where
+    I: Iterator<Item = J> + DoubleEndedIterator,
+{
+    #[inline]
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.iter.next_back()
     }
 }

--- a/polars/polars-core/src/chunked_array/iterator/mod.rs
+++ b/polars/polars-core/src/chunked_array/iterator/mod.rs
@@ -555,20 +555,6 @@ where
     }
 }
 
-impl<'a, T> IntoNoNullIterator for &'a ChunkedArray<T>
-where
-    T: PolarsNumericType,
-{
-    type Item = T::Native;
-    type IntoIter = Box<dyn PolarsIterator<Item = Self::Item> + 'a>;
-
-    fn into_no_null_iter(self) -> Self::IntoIter {
-        match self.chunks.len() {
-            1 => Box::new(NumIterSingleChunk::new(self)),
-            _ => Box::new(NumIterManyChunk::new(self)),
-        }
-    }
-}
 impl<'a> IntoIterator for &'a CategoricalChunked {
     type Item = Option<u32>;
     type IntoIter = Box<dyn PolarsIterator<Item = Self::Item> + 'a>;
@@ -578,11 +564,12 @@ impl<'a> IntoIterator for &'a CategoricalChunked {
     }
 }
 
-impl<'a> IntoNoNullIterator for &'a CategoricalChunked {
-    type Item = u32;
-    type IntoIter = Box<dyn PolarsIterator<Item = Self::Item> + 'a>;
-
-    fn into_no_null_iter(self) -> Self::IntoIter {
+impl CategoricalChunked {
+    #[allow(clippy::wrong_self_convention)]
+    pub fn into_no_null_iter(
+        &self,
+    ) -> impl Iterator<Item = u32> + '_ + Send + Sync + ExactSizeIterator + DoubleEndedIterator
+    {
         self.deref().into_no_null_iter()
     }
 }

--- a/polars/polars-core/src/chunked_array/ops/apply.rs
+++ b/polars/polars-core/src/chunked_array/ops/apply.rs
@@ -40,7 +40,6 @@ where
     {
         let mut ca: ChunkedArray<S> = self
             .data_views()
-            .into_iter()
             .zip(self.null_bits())
             .map(|(slice, (_null_count, opt_buffer))| {
                 let vec: AlignedVec<_> = slice.iter().copied().map(f).collect();
@@ -58,7 +57,6 @@ where
     {
         let chunks = self
             .downcast_iter()
-            .into_iter()
             .map(|array| {
                 let av: AlignedVec<_> = if array.null_count() == 0 {
                     array.values().iter().map(|&v| f(Some(v))).collect()

--- a/polars/polars-core/src/chunked_array/ops/unique.rs
+++ b/polars/polars-core/src/chunked_array/ops/unique.rs
@@ -120,17 +120,13 @@ where
     unique
 }
 
-fn arg_unique_ca<'a, T>(ca: &'a ChunkedArray<T>) -> AlignedVec<u32>
-where
-    &'a ChunkedArray<T>: IntoIterator + IntoNoNullIterator,
-    T: 'a,
-    <&'a ChunkedArray<T> as IntoIterator>::Item: Eq + Hash,
-    <&'a ChunkedArray<T> as IntoNoNullIterator>::Item: Eq + Hash,
-{
-    match ca.null_count() {
-        0 => arg_unique(ca.into_no_null_iter(), ca.len()),
-        _ => arg_unique(ca.into_iter(), ca.len()),
-    }
+macro_rules! arg_unique_ca {
+    ($ca:expr) => {{
+        match $ca.null_count() {
+            0 => arg_unique($ca.into_no_null_iter(), $ca.len()),
+            _ => arg_unique($ca.into_iter(), $ca.len()),
+        }
+    }};
 }
 
 macro_rules! impl_value_counts {
@@ -163,7 +159,7 @@ where
     fn arg_unique(&self) -> Result<UInt32Chunked> {
         Ok(UInt32Chunked::new_from_aligned_vec(
             self.name(),
-            arg_unique_ca(self),
+            arg_unique_ca!(self),
         ))
     }
 
@@ -192,7 +188,7 @@ impl ChunkUnique<Utf8Type> for Utf8Chunked {
     fn arg_unique(&self) -> Result<UInt32Chunked> {
         Ok(UInt32Chunked::new_from_aligned_vec(
             self.name(),
-            arg_unique_ca(self),
+            arg_unique_ca!(self),
         ))
     }
 
@@ -219,7 +215,7 @@ impl ChunkUnique<CategoricalType> for CategoricalChunked {
     fn arg_unique(&self) -> Result<UInt32Chunked> {
         Ok(UInt32Chunked::new_from_aligned_vec(
             self.name(),
-            arg_unique_ca(self),
+            arg_unique_ca!(self),
         ))
     }
 
@@ -346,7 +342,7 @@ impl ChunkUnique<BooleanType> for BooleanChunked {
     fn arg_unique(&self) -> Result<UInt32Chunked> {
         Ok(UInt32Chunked::new_from_aligned_vec(
             self.name(),
-            arg_unique_ca(self),
+            arg_unique_ca!(self),
         ))
     }
 

--- a/py-polars/src/dispatch.rs
+++ b/py-polars/src/dispatch.rs
@@ -416,11 +416,9 @@ impl<'a> ApplyLambda<'a> for BooleanChunked {
 
 impl<'a, T> ApplyLambda<'a> for ChunkedArray<T>
 where
-    T: PyArrowPrimitiveType,
+    T: PyArrowPrimitiveType + PolarsNumericType,
     T::Native: ToPyObject + FromPyObject<'a>,
     ChunkedArray<T>: IntoSeries,
-    &'a ChunkedArray<T>:
-        IntoIterator<Item = Option<T::Native>> + IntoNoNullIterator<Item = T::Native>,
 {
     fn apply_lambda_unknown(&'a self, py: Python, lambda: &'a PyAny) -> PyResult<PySeries> {
         let mut null_count = 0;


### PR DESCRIPTION
Can use data views + flatten to increase that performance.

```
bench                   time:   [48.387 us 48.398 us 48.408 us]
                        change: [-71.112% -71.088% -71.051%] (p = 0.00 < 0.05)
                        Performance has improved.
```

Note that `copied` was slower than a closure, probably due to not being inlined.