### PR TITLE
cleanup numerical iterators

### DIFF
--- a/polars/polars-core/src/chunked_array/ops/apply.rs
+++ b/polars/polars-core/src/chunked_array/ops/apply.rs
@@ -243,7 +243,7 @@ impl ChunkApplyKernel<BooleanArray> for BooleanChunked {
 
 impl<T> ChunkApplyKernel<PrimitiveArray<T>> for ChunkedArray<T>
 where
-    T: PolarsPrimitiveType,
+    T: PolarsNumericType,
 {
     fn apply_kernel<F>(&self, f: F) -> Self
     where

--- a/polars/polars-core/src/chunked_array/ops/downcast.rs
+++ b/polars/polars-core/src/chunked_array/ops/downcast.rs
@@ -39,7 +39,7 @@ impl<'a, T> Chunks<'a, T> {
 
 impl<T> ChunkedArray<T>
 where
-    T: PolarsPrimitiveType,
+    T: PolarsNumericType,
 {
     pub fn downcast_iter(&self) -> impl Iterator<Item = &PrimitiveArray<T>> + DoubleEndedIterator {
         self.chunks.iter().map(|arr| {

--- a/py-polars/CHANGELOG.md
+++ b/py-polars/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 The Rust crate `polars` has its own changelog.
 
+### polars 0.7.6
+* bug fix
+  - fix bug in downsample: #537
+
+* feature
+  - cast categorical in csv parser: #533
+  - add many groupby-context aware operations: #534
+  - dowcast by month: #537
+
+* performance
+  - improve iterator in no null case: #538
+  - remove indirection: #536
+
 ### polars 0.7.5
 * bug fix
   - fix bug in vectorized hashing algorithm that affected groupbys with null values: #523

--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -1106,7 +1106,7 @@ dependencies = [
 
 [[package]]
 name = "py-polars"
-version = "0.7.6-beta.2"
+version = "0.7.6"
 dependencies = [
  "libc",
  "ndarray",

--- a/py-polars/Cargo.toml
+++ b/py-polars/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "py-polars"
-version = "0.7.6-beta.2"
+version = "0.7.6"
 authors = ["ritchie46 <ritchie46@gmail.com>"]
 edition = "2018"
 readme = "README.md"


### PR DESCRIPTION
Numerical iterators now can use the arrow iterators. The same could be done for the other iterators in case of null values.