### PR TITLE
Generify file path APIs, use PathBuf instead of String

### DIFF
--- a/polars/polars-io/src/csv.rs
+++ b/polars/polars-io/src/csv.rs
@@ -61,6 +61,7 @@ pub use arrow::csv::WriterBuilder;
 use polars_core::prelude::*;
 use std::fs::File;
 use std::io::{Read, Seek, Write};
+use std::path::PathBuf;
 use std::sync::Arc;
 
 /// Write a DataFrame to csv.
@@ -184,7 +185,7 @@ where
     schema: Option<Arc<Schema>>,
     encoding: CsvEncoding,
     n_threads: Option<usize>,
-    path: Option<String>,
+    path: Option<PathBuf>,
     schema_overwrite: Option<&'a Schema>,
     sample_size: usize,
     chunk_size: usize,
@@ -296,8 +297,8 @@ where
 
     /// The preferred way to initialize this builder. This allows the CSV file to be memory mapped
     /// and thereby greatly increases parsing performance.
-    pub fn with_path(mut self, path: Option<String>) -> Self {
-        self.path = path;
+    pub fn with_path<P: Into<PathBuf>>(mut self, path: Option<P>) -> Self {
+        self.path = path.map(|p| p.into());
         self
     }
 
@@ -334,9 +335,10 @@ where
 
 impl<'a> CsvReader<'a, File> {
     /// This is the recommended way to create a csv reader as this allows for fastest parsing.
-    pub fn from_path(path: &str) -> Result<Self> {
-        let f = std::fs::File::open(path)?;
-        Ok(Self::new(f).with_path(Some(path.to_string())))
+    pub fn from_path<P: Into<PathBuf>>(path: P) -> Result<Self> {
+        let path = path.into();
+        let f = std::fs::File::open(&path)?;
+        Ok(Self::new(f).with_path(Some(path)))
     }
 }
 

--- a/polars/polars-io/src/csv_core/csv.rs
+++ b/polars/polars-io/src/csv_core/csv.rs
@@ -11,6 +11,7 @@ use rayon::prelude::*;
 use rayon::ThreadPoolBuilder;
 use std::fmt;
 use std::io::{Read, Seek};
+use std::path::PathBuf;
 use std::sync::atomic::Ordering;
 use std::sync::{atomic::AtomicUsize, Arc};
 
@@ -31,7 +32,7 @@ pub struct SequentialReader<R: Read> {
     n_rows: Option<usize>,
     encoding: CsvEncoding,
     n_threads: Option<usize>,
-    path: Option<String>,
+    path: Option<PathBuf>,
     has_header: bool,
     delimiter: u8,
     sample_size: usize,
@@ -85,7 +86,7 @@ impl<R: Read + Sync + Send> SequentialReader<R> {
         skip_rows: usize,
         encoding: CsvEncoding,
         n_threads: Option<usize>,
-        path: Option<String>,
+        path: Option<PathBuf>,
         sample_size: usize,
         chunk_size: usize,
     ) -> Self {
@@ -405,7 +406,7 @@ pub fn build_csv_reader<R: 'static + Read + Seek + Sync + Send>(
     columns: Option<Vec<String>>,
     encoding: CsvEncoding,
     n_threads: Option<usize>,
-    path: Option<String>,
+    path: Option<PathBuf>,
     schema_overwrite: Option<&Schema>,
     sample_size: usize,
     chunk_size: usize,

--- a/polars/polars-io/src/csv_core/parser.rs
+++ b/polars/polars-io/src/csv_core/parser.rs
@@ -414,7 +414,7 @@ pub(crate) fn parse_lines(
                 buffers.get_unchecked_mut(processed_fields)
             };
 
-            buf.add(&[], true, read, encoding).unwrap();
+            buf.add(&[], true, read, encoding)?;
             processed_fields += 1;
         }
 

--- a/polars/polars-io/src/lib.rs
+++ b/polars/polars-io/src/lib.rs
@@ -109,8 +109,8 @@ pub(crate) fn finish_reader<R: ArrowReader>(
         if let Some(aggregate) = aggregate {
             let cols = aggregate
                 .iter()
-                .map(|scan_agg| scan_agg.evaluate_batch(&df).unwrap())
-                .collect();
+                .map(|scan_agg| scan_agg.evaluate_batch(&df))
+                .collect::<Result<_>>()?;
             if cfg!(debug_assertions) {
                 df = DataFrame::new(cols).unwrap();
             } else {
@@ -130,8 +130,8 @@ pub(crate) fn finish_reader<R: ArrowReader>(
     if let Some(aggregate) = aggregate {
         let cols = aggregate
             .iter()
-            .map(|scan_agg| scan_agg.finish(&df).unwrap())
-            .collect();
+            .map(|scan_agg| scan_agg.finish(&df))
+            .collect::<Result<_>>()?;
         df = DataFrame::new_no_checks(cols)
     }
 

--- a/polars/polars-lazy/src/datafusion/conversion.rs
+++ b/polars/polars-lazy/src/datafusion/conversion.rs
@@ -1,4 +1,4 @@
-use crate::utils::expr_to_root_column_name;
+use crate::utils::{expr_to_root_column_name, try_path_to_str};
 use crate::{
     dsl::{AggExpr, Expr, Operator},
     logical_plan::{LiteralValue, LogicalPlan},
@@ -290,7 +290,8 @@ pub fn to_datafusion_lp(lp: LogicalPlan) -> Result<DLogicalPlan> {
             if ignore_errors || skip_rows > 0 {
                 return Err(PolarsError::Other("DataFusion does not support `ignore_errors`, `skip_rows`, `stop_after_n_rows`, `with_columns`".into()));
             }
-            let builder = LogicalPlanBuilder::scan_csv(&path, options, None).unwrap();
+            let builder =
+                LogicalPlanBuilder::scan_csv(try_path_to_str(&path)?, options, None).unwrap();
             match stop_after_n_rows {
                 Some(n) => builder.limit(n).unwrap().build().unwrap(),
                 None => builder.build().unwrap(),
@@ -302,7 +303,8 @@ pub fn to_datafusion_lp(lp: LogicalPlan) -> Result<DLogicalPlan> {
             stop_after_n_rows,
             ..
         } => {
-            let builder = LogicalPlanBuilder::scan_parquet(&path, None, 8).unwrap();
+            let builder =
+                LogicalPlanBuilder::scan_parquet(try_path_to_str(&path)?, None, 8).unwrap();
             match stop_after_n_rows {
                 Some(n) => builder.limit(n).unwrap().build().unwrap(),
                 None => builder.build().unwrap(),

--- a/polars/polars-lazy/src/logical_plan/alp.rs
+++ b/polars/polars-lazy/src/logical_plan/alp.rs
@@ -8,6 +8,7 @@ use polars_core::prelude::*;
 use polars_core::utils::{Arena, Node};
 use std::collections::HashSet;
 use std::fs::canonicalize;
+use std::path::PathBuf;
 use std::sync::Arc;
 
 // ALogicalPlan is a representation of LogicalPlan with Nodes which are allocated in an Arena
@@ -29,7 +30,7 @@ pub enum ALogicalPlan {
         predicate: Node,
     },
     CsvScan {
-        path: String,
+        path: PathBuf,
         schema: SchemaRef,
         has_header: bool,
         delimiter: u8,
@@ -43,7 +44,7 @@ pub enum ALogicalPlan {
     },
     #[cfg(feature = "parquet")]
     ParquetScan {
-        path: String,
+        path: PathBuf,
         schema: SchemaRef,
         with_columns: Option<Vec<String>>,
         predicate: Option<Node>,

--- a/polars/polars-lazy/src/utils.rs
+++ b/polars/polars-lazy/src/utils.rs
@@ -4,6 +4,7 @@ use crate::prelude::*;
 use ahash::RandomState;
 use polars_core::prelude::*;
 use std::collections::HashSet;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 pub(crate) fn equal_aexprs(left: &[Node], right: &[Node], expr_arena: &Arena<AExpr>) -> bool {
@@ -197,7 +198,7 @@ pub(crate) fn expressions_to_schema(expr: &[Expr], schema: &Schema, ctxt: Contex
 /// Get a set of the data source paths in this LogicalPlan
 pub(crate) fn agg_source_paths(
     root_lp: Node,
-    paths: &mut HashSet<String, RandomState>,
+    paths: &mut HashSet<PathBuf, RandomState>,
     lp_arena: &Arena<ALogicalPlan>,
 ) {
     use ALogicalPlan::*;
@@ -257,6 +258,13 @@ pub(crate) fn agg_source_paths(
         }
     }
 }
+
+pub(crate) fn try_path_to_str(path: &Path) -> Result<&str> {
+    path.to_str().ok_or_else(|| {
+        PolarsError::Other(format!("Non-UTF8 file path: {}", path.to_string_lossy()).into())
+    })
+}
+
 pub(crate) fn aexpr_to_root_names(node: Node, arena: &Arena<AExpr>) -> Vec<Arc<String>> {
     aexpr_to_root_nodes(node, arena)
         .into_iter()


### PR DESCRIPTION
This changes some APIs to accept anything that can be converted into a PathBuf, so users can put in `&str`, `&Path` etc. Everything should be backwards compatible.

I also replaced `String` by `PathBuf` in the backing code for better type safety and to allow usage on non-UTF8 filenames later on. I hope my usage of `to_string_lossy` in some places is correct. I only used it for debug prints and when building the dot representation.

Also, some `unwrap()` usages on Results are now replaced by `?`.