### PR TITLE
Join pruning + plan combining

### DIFF
--- a/polars/polars-core/src/testing.rs
+++ b/polars/polars-core/src/testing.rs
@@ -1,9 +1,13 @@
 //! Testing utilities.
 use crate::prelude::*;
+use std::ops::Deref;
 
 impl Series {
     /// Check if series are equal. Note that `None == None` evaluates to `false`
     pub fn series_equal(&self, other: &Series) -> bool {
+        if self.get_data_ptr() == other.get_data_ptr() {
+            return true;
+        }
         if self.len() != other.len() {
             return false;
         }
@@ -32,6 +36,20 @@ impl Series {
             None => false,
             Some(sum) => sum as usize == self.len(),
         }
+    }
+
+    /// Get a pointer to the underlying data of this Series.
+    /// Can be useful for fast comparisons.
+    pub fn get_data_ptr(&self) -> usize {
+        let object = self.0.deref();
+
+        // Safety:
+        // A fat pointer consists of a data ptr and a ptr to the vtable.
+        // we specifically check that we only transmute &dyn SeriesTrait e.g.
+        // a trait object, therefore this is sound.
+        let (data_ptr, _vtable_ptr) =
+            unsafe { std::mem::transmute::<&dyn SeriesTrait, (usize, usize)>(object) };
+        data_ptr
     }
 }
 
@@ -63,12 +81,11 @@ impl DataFrame {
     }
 
     /// Checks if the Arc ptrs of the Series are equal
-    #[allow(clippy::vtable_address_comparisons)]
-    pub fn fast_equal(&self, other: &DataFrame) -> bool {
+    pub fn ptr_equal(&self, other: &DataFrame) -> bool {
         self.columns
             .iter()
             .zip(other.columns.iter())
-            .all(|(a, b)| Arc::ptr_eq(&a.0, &b.0) && a.name() == b.name() && a.len() == b.len())
+            .all(|(a, b)| a.get_data_ptr() == b.get_data_ptr())
     }
 }
 

--- a/polars/polars-io/src/csv.rs
+++ b/polars/polars-io/src/csv.rs
@@ -123,7 +123,7 @@ where
         self
     }
 
-    /// Set the CSV file's timestamp formatch array in
+    /// Set the CSV file's timestamp format array in
     pub fn with_timestamp_format(mut self, format: String) -> Self {
         self.writer_builder = self.writer_builder.with_timestamp_format(format);
         self

--- a/polars/polars-lazy/src/frame.rs
+++ b/polars/polars-lazy/src/frame.rs
@@ -231,7 +231,7 @@ impl LazyFrame {
             logical_plan = node_to_lp(lp_top, &mut expr_arena, &mut lp_arena);
         }
 
-        logical_plan.dot(&mut s, 0, "").expect("io error");
+        logical_plan.dot(&mut s, (0, 0), "").expect("io error");
         s.push_str("\n}");
         Ok(s)
     }
@@ -428,7 +428,8 @@ impl LazyFrame {
         let projection_pushdown = self.opt_state.projection_pushdown;
         let type_coercion = self.opt_state.type_coercion;
         let simplify_expr = self.opt_state.simplify_expr;
-        let agg_scan_projection = self.opt_state.agg_scan_projection;
+
+        let mut agg_scan_projection = self.opt_state.agg_scan_projection;
         let aggregate_pushdown = self.opt_state.aggregate_pushdown;
         let join_pruning = self.opt_state.join_pruning;
 
@@ -474,7 +475,8 @@ impl LazyFrame {
             rules.push(Box::new(AggregatePushdown::new()))
         }
         if join_pruning {
-            rules.push(Box::new(JoinPrune {}))
+            rules.push(Box::new(JoinPrune {}));
+            agg_scan_projection = true;
         }
 
         if agg_scan_projection {

--- a/polars/polars-lazy/src/frame.rs
+++ b/polars/polars-lazy/src/frame.rs
@@ -194,11 +194,11 @@ impl Default for OptState {
             predicate_pushdown: true,
             type_coercion: true,
             simplify_expr: true,
+            global_string_cache: true,
+            join_pruning: true,
             // will be toggled by a scan operation such as csv scan or parquet scan
             agg_scan_projection: false,
             aggregate_pushdown: false,
-            global_string_cache: true,
-            join_pruning: true,
         }
     }
 }

--- a/polars/polars-lazy/src/lib.rs
+++ b/polars/polars-lazy/src/lib.rs
@@ -90,26 +90,17 @@
 //!
 //!```rust
 //! use polars_core::prelude::*;
+//! use polars_core::df;
 //! use polars_lazy::prelude::*;
 //!
