### PR TITLE
fix panic in physical dispatch of Series

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -10,6 +10,10 @@ assignees: ''
 
 Replace this text with the **Rust** or **Python**.
 
+#### Which feature gates did you use?
+
+This can be ignored by Python users.
+
 #### What version of polars are you using?
 
 Replace this text with the version.

--- a/polars/polars-core/src/series/mod.rs
+++ b/polars/polars-core/src/series/mod.rs
@@ -1233,6 +1233,26 @@ impl Series {
         };
         left.is_in_same_type(list_array)
     }
+
+    /// Cast a datelike Series to their physical representation.
+    /// Primitives remain unchanged
+    ///
+    /// * Date32 -> Int32
+    /// * Date64 -> Int64
+    /// * Time64 -> Int64
+    /// * Duration -> Int64
+    ///
+    pub fn to_physical_repr(&self) -> Series {
+        use DataType::*;
+        let out = match self.dtype() {
+            Date32 => self.cast_with_datatype(&DataType::Int32),
+            Date64 => self.cast_with_datatype(&DataType::Int64),
+            Time64(_) => self.cast_with_datatype(&DataType::Int64),
+            Duration(_) => self.cast_with_datatype(&DataType::Int64),
+            _ => return self.clone(),
+        };
+        out.unwrap()
+    }
 }
 
 impl Deref for Series {

--- a/polars/polars-lazy/src/datafusion/mod.rs
+++ b/polars/polars-lazy/src/datafusion/mod.rs
@@ -54,4 +54,21 @@ mod test {
         );
         Ok(())
     }
+    #[test]
+    fn test_datafusion_with_column() -> Result<()> {
+        let df = df! {
+            "a" => ["a", "a", "a", "b", "b", "c"],
+            "b" => [1, 2, 3, 4, 5, 6]
+        }?;
+
+        let out = df
+            .lazy()
+            .with_column(col("b").alias("c"))
+            .select(&[col("c")])
+            .ooc()?;
+
+        assert!(out.column("c").is_ok());
+        assert_eq!(out.shape(), (6, 1));
+        Ok(())
+    }
 }


### PR DESCRIPTION
Datelike dtypes are dispatched to their physical types. In case an argument is also datelike, it should also be downcast to their physical representation.