### PR TITLE
use id hash for reverse mapping in categorical cast

### DIFF
--- a/polars/polars-core/src/chunked_array/builder/categorical.rs
+++ b/polars/polars-core/src/chunked_array/builder/categorical.rs
@@ -1,13 +1,15 @@
 use crate::prelude::*;
 use crate::use_string_cache;
 use crate::utils::arrow::array::{Array, ArrayBuilder};
-use ahash::AHashMap;
+use hashbrown::HashMap;
 use arrow::array::{LargeStringArray, LargeStringBuilder};
 use polars_arrow::builder::PrimitiveArrayBuilder;
 use std::marker::PhantomData;
+use crate::vector_hasher::IdBuildHasher;
+use ahash::AHashMap;
 
 pub enum RevMappingBuilder {
-    Global(AHashMap<u32, u32>, LargeStringBuilder),
+    Global(HashMap<u32, u32, IdBuildHasher>, LargeStringBuilder),
     Local(LargeStringBuilder),
 }
 
@@ -34,7 +36,7 @@ impl RevMappingBuilder {
 }
 
 pub enum RevMapping {
-    Global(AHashMap<u32, u32>, LargeStringArray),
+    Global(HashMap<u32, u32, IdBuildHasher>, LargeStringArray),
     Local(LargeStringArray),
 }
 
