### PR TITLE
make sure that agg_list maintains dtype

### DIFF
--- a/polars/polars-lazy/src/dsl.rs
+++ b/polars/polars-lazy/src/dsl.rs
@@ -183,6 +183,8 @@ pub enum Expr {
         reverse: bool,
     },
     Agg(AggExpr),
+    /// A ternary operation
+    /// if true then "foo" else "bar"
     Ternary {
         predicate: Box<Expr>,
         truthy: Box<Expr>,
@@ -358,9 +360,6 @@ pub enum Operator {
     Modulus,
     And,
     Or,
-    Not,
-    Like,
-    NotLike,
 }
 
 pub fn binary_expr(l: Expr, op: Operator, r: Expr) -> Expr {

--- a/polars/polars-lazy/src/lib.rs
+++ b/polars/polars-lazy/src/lib.rs
@@ -189,7 +189,7 @@ pub mod dsl;
 mod dummies;
 pub mod frame;
 pub mod functions;
-mod logical_plan;
+pub mod logical_plan;
 pub mod physical_plan;
 pub mod prelude;
 pub(crate) mod utils;

--- a/polars/polars-lazy/src/logical_plan/aexpr.rs
+++ b/polars/polars-lazy/src/logical_plan/aexpr.rs
@@ -147,17 +147,14 @@ impl AExpr {
                 let right_type = arena.get(*right).get_type(schema, ctxt, arena)?;
 
                 let expr_type = match op {
-                    Operator::Not
-                    | Operator::Lt
+                    Operator::Lt
                     | Operator::Gt
                     | Operator::Eq
                     | Operator::NotEq
                     | Operator::And
                     | Operator::LtEq
                     | Operator::GtEq
-                    | Operator::Or
-                    | Operator::NotLike
-                    | Operator::Like => DataType::Boolean,
+                    | Operator::Or => DataType::Boolean,
                     _ => get_supertype(&left_type, &right_type)?,
                 };
 

--- a/polars/polars-lazy/src/logical_plan/mod.rs
+++ b/polars/polars-lazy/src/logical_plan/mod.rs
@@ -135,14 +135,14 @@ impl LiteralValue {
 // https://stackoverflow.com/questions/1031076/what-are-projection-and-selection
 #[derive(Clone)]
 pub enum LogicalPlan {
-    // filter on a boolean mask
+    /// Filter on a boolean mask
     Selection {
         input: Box<LogicalPlan>,
         predicate: Expr,
     },
-    Cache {
-        input: Box<LogicalPlan>,
-    },
+    /// Cache the input at this point in the LP
+    Cache { input: Box<LogicalPlan> },
+    /// Scan a CSV file
     CsvScan {
         path: String,
         schema: SchemaRef,
@@ -160,6 +160,7 @@ pub enum LogicalPlan {
     },
     #[cfg(feature = "parquet")]
     #[cfg_attr(docsrs, doc(cfg(feature = "parquet")))]
+    /// Scan a Parquet file
     ParquetScan {
         path: String,
         schema: SchemaRef,
@@ -170,6 +171,7 @@ pub enum LogicalPlan {
         cache: bool,
     },
     // we keep track of the projection and selection as it is cheaper to first project and then filter
+    /// In memory DataFrame
     DataFrameScan {
         df: Arc<DataFrame>,
         schema: SchemaRef,
@@ -183,12 +185,13 @@ pub enum LogicalPlan {
         input: Box<LogicalPlan>,
         schema: SchemaRef,
     },
-    // vertical selection
+    /// Column selection
     Projection {
         expr: Vec<Expr>,
         input: Box<LogicalPlan>,
         schema: SchemaRef,
     },
+    /// Groupby aggregation
     Aggregate {
         input: Box<LogicalPlan>,
         keys: Arc<Vec<Expr>>,
@@ -196,6 +199,7 @@ pub enum LogicalPlan {
         schema: SchemaRef,
         apply: Option<Arc<dyn DataFrameUdf>>,
     },
+    /// Join operation
     Join {
         input_left: Box<LogicalPlan>,
         input_right: Box<LogicalPlan>,
@@ -206,36 +210,43 @@ pub enum LogicalPlan {
         allow_par: bool,
         force_par: bool,
     },
+    /// Adding columns to the table without a Join
     HStack {
         input: Box<LogicalPlan>,
         exprs: Vec<Expr>,
         schema: SchemaRef,
     },
+    /// Remove duplicates from the table
     Distinct {
         input: Box<LogicalPlan>,
         maintain_order: bool,
         subset: Arc<Option<Vec<String>>>,
     },
+    /// Sort the table
     Sort {
         input: Box<LogicalPlan>,
         by_column: String,
         reverse: bool,
     },
+    /// An explode operation
     Explode {
         input: Box<LogicalPlan>,
         columns: Vec<String>,
     },
+    /// Slice the table
     Slice {
         input: Box<LogicalPlan>,
         offset: i64,
         len: usize,
     },
+    /// A Melt operation
     Melt {
         input: Box<LogicalPlan>,
         id_vars: Arc<Vec<String>>,
         value_vars: Arc<Vec<String>>,
         schema: SchemaRef,
     },
+    /// A User Defined Function
     Udf {
         input: Box<LogicalPlan>,
         function: Arc<dyn DataFrameUdf>,

--- a/polars/polars-lazy/src/logical_plan/optimizer/simplify_expr.rs
+++ b/polars/polars-lazy/src/logical_plan/optimizer/simplify_expr.rs
@@ -306,7 +306,6 @@ impl OptimizationRule for SimplifyExprRule {
                     Operator::LtEq => eval_binary_bool_type!(left, >=, right),
                     Operator::And => eval_and(left, right),
                     Operator::Or => eval_or(left, right),
-                    _ => None,
                 }
             }
             _ => None,

--- a/polars/polars-lazy/src/physical_plan/expressions/default.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/default.rs
@@ -168,9 +168,6 @@ pub(crate) fn apply_operator(left: &Series, right: &Series, op: Operator) -> Res
         Operator::Divide => Ok(left / right),
         Operator::And => Ok((left.bool()? & right.bool()?).into_series()),
         Operator::Or => Ok((left.bool()? | right.bool()?).into_series()),
-        Operator::Not => Ok(ChunkCompare::<&Series>::eq(left, right).into_series()),
-        Operator::Like => todo!(),
-        Operator::NotLike => todo!(),
         Operator::Modulus => Ok(left % right),
     }
 }
@@ -695,6 +692,7 @@ impl PhysicalExpr for WindowExpr {
                 format!("{:?} function not supported", self.function).into(),
             )),
         }?;
+
         let mut out = df
             .select(self.group_column.as_str())?
             .left_join(&out, self.group_column.as_str(), &self.group_column)?

--- a/py-polars/src/lazy/dsl.rs
+++ b/py-polars/src/lazy/dsl.rs
@@ -460,9 +460,6 @@ pub fn binary_expr(l: PyExpr, op: u8, r: PyExpr) -> PyExpr {
         10 => Operator::Modulus,
         11 => Operator::And,
         12 => Operator::Or,
-        13 => Operator::Not,
-        14 => Operator::Like,
-        15 => Operator::NotLike,
         _ => panic!("not an operator"),
     };
 


### PR DESCRIPTION
[This example](https://ritchie46.github.io/polars-book/how_can_i/split_apply_combine.html) in the user guide does not work anymore because the `agg_list` on a `Date64` `Series` dispatched to the implementation of `Int64`, which in case of a `List` aggregation leads to the wrong inner type.

This PR fixes that.