-//! let s0 = Date32Chunked::parse_from_str_slice(
-//!     "date",
-//!     &[
-//!         "2020-08-21",
-//!         "2020-08-21",
-//!         "2020-08-22",
-//!         "2020-08-23",
-//!         "2020-08-22",
-//!     ],
-//!     "%Y-%m-%d",
-//! )
-//! .into_series();
-//! let s1 = Series::new("temp", &[20, 10, 7, 9, 1]);
-//! let s2 = Series::new("rain", &[0.2, 0.1, 0.3, 0.1, 0.01]);
-//! let df = DataFrame::new(vec![s0, s1, s2]).unwrap();
+//! fn example() -> Result<DataFrame> {
+//!     let df = df!(
+//!     "date" => ["2020-08-21", "2020-08-21", "2020-08-22", "2020-08-23", "2020-08-22"],
+//!     "temp" => [20, 10, 7, 9, 1],
+//!     "rain" => [0.2, 0.1, 0.3, 0.1, 0.01]
+//!     )?;
 //!
-//! let new = df
-//!     .lazy()
+//!     df.lazy()
 //!     .groupby(vec![col("date")])
 //!     .agg(vec![
 //!         col("rain").min(),
@@ -118,7 +109,8 @@
 //!     ])
 //!     .sort("date", false)
 //!     .collect()
-//!     .unwrap();
+//!
+//! }
 //! ```
 //!
 //! #### Calling any function

--- a/polars/polars-lazy/src/logical_plan/alp.rs
+++ b/polars/polars-lazy/src/logical_plan/alp.rs
@@ -171,7 +171,7 @@ impl ALogicalPlan {
                     canonicalize(path_a).unwrap() == canonicalize(path_b).unwrap()
                 }
                 (DataFrameScan { df: df_a, .. }, DataFrameScan { df: df_b, .. }) => {
-                    df_a.fast_equal(df_b)
+                    df_a.ptr_equal(df_b)
                 }
                 (a, b) => {
                     std::mem::discriminant(a) == std::mem::discriminant(b)

--- a/polars/polars-lazy/src/utils.rs
+++ b/polars/polars-lazy/src/utils.rs
@@ -12,6 +12,23 @@ pub(crate) fn equal_aexprs(left: &[Node], right: &[Node], expr_arena: &Arena<AEx
         .all(|(l, r)| AExpr::eq(*l, *r, expr_arena))
 }
 
+pub(crate) fn remove_duplicate_aexprs(exprs: &[Node], expr_arena: &Arena<AExpr>) -> Vec<Node> {
+    let mut unique = HashSet::with_capacity_and_hasher(exprs.len(), RandomState::new());
+    let mut new = Vec::with_capacity(exprs.len());
+    for node in exprs {
+        let mut can_insert = false;
+        for name in aexpr_to_root_names(*node, expr_arena) {
+            if unique.insert(name) {
+                can_insert = true
+            }
+        }
+        if can_insert {
+            new.push(*node)
+        }
+    }
+    new
+}
+
 pub(crate) trait PushNode {
     fn push_node(&mut self, value: Node);
 }

--- a/py-polars/polars/lazy/__init__.py
+++ b/py-polars/polars/lazy/__init__.py
@@ -137,7 +137,24 @@ class LazyFrame:
         show: bool = True,
         output_path: "Optional[str]" = None,
         raw_output: bool = False,
+        figsize=(16, 12),
     ) -> "Optional[str]":
+        """
+        Show a plot of the query plan. Note that you should have graphviz installed.
+
+        Parameters
+        ----------
+        optimized
+            Optimize the query plan.
+        show
+            Show the figure.
+        output_path
+            Write the figure to disk
+        raw_output
+            Return dot syntax
+        figsize
+            Passed to matlotlib if `show` == True
+        """
         try:
             import matplotlib.pyplot as plt
             import matplotlib.image as mpimg
@@ -160,6 +177,7 @@ class LazyFrame:
                 shutil.copy(out_path, output_path)
 
             if show:
+                plt.figure(figsize=figsize)
                 img = mpimg.imread(out_path)
                 plt.imshow(img)
                 plt.show()


### PR DESCRIPTION
This example:

```python
import polars as pl
from polars import col

reddit = pl.scan_csv("reddit10k.csv.txt")

comment_by_name = (reddit
    .select([col("name").apply(lambda s: s[:1]), col("comment_karma").alias("comment")])
    .groupby("name")
    .agg([
        col("comment").n_unique().alias("unique_comment"),
        col("comment").sum()
    ])
)

link_by_name = (reddit
    .select([col("name").apply(lambda s: s[:1]), col("link_karma").alias("link")])
    .groupby("name")
    .agg([
        col("link").n_unique().alias("unique_link"),
        col("link").sum()
    ])
)

comment_by_name.join(link_by_name, on="name").show_graph()
```

Transforms this query plan:

![image](https://user-images.githubusercontent.com/3023000/115564297-a45a5e00-a2b8-11eb-8ab1-79799c99ce6c.png)

To this optimized plan:

![image](https://user-images.githubusercontent.com/3023000/115564442-bfc56900-a2b8-11eb-9ad4-ba04e04d6096.png)

And thus removes the redundant join.

@nickray  FYI

#closes #449

Still todo: remove redundant projections.