### PR TITLE
[Lazy] Cache window functions

### DIFF
--- a/polars/polars-core/src/frame/groupby/mod.rs
+++ b/polars/polars-core/src/frame/groupby/mod.rs
@@ -513,13 +513,7 @@ impl DataFrame {
                 }
             }
         };
-
-        Ok(GroupBy {
-            df: self,
-            selected_keys: by,
-            groups,
-            selected_agg: None,
-        })
+        Ok(GroupBy::new(self, by, groups, None))
     }
 
     /// Group DataFrame using a Series column.
@@ -608,8 +602,7 @@ pub struct GroupBy<'df, 'selection_str> {
 }
 
 impl<'df, 'selection_str> GroupBy<'df, 'selection_str> {
-    #[cfg(feature = "downsample")]
-    fn new(
+    pub fn new(
         df: &'df DataFrame,
         by: Vec<Series>,
         groups: GroupTuples,
@@ -642,6 +635,14 @@ impl<'df, 'selection_str> GroupBy<'df, 'selection_str> {
     ///     Where second value in the tuple is a vector with all matching indexes.
     pub fn get_groups(&self) -> &GroupTuples {
         &self.groups
+    }
+
+    /// Get the internal representation of the GroupBy operation.
+    /// The Vec returned contains:
+    ///     (first_idx, Vec<indexes>)
+    ///     Where second value in the tuple is a vector with all matching indexes.
+    pub fn get_groups_mut(&mut self) -> &mut GroupTuples {
+        &mut self.groups
     }
 
     pub fn keys(&self) -> Vec<Series> {

--- a/polars/polars-core/src/utils.rs
+++ b/polars/polars-core/src/utils.rs
@@ -10,6 +10,15 @@ use rayon::prelude::*;
 use std::borrow::Cow;
 use std::ops::{Deref, DerefMut};
 
+pub struct Wrap<T>(pub T);
+
+impl<T> Deref for Wrap<T> {
+    type Target = T;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
 unsafe fn index_of_unchecked<T>(slice: &[T], item: &T) -> usize {
     (item as *const _ as usize - slice.as_ptr() as usize) / std::mem::size_of::<T>()
 }

--- a/polars/polars-lazy/src/physical_plan/executors.rs
+++ b/polars/polars-lazy/src/physical_plan/executors.rs
@@ -26,7 +26,7 @@ impl<'a, R: 'static + Read + Seek + Sync + Send> FinishScanOps for CsvReader<'a,
         aggregate: Option<&[ScanAggregation]>,
     ) -> Result<DataFrame> {
         let predicate =
-            predicate.map(|expr| Arc::new(PhysicalIoHelper::new(expr)) as Arc<dyn PhysicalIoExpr>);
+            predicate.map(|expr| Arc::new(PhysicalIoHelper { expr }) as Arc<dyn PhysicalIoExpr>);
 
         let rechunk = self.rechunk;
         let mut csv_reader = self.build_inner_reader()?;
@@ -149,7 +149,7 @@ impl Executor for ParquetExec {
         let predicate = self
             .predicate
             .clone()
-            .map(|expr| Arc::new(PhysicalIoHelper::new(expr)) as Arc<dyn PhysicalIoExpr>);
+            .map(|expr| Arc::new(PhysicalIoHelper { expr }) as Arc<dyn PhysicalIoExpr>);
 
         let df = ParquetReader::new(file)
             .with_stop_after_n_rows(stop_after_n_rows)

--- a/polars/polars-lazy/src/physical_plan/expressions/default.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/default.rs
@@ -2,7 +2,7 @@ use crate::logical_plan::Context;
 use crate::physical_plan::state::ExecutionState;
 use crate::physical_plan::PhysicalAggregation;
 use crate::prelude::*;
-use polars_core::frame::groupby::{fmt_groupby_column, GroupByMethod, GroupTuples};
+use polars_core::frame::groupby::{fmt_groupby_column, GroupBy, GroupByMethod, GroupTuples};
 use polars_core::prelude::*;
 use polars_core::utils::{slice_offsets, NoNull};
 use rayon::prelude::*;
@@ -664,10 +664,42 @@ pub struct WindowExpr {
 impl PhysicalExpr for WindowExpr {
     // Note: this was first implemented with expression evaluation but this performed really bad.
     // Therefore we choose the groupby -> apply -> self join approach
-    fn evaluate(&self, df: &DataFrame, _state: &ExecutionState) -> Result<Series> {
-        let gb = df
-            .groupby(self.group_column.as_str())?
-            .select(self.apply_column.as_str());
+    fn evaluate(&self, df: &DataFrame, state: &ExecutionState) -> Result<Series> {
+        // This method does the following:
+        // 1. determine groupby tuples based on the group_column
+        // 2. apply an aggregation function
+        // 3. join the results back to the original dataframe
+        //    this stores all group values on the original df size
+        // 4. select the final column and return
+
+        // We create a key to store in the state cache
+        // assume 16 digits per ptr.
+        let mut key = String::with_capacity(df.width() * 16 + self.group_column.len());
+        key.push_str(&self.group_column);
+        df.get_columns()
+            .iter()
+            .for_each(|s| key.push_str(&format!("{}", s.get_data_ptr())));
+        let groupby_column = df.column(&self.group_column).unwrap();
+
+        // 1. get the group tuples
+        // We keep the lock for the entire window expression, we want those to be sequential
+        // The utilize parallelism enough in groupby and join operation
+        let mut groups_lock = state.group_tuples.lock().unwrap();
+        let groups = match groups_lock.get_mut(&key) {
+            Some(groups) => std::mem::take(groups),
+            None => {
+                let mut gb = df.groupby(&**self.group_column)?;
+                std::mem::take(gb.get_groups_mut())
+            }
+        };
+
+        // 2. create GroupBy object and apply aggregation
+        let mut gb = GroupBy::new(
+            df,
+            vec![groupby_column.clone()],
+            groups,
+            Some(vec![&self.apply_column]),
+        );
 
         let out = match &self.function {
             Expr::Udf { function, .. } => {
@@ -695,18 +727,27 @@ impl PhysicalExpr for WindowExpr {
                 format!("{:?} function not supported", self.function).into(),
             )),
         }?;
+        // store the group tuples and drop the lock so other threads may use them
+        groups_lock.insert(key.clone(), std::mem::take(gb.get_groups_mut()));
+        drop(groups_lock);
 
-        let mut out = df
-            .select(self.group_column.as_str())?
-            .left_join(&out, self.group_column.as_str(), &self.group_column)?
-            .select_at_idx(1)
-            .unwrap_or_else(|| {
-                panic!(
-                    "the aggregation function did not succeed on {}",
-                    self.apply_column
-                )
-            })
-            .clone();
+        // 3. get the join tuples and use them to take the new Series
+        let out_column = out.select_at_idx(1).unwrap();
+        let mut join_tuples_lock = state.join_tuples.lock().unwrap();
+        let opt_join_tuples = match join_tuples_lock.get_mut(&key) {
+            Some(t) => std::mem::take(t),
+            None => {
+                // group key from right column
+                let right = out.select_at_idx(0).unwrap();
+                groupby_column.hash_join_left(right)
+            }
+        };
+
+        let mut iter = opt_join_tuples
+            .iter()
+            .map(|(_left, right)| right.map(|i| i as usize));
+        let mut out = unsafe { out_column.take_opt_iter_unchecked(&mut iter) };
+        join_tuples_lock.insert(key, opt_join_tuples);
         out.rename(self.out_name.as_str());
         Ok(out)
     }

--- a/polars/polars-lazy/src/physical_plan/expressions/mod.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/mod.rs
@@ -49,29 +49,16 @@ pub trait PhysicalExpr: Send + Sync {
     }
 }
 
-trait ToPhysicalIoExpr {
-    fn into_physical_io_expr(self) -> Arc<dyn PhysicalIoExpr>;
-}
-
+/// Wrapper struct that allow us to use a PhysicalExpr in polars-io.
+///
+/// This is used to filter rows during the scan of file.
 pub struct PhysicalIoHelper {
-    expr: Arc<dyn PhysicalExpr>,
-}
-
-impl PhysicalIoHelper {
-    pub(crate) fn new(expr: Arc<dyn PhysicalExpr>) -> Self {
-        PhysicalIoHelper { expr }
-    }
+    pub expr: Arc<dyn PhysicalExpr>,
 }
 
 impl PhysicalIoExpr for PhysicalIoHelper {
     fn evaluate(&self, df: &DataFrame) -> Result<Series> {
         self.expr.evaluate(df)
-    }
-}
-
-impl PhysicalIoExpr for dyn PhysicalExpr {
-    fn evaluate(&self, df: &DataFrame) -> Result<Series> {
-        <Self as PhysicalExpr>::evaluate(self, df)
     }
 }
 

--- a/polars/polars-lazy/src/physical_plan/mod.rs
+++ b/polars/polars-lazy/src/physical_plan/mod.rs
@@ -1,19 +1,17 @@
 pub mod executors;
 pub mod expressions;
 pub mod planner;
+pub(crate) mod state;
 
+use crate::physical_plan::state::ExecutionState;
 use crate::prelude::*;
-use ahash::RandomState;
 use polars_core::prelude::*;
 use polars_io::PhysicalIoExpr;
-use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
 
-pub enum ExprVal {
-    Series(Series),
-    Column(Vec<String>),
-}
-
+/// A type that implements this transforms a LogicalPlan to a physical plan.
+///
+/// We could produce different physical plans with different goals in mind, e.g. memory optimized
+/// performance optimized, out of core, etc.
 pub trait PhysicalPlanner {
     fn create_physical_plan(
         &self,
@@ -27,8 +25,9 @@ pub trait PhysicalPlanner {
 // combine physical expressions, which produce Series.
 
 /// Executors will evaluate physical expressions and collect them in a DataFrame.
+///
+/// Executors have other executors as input. By having a tree of executors we can execute the
+/// physical plan until the last executor is evaluated.
 pub trait Executor: Send + Sync {
-    fn execute(&mut self, cache: &Cache) -> Result<DataFrame>;
+    fn execute(&mut self, cache: &ExecutionState) -> Result<DataFrame>;
 }
-
-pub(crate) type Cache = Arc<Mutex<HashMap<String, DataFrame, RandomState>>>;

--- a/polars/polars-lazy/src/physical_plan/state.rs
+++ b/polars/polars-lazy/src/physical_plan/state.rs
@@ -1,0 +1,39 @@
+use ahash::RandomState;
+use polars_core::frame::groupby::GroupTuples;
+use polars_core::prelude::*;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+/// State/ cache that is maintained during the Execution of the physical plan.
+#[derive(Clone)]
+pub struct ExecutionState {
+    df_cache: Arc<Mutex<HashMap<String, DataFrame, RandomState>>>,
+    gb_cache: Arc<Mutex<HashMap<String, GroupTuples, RandomState>>>,
+}
+
+impl ExecutionState {
+    pub fn new() -> Self {
+        Self {
+            df_cache: Arc::new(Mutex::new(HashMap::with_hasher(RandomState::default()))),
+            gb_cache: Arc::new(Mutex::new(HashMap::with_hasher(RandomState::default()))),
+        }
+    }
+
+    /// Check if we have DataFrame in cache
+    pub fn cache_hit(&self, key: &str) -> Option<DataFrame> {
+        let guard = self.df_cache.lock().unwrap();
+        guard.get(key).cloned()
+    }
+
+    /// Store DataFrame in cache.
+    pub fn store_cache(&self, key: String, df: DataFrame) {
+        let mut guard = self.df_cache.lock().unwrap();
+        guard.insert(key, df);
+    }
+}
+
+impl Default for ExecutionState {
+    fn default() -> Self {
+        ExecutionState::new()
+    }
+}


### PR DESCRIPTION
Window expressions do two expensive operations, a groupby and a join. They are now cached and behind a mutex so that sequential execution is ensured.