### PR TITLE
Improve categorical cast performance 

### DIFF
--- a/polars/polars-arrow/src/builder.rs
+++ b/polars/polars-arrow/src/builder.rs
@@ -98,7 +98,6 @@ impl BooleanBufferBuilder {
 
     #[inline]
     pub fn finish(&mut self) -> Buffer {
-        self.shrink_to_fit();
         let buf = std::mem::replace(&mut self.buffer, MutableBuffer::new(0));
         self.len = 0;
         buf.into()

--- a/polars/polars-core/src/chunked_array/builder/categorical.rs
+++ b/polars/polars-core/src/chunked_array/builder/categorical.rs
@@ -1,0 +1,150 @@
+use crate::prelude::*;
+use crate::use_string_cache;
+use crate::utils::arrow::array::{Array, ArrayBuilder};
+use ahash::AHashMap;
+use arrow::array::{LargeStringArray, LargeStringBuilder};
+use polars_arrow::builder::PrimitiveArrayBuilder;
+use std::marker::PhantomData;
+
+pub enum RevMappingBuilder {
+    Global(AHashMap<u32, u32>, LargeStringBuilder),
+    Local(LargeStringBuilder),
+}
+
+impl RevMappingBuilder {
+    fn insert(&mut self, idx: u32, value: &str) {
+        use RevMappingBuilder::*;
+        match self {
+            Local(builder) => builder.append_value(value).unwrap(),
+            Global(map, builder) => {
+                builder.append_value(value).unwrap();
+                let new_idx = builder.len() as u32 - 1;
+                map.insert(idx, new_idx);
+            }
+        };
+    }
+
+    fn finish(self) -> RevMapping {
+        use RevMappingBuilder::*;
+        match self {
+            Local(mut b) => RevMapping::Local(b.finish()),
+            Global(map, mut b) => RevMapping::Global(map, b.finish()),
+        }
+    }
+}
+
+pub enum RevMapping {
+    Global(AHashMap<u32, u32>, LargeStringArray),
+    Local(LargeStringArray),
+}
+
+#[allow(clippy::len_without_is_empty)]
+impl RevMapping {
+    pub fn len(&self) -> usize {
+        match self {
+            Self::Global(_, a) => a.len(),
+            Self::Local(a) => a.len(),
+        }
+    }
+
+    pub fn get(&self, idx: u32) -> &str {
+        match self {
+            Self::Global(map, a) => {
+                let idx = *map.get(&idx).unwrap();
+                a.value(idx as usize)
+            }
+            Self::Local(a) => a.value(idx as usize),
+        }
+    }
+}
+
+pub struct CategoricalChunkedBuilder {
+    array_builder: PrimitiveArrayBuilder<UInt32Type>,
+    field: Field,
+    reverse_mapping: RevMappingBuilder,
+}
+
+impl CategoricalChunkedBuilder {
+    pub fn new(name: &str, capacity: usize) -> Self {
+        let builder = LargeStringBuilder::new(capacity / 10);
+        let reverse_mapping = if use_string_cache() {
+            RevMappingBuilder::Global(AHashMap::new(), builder)
+        } else {
+            RevMappingBuilder::Local(builder)
+        };
+
+        CategoricalChunkedBuilder {
+            array_builder: PrimitiveArrayBuilder::<UInt32Type>::new(capacity),
+            field: Field::new(name, DataType::Categorical),
+            reverse_mapping,
+        }
+    }
+}
+impl CategoricalChunkedBuilder {
+    /// Appends all the values in a single lock of the global string cache.
+    pub fn from_iter<'a, I>(&mut self, i: I)
+    where
+        I: IntoIterator<Item = Option<&'a str>>,
+    {
+        if use_string_cache() {
+            let mut mapping = crate::STRING_CACHE.lock_map();
+
+            for opt_s in i {
+                match opt_s {
+                    Some(s) => {
+                        let idx = match mapping.get(s) {
+                            Some(idx) => *idx,
+                            None => {
+                                let idx = mapping.len() as u32;
+                                mapping.insert(s.to_string(), idx);
+                                idx
+                            }
+                        };
+                        self.reverse_mapping.insert(idx, s);
+                        self.array_builder.append_value(idx);
+                    }
+                    None => {
+                        self.array_builder.append_null();
+                    }
+                }
+            }
+        } else {
+            let mut mapping = AHashMap::new();
+            for opt_s in i {
+                match opt_s {
+                    Some(s) => {
+                        let idx = match mapping.get(s) {
+                            Some(idx) => *idx,
+                            None => {
+                                let idx = mapping.len() as u32;
+                                mapping.insert(s, idx);
+                                idx
+                            }
+                        };
+                        self.reverse_mapping.insert(idx, s);
+                        self.array_builder.append_value(idx);
+                    }
+                    None => {
+                        self.array_builder.append_null();
+                    }
+                }
+            }
+
+            if mapping.len() > u32::MAX as usize {
+                panic!("not more than {} categories supported", u32::MAX)
+            };
+        }
+    }
+
+    pub fn finish(mut self) -> ChunkedArray<CategoricalType> {
+        let arr = Arc::new(self.array_builder.finish());
+        let len = arr.len();
+        ChunkedArray {
+            field: Arc::new(self.field),
+            chunks: vec![arr],
+            chunk_id: vec![len],
+            phantom: PhantomData,
+            categorical_map: Some(Arc::new(self.reverse_mapping.finish())),
+        }
+    }
+}

--- a/polars/polars-core/src/chunked_array/kernels/take.rs
+++ b/polars/polars-core/src/chunked_array/kernels/take.rs
@@ -447,7 +447,6 @@ pub(crate) unsafe fn take_utf8(
 
         return Arc::new(builder.finish());
     }
-    values_buf.shrink_to_fit();
 
     let mut data = ArrayData::builder(ArrowDataType::LargeUtf8)
         .len(data_len)

--- a/polars/polars-core/src/frame/groupby/mod.rs
+++ b/polars/polars-core/src/frame/groupby/mod.rs
@@ -1104,7 +1104,6 @@ impl<'df, 'selection_str> GroupBy<'df, 'selection_str> {
         let new_name = fmt_groupby_column("", GroupByMethod::Groups);
         column.rename(&new_name);
         cols.push(column.into_series());
-        cols.shrink_to_fit();
         DataFrame::new(cols)
     }
 

--- a/polars/polars-core/src/vector_hasher.rs
+++ b/polars/polars-core/src/vector_hasher.rs
@@ -168,7 +168,6 @@ where
 
                 offset += len as u32;
             }
-            hash_tbl.shrink_to_fit();
             hash_tbl
         })
     })


### PR DESCRIPTION
Benchmarks of casting `Utf8Chunked` with a size of 100k and random string lengths 2 < n < 80.

```
bench                   time:   [8.6611 ms 8.6646 ms 8.6683 ms]                  
                        change: [-77.388% -77.175% -76.962%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  1 (1.00%) low severe
  1 (1.00%) low mild
  5 (5.00%) high mild
  2 (2.00%) high severe

bench_global_cache      time:   [11.896 ms 11.937 ms 11.980 ms]                               
                        change: [-64.854% -64.429% -64.020%] (p = 0.00 < 0.05)
                        Performance has improved.


```