### PR TITLE
Don't allow join on categoricals from different cache

### DIFF
--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -1105,7 +1105,7 @@ dependencies = [
 
 [[package]]
 name = "py-polars"
-version = "0.7.8"
+version = "0.7.9"
 dependencies = [
  "libc",
  "mimalloc",

--- a/py-polars/Cargo.toml
+++ b/py-polars/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "py-polars"
-version = "0.7.8"
+version = "0.7.9"
 authors = ["ritchie46 <ritchie46@gmail.com>"]
 edition = "2018"
 readme = "README.md"
@@ -48,9 +48,9 @@ crate-type = ["cdylib"]
 
 [package.metadata.maturin]
 name = "polars"
-# the Arrow memory format is stable between 3.0 and 4.0-SNAPSHOTS
+# the Arrow memory format is stable between 4.0 and 5.0-SNAPSHOTS
 # (which the Rust libraries use to take advantage of Rust API changes).
-requires-dist = ["numpy", "pyarrow==3.0"]
+requires-dist = ["numpy", "pyarrow==4.0"]
 
 [profile.release]
 codegen-units = 1

--- a/py-polars/polars/series.py
+++ b/py-polars/polars/series.py
@@ -39,6 +39,7 @@ from . import datatypes
 from numbers import Number
 import polars
 import pyarrow as pa
+from .utils import coerce_arrow
 
 from typing import TYPE_CHECKING
 
@@ -271,6 +272,7 @@ class Series:
         array
             Arrow array.
         """
+        array = coerce_arrow(array)
         return Series._from_pyseries(PySeries.from_arrow(name, array))
 
     def inner(self) -> "PySeries":

--- a/py-polars/polars/utils.py
+++ b/py-polars/polars/utils.py
@@ -1,0 +1,38 @@
+import pyarrow as pa
+
+
+def coerce_arrow(array: "pa.Array") -> "pa.Array":
+    if array.type == pa.timestamp("s"):
+        array = pa.compute.cast(
+            pa.compute.multiply(pa.compute.cast(array, pa.int64()), 1000),
+            pa.date64(),
+        )
+    elif array.type == pa.timestamp("ms"):
+        array = pa.compute.cast(pa.compute.cast(array, pa.int64()), pa.date64())
+    elif array.type == pa.timestamp("us"):
+        array = pa.compute.cast(
+            pa.compute.divide(pa.compute.cast(array, pa.int64()), 1000),
+            pa.date64(),
+        )
+    elif array.type == pa.timestamp("ns"):
+        array = pa.compute.cast(
+            pa.compute.divide(pa.compute.cast(array, pa.int64()), 1000000),
+            pa.date64(),
+        )
+    # note: Decimal256 could not be cast to float
+    elif isinstance(array.type, pa.Decimal128Type):
+        array = pa.compute.cast(array, pa.float64())
+
+    # simplest solution is to cast to (large)-string arrays
+    # this is copy and expensive
+    elif isinstance(array, pa.DictionaryArray):
+        if array.dictionary.type == pa.string():
+            array = pa.compute.cast(pa.compute.cast(array, pa.utf8()), pa.large_utf8())
+        else:
+            raise ValueError(
+                "polars does not support dictionary encoded types other than strings"
+            )
+
+    if hasattr(array, "num_chunks") and array.num_chunks > 1:
+        array = array.combine_chunks()
+    return array

--- a/py-polars/tests/test_series.py
+++ b/py-polars/tests/test_series.py
@@ -153,6 +153,10 @@ def test_arrow():
     out = a.to_arrow()
     assert out == pa.array([1, 2, 3, None])
 
+    a = pa.array(["foo", "bar"], pa.dictionary(pa.int32(), pa.utf8()))
+    s = pl.Series("a", a)
+    assert s.dtype == pl.Utf8
+
 
 def test_view():
     a = Series("a", [1.0, 2.0, 3.0])


### PR DESCRIPTION
Partially fixes #581 

A join categoricals that are not synchronized will throw an error. A user can cast to `utf8` to join these colums. Upon entry from `pyarrow` to `polars`, dictionary encoded strings will be coerced to `large-utf8` arrays.