@@ -68,7 +70,7 @@ impl CategoricalChunkedBuilder {
     pub fn new(name: &str, capacity: usize) -> Self {
         let builder = LargeStringBuilder::new(capacity / 10);
         let reverse_mapping = if use_string_cache() {
-            RevMappingBuilder::Global(AHashMap::new(), builder)
+            RevMappingBuilder::Global(HashMap::with_hasher(IdBuildHasher::default()), builder)
         } else {
             RevMappingBuilder::Local(builder)
         };

--- a/polars/polars-core/src/chunked_array/builder/categorical.rs
+++ b/polars/polars-core/src/chunked_array/builder/categorical.rs
@@ -1,12 +1,12 @@
 use crate::prelude::*;
 use crate::use_string_cache;
 use crate::utils::arrow::array::{Array, ArrayBuilder};
-use hashbrown::HashMap;
-use arrow::array::{LargeStringArray, LargeStringBuilder};
-use polars_arrow::builder::PrimitiveArrayBuilder;
-use std::marker::PhantomData;
 use crate::vector_hasher::IdBuildHasher;
 use ahash::AHashMap;
+use arrow::array::{LargeStringArray, LargeStringBuilder};
+use hashbrown::HashMap;
+use polars_arrow::builder::PrimitiveArrayBuilder;
+use std::marker::PhantomData;
 
 pub enum RevMappingBuilder {
     Global(HashMap<u32, u32, IdBuildHasher>, LargeStringBuilder),

--- a/polars/polars-core/src/prelude.rs
+++ b/polars/polars-core/src/prelude.rs
@@ -22,12 +22,13 @@ pub use crate::{
     datatypes,
     datatypes::*,
     error::{PolarsError, Result},
-    frame::{groupby::VecHash, hash_join::JoinType, DataFrame},
+    frame::{hash_join::JoinType, DataFrame},
     series::{
         arithmetic::{LhsNumOps, NumOpsDispatch},
         IntoSeries, NamedFrom, Series, SeriesTrait,
     },
     testing::*,
+    vector_hasher::VecHash,
 };
 pub use arrow::datatypes::{ArrowPrimitiveType, Field as ArrowField, Schema as ArrowSchema};
 pub(crate) use polars_arrow::array::*;

--- a/polars/polars-core/src/series/mod.rs
+++ b/polars/polars-core/src/series/mod.rs
@@ -44,7 +44,7 @@ pub(crate) mod private {
         ) -> bool {
             unimplemented!()
         }
-        fn vec_hash(&self, _random_state: RandomState) -> UInt64Chunked {
+        fn vec_hash(&self, _build_hasher: RandomState) -> UInt64Chunked {
             unimplemented!()
         }
         fn agg_mean(&self, _groups: &[(u32, Vec<u32>)]) -> Option<Series> {

--- a/polars/polars-core/src/vector_hasher.rs
+++ b/polars/polars-core/src/vector_hasher.rs
@@ -12,6 +12,140 @@ use std::hash::{BuildHasher, BuildHasherDefault, Hash, Hasher};
 //  https://www.cockroachlabs.com/blog/vectorized-hash-joiner/
 //  http://myeyesareblind.com/2017/02/06/Combine-hash-values/
 
+pub trait VecHash {
+    /// Compute the hash for all values in the array.
+    ///
+    /// This currently only works with the AHash RandomState hasher builder.
+    fn vec_hash(&self, _random_state: RandomState) -> UInt64Chunked {
+        unimplemented!()
+    }
+}
+
+pub trait VecHashId {
+    /// Compute the hash id by interpreting the bits as 64 bits.
+    ///
+    /// Watch out for [accidental quadratic behavior](https://accidentallyquadratic.tumblr.com/post/153545455987/rust-hash-iteration-reinsertion)
+    fn vec_hash_id(&self) -> UInt64Chunked {
+        unimplemented!()
+    }
+}
+
+/// A random u64 used for the None case
+/// the other values hash `T` instead of `Option<T>`
+const RANDOM_U64: u64 = 4352984574;
+
+impl VecHashId for UInt64Chunked {
+    fn vec_hash_id(&self) -> UInt64Chunked {
+        self.branch_apply_cast_numeric_no_null(|opt_v| match opt_v {
+            None => RANDOM_U64,
+            Some(v) => v,
+        })
+    }
+}
+
+impl VecHashId for UInt32Chunked {
+    fn vec_hash_id(&self) -> UInt64Chunked {
+        self.branch_apply_cast_numeric_no_null(|opt_v| match opt_v {
+            None => RANDOM_U64,
+            Some(v) => v as u64,
+        })
+    }
+}
+
+impl VecHashId for Int32Chunked {
+    fn vec_hash_id(&self) -> UInt64Chunked {
+        self.branch_apply_cast_numeric_no_null(|opt_v| match opt_v {
+            None => RANDOM_U64,
+            Some(v) => (unsafe { std::mem::transmute::<i32, u32>(v) }) as u64,
+        })
+    }
+}
+
+impl VecHashId for Int64Chunked {
+    fn vec_hash_id(&self) -> UInt64Chunked {
+        self.branch_apply_cast_numeric_no_null(|opt_v| match opt_v {
+            None => RANDOM_U64,
+            Some(v) => unsafe { std::mem::transmute::<i64, u64>(v) },
+        })
+    }
+}
+
+impl Series {
+    pub fn vec_hash_id(&self) -> UInt64Chunked {
+        use DataType::*;
+        match self.dtype() {
+            UInt64 => self.u64().unwrap().vec_hash_id(),
+            Int64 => self.i64().unwrap().vec_hash_id(),
+            Int32 => self.i32().unwrap().vec_hash_id(),
+            UInt32 => self.u32().unwrap().vec_hash_id(),
+            _ => unimplemented!(),
+        }
+    }
+}
+
+impl<T> VecHash for ChunkedArray<T>
+where
+    T: PolarsIntegerType,
+    T::Native: Hash,
+{
+    fn vec_hash(&self, random_state: RandomState) -> UInt64Chunked {
+        // Note that we don't use the no null branch! This can break in unexpected ways.
+        // for instance with threading we split an array in n_threads, this may lead to
+        // splits that have no nulls and splits that have nulls. Then one array is hashed with
+        // Option<T> and the other array with T.
+        // Meaning that they cannot be compared. By always hashing on Option<T> the random_state is
+        // the only deterministic seed.
+        self.branch_apply_cast_numeric_no_null(|opt_v| {
+            let mut hasher = random_state.build_hasher();
+            opt_v.hash(&mut hasher);
+            hasher.finish()
+        })
+    }
+}
+
+impl VecHash for Utf8Chunked {
+    fn vec_hash(&self, random_state: RandomState) -> UInt64Chunked {
+        self.branch_apply_cast_numeric_no_null(|opt_v| {
+            let mut hasher = random_state.build_hasher();
+            opt_v.hash(&mut hasher);
+            hasher.finish()
+        })
+    }
+}
+
+impl VecHash for BooleanChunked {
+    fn vec_hash(&self, random_state: RandomState) -> UInt64Chunked {
+        self.branch_apply_cast_numeric_no_null(|opt_v| {
+            let mut hasher = random_state.build_hasher();
+            opt_v.hash(&mut hasher);
+            hasher.finish()
+        })
+    }
+}
+
+impl VecHash for Float32Chunked {
+    fn vec_hash(&self, random_state: RandomState) -> UInt64Chunked {
+        self.branch_apply_cast_numeric_no_null(|opt_v| {
+            let opt_v = opt_v.map(|v| v.to_bits());
+            let mut hasher = random_state.build_hasher();
+            opt_v.hash(&mut hasher);
+            hasher.finish()
+        })
+    }
+}
+impl VecHash for Float64Chunked {
+    fn vec_hash(&self, random_state: RandomState) -> UInt64Chunked {
+        self.branch_apply_cast_numeric_no_null(|opt_v| {
+            let opt_v = opt_v.map(|v| v.to_bits());
+            let mut hasher = random_state.build_hasher();
+            opt_v.hash(&mut hasher);
+            hasher.finish()
+        })
+    }
+}
+
+impl VecHash for ListChunked {}
+
 pub struct IdHasher {
     hash: u64,
 }
@@ -114,18 +248,18 @@ pub(crate) fn prepare_hashed_relation<T>(
 where
     T: Hash + Eq,
 {
-    let random_state = RandomState::default();
+    let build_hasher = RandomState::default();
 
     let hashes_nd_keys = b
         .map(|val| {
-            let mut hasher = random_state.build_hasher();
+            let mut hasher = build_hasher.build_hasher();
             val.hash(&mut hasher);
             (hasher.finish(), val)
         })
         .collect::<Vec<_>>();
 
     let hash_tbl: HashMap<T, Vec<u32>, RandomState> =
-        HashMap::with_capacity_and_hasher(hashes_nd_keys.len(), random_state);
+        HashMap::with_capacity_and_hasher(hashes_nd_keys.len(), build_hasher);
 
     finish_table_from_key_hashes(hashes_nd_keys, hash_tbl, 0)
 }
@@ -138,7 +272,7 @@ where
     T: Send + Hash + Eq + Sync + Copy,
 {
     let n_threads = iters.len();
-    let (hashes_and_keys, random_state) = create_hash_and_keys_threaded_vectorized(iters, None);
+    let (hashes_and_keys, build_hasher) = create_hash_and_keys_threaded_vectorized(iters, None);
     let size = hashes_and_keys.iter().fold(0, |acc, v| acc + v.len());
 
     // We will create a hashtable in every thread.
@@ -146,11 +280,11 @@ where
     // Every thread traverses all keys/hashes and ignores the ones that doesn't fall in that partition.
     POOL.install(|| {
         (0..n_threads).into_par_iter().map(|thread_no| {
-            let random_state = random_state.clone();
+            let build_hasher = build_hasher.clone();
             let hashes_and_keys = &hashes_and_keys;
             let thread_no = thread_no as u64;
             let mut hash_tbl: HashMap<T, Vec<u32>, RandomState> =
-                HashMap::with_capacity_and_hasher(size / (5 * n_threads), random_state);
+                HashMap::with_capacity_and_hasher(size / (5 * n_threads), build_hasher);
 
             let n_threads = n_threads as u64;
             let mut offset = 0;
@@ -192,13 +326,13 @@ where
 
 pub(crate) fn create_hash_and_keys_threaded_vectorized<I, T>(
     iters: Vec<I>,
-    random_state: Option<RandomState>,
+    build_hasher: Option<RandomState>,
 ) -> (Vec<Vec<(u64, T)>>, RandomState)
 where
     I: IntoIterator<Item = T> + Send,
     T: Send + Hash + Eq,
 {
-    let random_state = random_state.unwrap_or_default();
+    let build_hasher = build_hasher.unwrap_or_default();
     let hashes = POOL.install(|| {
         iters
             .into_par_iter()
@@ -206,7 +340,7 @@ where
                 // create hashes and keys
                 iter.into_iter()
                     .map(|val| {
-                        let mut hasher = random_state.build_hasher();
+                        let mut hasher = build_hasher.build_hasher();
                         val.hash(&mut hasher);
                         (hasher.finish(), val)
                     })
@@ -214,7 +348,7 @@ where
             })
             .collect()
     });
-    (hashes, random_state)
+    (hashes, build_hasher)
 }
 
 // Combines two hashes into one hash
@@ -226,32 +360,39 @@ fn combine_hashes(l: u64, r: u64) -> u64 {
 
 pub(crate) fn df_rows_to_hashes_threaded(
     keys: &[DataFrame],
-    random_state: Option<RandomState>,
+    hasher_builder: Option<RandomState>,
 ) -> (Vec<UInt64Chunked>, RandomState) {
-    let random_state = random_state.unwrap_or_default();
+    let hasher_builder = hasher_builder.unwrap_or_default();
 
     let hashes = POOL.install(|| {
         keys.into_par_iter()
             .map(|df| {
-                let random_state = random_state.clone();
-                let (ca, _) = df_rows_to_hashes(df, Some(random_state));
+                let hb = hasher_builder.clone();
+                let (ca, _) = df_rows_to_hashes(df, Some(hb));
                 ca
             })
             .collect()
     });
-    (hashes, random_state)
+    (hashes, hasher_builder)
 }
 
 pub(crate) fn df_rows_to_hashes(
     keys: &DataFrame,
-    random_state: Option<RandomState>,
+    build_hasher: Option<RandomState>,
 ) -> (UInt64Chunked, RandomState) {
-    let random_state = random_state.unwrap_or_default();
+    let build_hasher = build_hasher.unwrap_or_default();
     let hashes: Vec<_> = keys
         .columns
         .iter()
         .map(|s| {
-            let h = s.vec_hash(random_state.clone());
+            let h = match s.dtype() {
+                DataType::UInt64 => s.vec_hash_id(),
+                DataType::UInt32 => s.vec_hash_id(),
+                DataType::Int64 => s.vec_hash_id(),
+                DataType::Int32 => s.vec_hash_id(),
+                _ => s.vec_hash(build_hasher.clone()),
+            };
+
             // if this fails we have unexpected groupby results.
             debug_assert_eq!(h.null_count(), 0);
             h
@@ -279,6 +420,6 @@ pub(crate) fn df_rows_to_hashes(
                 .collect();
             UInt64Chunked::new_from_chunks("", chunks)
         }),
-        random_state,
+        build_hasher,
     )
 }


### PR DESCRIPTION
```
bench_global_cache      time:   [8.9679 ms 8.9989 ms 9.0354 ms]
                        change: [-24.972% -24.612% -24.184%] (p = 0.00 < 0.05)
                        Performance has improved.
```