### PR TITLE
lint default features in ci

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -28,7 +28,7 @@ jobs:
           -p polars-io \
           -p polars-lazy \
           -- -D warnings
-          cargo clippy
+          cargo clippy -Z unstable-options -- -D warnings
       - name: Feature test
         run: |
           cd polars && cargo hack check --each-feature --no-dev-deps

--- a/polars/Makefile
+++ b/polars/Makefile
@@ -16,6 +16,9 @@ clippy:
 	-p polars-lazy \
 	-p polars-arrow
 
+clippy-default:
+	cargo clippy -Z unstable-options
+
 test:
 	cargo test --all-features \
 	-p polars-lazy \


### PR DESCRIPTION
Linting was checked with all features enabled. This also check compiler warnings on default features.