### PR TITLE
Lazy DSL: take, arg_unqiue, unique and python eager

### DIFF
--- a/polars/polars-lazy/src/dsl.rs
+++ b/polars/polars-lazy/src/dsl.rs
@@ -177,6 +177,10 @@ pub enum Expr {
         expr: Box<Expr>,
         reverse: bool,
     },
+    Take {
+        expr: Box<Expr>,
+        idx: Box<Expr>,
+    },
     SortBy {
         expr: Box<Expr>,
         by: Box<Expr>,
@@ -276,6 +280,9 @@ impl fmt::Debug for Expr {
             },
             Filter { input, by } => {
                 write!(f, "FILTER {:?} BY {:?}", input, by)
+            }
+            Take { expr, idx } => {
+                write!(f, "TAKE {:?} AT {:?}", expr, idx)
             }
             Agg(agg) => {
                 use AggExpr::*;
@@ -573,6 +580,14 @@ impl Expr {
         Expr::Cast {
             expr: Box::new(self),
             data_type,
+        }
+    }
+
+    /// Take the values by idx.
+    pub fn take(self, idx: Expr) -> Self {
+        Expr::Take {
+            expr: Box::new(self),
+            idx: Box::new(idx),
         }
     }
 

--- a/polars/polars-lazy/src/dsl.rs
+++ b/polars/polars-lazy/src/dsl.rs
@@ -549,6 +549,25 @@ impl Expr {
         self.slice(-(len as i64), len)
     }
 
+    /// Get unique values of this expression.
+    pub fn unique(self) -> Self {
+        if has_expr(&self, |e| matches!(e, Expr::Wildcard)) {
+            panic!("wildcard not supperted in unique expr");
+        }
+        self.map(|s: Series| s.unique(), None)
+    }
+
+    /// Get the first index of unique values of this expression.
+    pub fn arg_unique(self) -> Self {
+        if has_expr(&self, |e| matches!(e, Expr::Wildcard)) {
+            panic!("wildcard not supported in unique expr");
+        }
+        self.map(
+            |s: Series| s.arg_unique().map(|ca| ca.into_series()),
+            Some(DataType::UInt32),
+        )
+    }
+
     /// Cast expression to another data type.
     pub fn cast(self, data_type: DataType) -> Self {
         Expr::Cast {

--- a/polars/polars-lazy/src/logical_plan/aexpr.rs
+++ b/polars/polars-lazy/src/logical_plan/aexpr.rs
@@ -51,6 +51,10 @@ pub enum AExpr {
         expr: Node,
         reverse: bool,
     },
+    Take {
+        expr: Node,
+        idx: Node,
+    },
     SortBy {
         expr: Node,
         by: Node,
@@ -175,6 +179,7 @@ impl AExpr {
             IsNull(_) => Ok(Field::new("is_null", DataType::Boolean)),
             IsNotNull(_) => Ok(Field::new("is_not_null", DataType::Boolean)),
             Sort { expr, .. } => arena.get(*expr).to_field(schema, ctxt, arena),
+            Take { expr, .. } => arena.get(*expr).to_field(schema, ctxt, arena),
             SortBy { expr, .. } => arena.get(*expr).to_field(schema, ctxt, arena),
             Filter { input, .. } => arena.get(*input).to_field(schema, ctxt, arena),
             Agg(agg) => {

--- a/polars/polars-lazy/src/logical_plan/alp.rs
+++ b/polars/polars-lazy/src/logical_plan/alp.rs
@@ -585,9 +585,6 @@ impl<'a> ALogicalPlanBuilder<'a> {
             self
         }
     }
-    pub fn into_node(self) -> Node {
-        self.root
-    }
 
     pub fn build(self) -> ALogicalPlan {
         if self.root.0 == self.lp_arena.len() {

--- a/polars/polars-lazy/src/logical_plan/conversion.rs
+++ b/polars/polars-lazy/src/logical_plan/conversion.rs
@@ -28,6 +28,10 @@ pub(crate) fn to_aexpr(expr: Expr, arena: &mut Arena<AExpr>) -> Node {
             expr: to_aexpr(*expr, arena),
             data_type,
         },
+        Expr::Take { expr, idx } => AExpr::Take {
+            expr: to_aexpr(*expr, arena),
+            idx: to_aexpr(*idx, arena),
+        },
         Expr::Sort { expr, reverse } => AExpr::Sort {
             expr: to_aexpr(*expr, arena),
             reverse,
@@ -411,6 +415,14 @@ pub(crate) fn node_to_exp(node: Node, expr_arena: &Arena<AExpr>) -> Expr {
             Expr::Sort {
                 expr: Box::new(exp),
                 reverse,
+            }
+        }
+        AExpr::Take { expr, idx } => {
+            let expr = node_to_exp(expr, expr_arena);
+            let idx = node_to_exp(idx, expr_arena);
+            Expr::Take {
+                expr: Box::new(expr),
+                idx: Box::new(idx),
             }
         }
         AExpr::SortBy { expr, by, reverse } => {

--- a/polars/polars-lazy/src/logical_plan/iterator.rs
+++ b/polars/polars-lazy/src/logical_plan/iterator.rs
@@ -24,6 +24,10 @@ impl<'a> Iterator for ExprIter<'a> {
                 IsNotNull(e) => push(e),
                 Cast { expr, .. } => push(expr),
                 Sort { expr, .. } => push(expr),
+                Take { expr, idx } => {
+                    push(expr);
+                    push(idx);
+                }
                 Filter { input, by } => {
                     push(input);
                     push(by)
@@ -120,6 +124,10 @@ impl AExpr {
             IsNotNull(e) => push(e),
             Cast { expr, .. } => push(expr),
             Sort { expr, .. } => push(expr),
+            Take { expr, idx } => {
+                push(expr);
+                push(idx);
+            }
             SortBy { expr, by, .. } => {
                 push(expr);
                 push(by);

--- a/polars/polars-lazy/src/logical_plan/mod.rs
+++ b/polars/polars-lazy/src/logical_plan/mod.rs
@@ -684,6 +684,10 @@ fn replace_wildcard_with_column(expr: Expr, column_name: Arc<String>) -> Expr {
         Expr::Explode(expr) => {
             Expr::Explode(Box::new(replace_wildcard_with_column(*expr, column_name)))
         }
+        Expr::Take { expr, idx } => Expr::Take {
+            expr: Box::new(replace_wildcard_with_column(*expr, column_name)),
+            idx,
+        },
         Expr::Ternary {
             predicate,
             truthy,

--- a/polars/polars-lazy/src/logical_plan/optimizer/predicate_pushdown.rs
+++ b/polars/polars-lazy/src/logical_plan/optimizer/predicate_pushdown.rs
@@ -125,7 +125,6 @@ fn no_pushdown_preds<F>(
     if has_aexpr(node, &arena, matches) {
         // columns that are projected. We check if we can push down the predicates past this projection
         let columns = aexpr_to_root_names(node, &arena);
-        debug_assert_eq!(columns.len(), 1);
 
         let condition = |name: Arc<String>| columns.contains(&name);
         local_predicates.extend(transfer_to_local(arena, acc_predicates, condition));
@@ -270,7 +269,11 @@ impl PredicatePushDown {
                     no_pushdown_preds(
                         *node,
                         &expr_arena,
-                        |e| matches!(e, AExpr::Explode(_)) || matches!(e, AExpr::Shift { .. }),
+                        |e| {
+                            matches!(e, AExpr::Explode(_))
+                                || matches!(e, AExpr::Shift { .. })
+                                || matches!(e, AExpr::Sort { .. })
+                        },
                         &mut local_predicates,
                         &mut acc_predicates,
                     );

--- a/polars/polars-lazy/src/physical_plan/expressions/default.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/default.rs
@@ -2,7 +2,7 @@ use crate::logical_plan::Context;
 use crate::physical_plan::state::ExecutionState;
 use crate::physical_plan::PhysicalAggregation;
 use crate::prelude::*;
-use polars_core::frame::groupby::{fmt_groupby_column, GroupBy, GroupByMethod, GroupTuples};
+use polars_core::frame::groupby::{fmt_groupby_column, GroupByMethod, GroupTuples};
 use polars_core::prelude::*;
 use polars_core::utils::{slice_offsets, NoNull};
 use rayon::prelude::*;
@@ -648,112 +648,6 @@ impl PhysicalExpr for ApplyExpr {
     }
     fn as_agg_expr(&self) -> Result<&dyn PhysicalAggregation> {
         Ok(self)
-    }
-}
-
-pub struct WindowExpr {
-    /// the root column that the Function will be applied on.
-    /// This will be used to create a smaller DataFrame to prevent taking unneeded columns by index
-    pub(crate) group_column: Arc<String>,
-    pub(crate) apply_column: Arc<String>,
-    pub(crate) out_name: Arc<String>,
-    /// A function Expr. i.e. Mean, Median, Max, etc.
-    pub(crate) function: Expr,
-}
-
-impl PhysicalExpr for WindowExpr {
-    // Note: this was first implemented with expression evaluation but this performed really bad.
-    // Therefore we choose the groupby -> apply -> self join approach
-    fn evaluate(&self, df: &DataFrame, state: &ExecutionState) -> Result<Series> {
-        // This method does the following:
-        // 1. determine groupby tuples based on the group_column
-        // 2. apply an aggregation function
-        // 3. join the results back to the original dataframe
-        //    this stores all group values on the original df size
-        // 4. select the final column and return
-
-        // We create a key to store in the state cache
-        // assume 16 digits per ptr.
-        let mut key = String::with_capacity(df.width() * 16 + self.group_column.len());
-        key.push_str(&self.group_column);
-        df.get_columns()
-            .iter()
-            .for_each(|s| key.push_str(&format!("{}", s.get_data_ptr())));
-        let groupby_column = df.column(&self.group_column).unwrap();
-
-        // 1. get the group tuples
-        // We keep the lock for the entire window expression, we want those to be sequential
-        // The utilize parallelism enough in groupby and join operation
-        let mut groups_lock = state.group_tuples.lock().unwrap();
-        let groups = match groups_lock.get_mut(&key) {
-            Some(groups) => std::mem::take(groups),
-            None => {
-                let mut gb = df.groupby(&**self.group_column)?;
-                std::mem::take(gb.get_groups_mut())
-            }
-        };
-
-        // 2. create GroupBy object and apply aggregation
-        let mut gb = GroupBy::new(
-            df,
-            vec![groupby_column.clone()],
-            groups,
-            Some(vec![&self.apply_column]),
-        );
-
-        let out = match &self.function {
-            Expr::Udf { function, .. } => {
-                let mut df = gb.agg_list()?;
-                df.may_apply_at_idx(1, |s| function.call_udf(s.clone()))?;
-                Ok(df)
-            }
-            Expr::Agg(agg) => match agg {
-                AggExpr::Median(_) => gb.median(),
-                AggExpr::Mean(_) => gb.mean(),
-                AggExpr::Max(_) => gb.max(),
-                AggExpr::Min(_) => gb.min(),
-                AggExpr::Sum(_) => gb.sum(),
-                AggExpr::First(_) => gb.first(),
-                AggExpr::Last(_) => gb.last(),
-                AggExpr::Count(_) => gb.count(),
-                AggExpr::NUnique(_) => gb.n_unique(),
-                AggExpr::Quantile { quantile, .. } => gb.quantile(*quantile),
-                AggExpr::List(_) => gb.agg_list(),
-                AggExpr::AggGroups(_) => gb.groups(),
-                AggExpr::Std(_) => gb.std(),
-                AggExpr::Var(_) => gb.var(),
-            },
-            _ => Err(PolarsError::Other(
-                format!("{:?} function not supported", self.function).into(),
-            )),
-        }?;
-        // store the group tuples and drop the lock so other threads may use them
-        groups_lock.insert(key.clone(), std::mem::take(gb.get_groups_mut()));
-        drop(groups_lock);
-
-        // 3. get the join tuples and use them to take the new Series
-        let out_column = out.select_at_idx(1).unwrap();
-        let mut join_tuples_lock = state.join_tuples.lock().unwrap();
-        let opt_join_tuples = match join_tuples_lock.get_mut(&key) {
-            Some(t) => std::mem::take(t),
-            None => {
-                // group key from right column
-                let right = out.select_at_idx(0).unwrap();
-                groupby_column.hash_join_left(right)
-            }
-        };
-
-        let mut iter = opt_join_tuples
-            .iter()
-            .map(|(_left, right)| right.map(|i| i as usize));
-        let mut out = unsafe { out_column.take_opt_iter_unchecked(&mut iter) };
-        join_tuples_lock.insert(key, opt_join_tuples);
-        out.rename(self.out_name.as_str());
-        Ok(out)
-    }
-
-    fn to_field(&self, input_schema: &Schema) -> Result<Field> {
-        self.function.to_field(input_schema, Context::Default)
     }
 }
 

--- a/polars/polars-lazy/src/physical_plan/expressions/mod.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/mod.rs
@@ -1,6 +1,7 @@
 pub mod default;
 mod final_agg;
 pub(crate) mod take;
+pub(crate) mod window;
 
 use crate::physical_plan::state::ExecutionState;
 use crate::prelude::*;

--- a/polars/polars-lazy/src/physical_plan/expressions/mod.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/mod.rs
@@ -1,5 +1,6 @@
 pub mod default;
 mod final_agg;
+pub(crate) mod take;
 
 use crate::physical_plan::state::ExecutionState;
 use crate::prelude::*;

--- a/polars/polars-lazy/src/physical_plan/expressions/take.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/take.rs
@@ -1,0 +1,29 @@
+use crate::physical_plan::state::ExecutionState;
+use crate::prelude::*;
+use polars_core::prelude::*;
+use std::sync::Arc;
+
+pub struct TakeExpr {
+    pub(crate) expr: Arc<dyn PhysicalExpr>,
+    pub(crate) idx: Arc<dyn PhysicalExpr>,
+}
+
+impl TakeExpr {
+    pub fn new(expr: Arc<dyn PhysicalExpr>, idx: Arc<dyn PhysicalExpr>) -> Self {
+        Self { expr, idx }
+    }
+}
+
+impl PhysicalExpr for TakeExpr {
+    fn evaluate(&self, df: &DataFrame, state: &ExecutionState) -> Result<Series> {
+        let series = self.expr.evaluate(df, state)?;
+        let idx = self.idx.evaluate(df, state)?;
+        let idx_ca = idx.u32()?;
+
+        Ok(series.take(idx_ca))
+    }
+
+    fn to_field(&self, input_schema: &Schema) -> Result<Field> {
+        self.expr.to_field(input_schema)
+    }
+}

--- a/polars/polars-lazy/src/physical_plan/expressions/window.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/window.rs
@@ -1,0 +1,115 @@
+use crate::logical_plan::Context;
+use crate::physical_plan::state::ExecutionState;
+use crate::prelude::*;
+use polars_core::frame::groupby::GroupBy;
+use polars_core::prelude::*;
+use std::sync::Arc;
+
+pub struct WindowExpr {
+    /// the root column that the Function will be applied on.
+    /// This will be used to create a smaller DataFrame to prevent taking unneeded columns by index
+    pub(crate) group_column: Arc<dyn PhysicalExpr>,
+    pub(crate) apply_column: Arc<String>,
+    pub(crate) out_name: Option<Arc<String>>,
+    /// A function Expr. i.e. Mean, Median, Max, etc.
+    pub(crate) function: Expr,
+}
+
+impl PhysicalExpr for WindowExpr {
+    // Note: this was first implemented with expression evaluation but this performed really bad.
+    // Therefore we choose the groupby -> apply -> self join approach
+    fn evaluate(&self, df: &DataFrame, state: &ExecutionState) -> Result<Series> {
+        // This method does the following:
+        // 1. determine groupby tuples based on the group_column
+        // 2. apply an aggregation function
+        // 3. join the results back to the original dataframe
+        //    this stores all group values on the original df size
+        // 4. select the final column and return
+
+        // We create a key to store in the state cache
+        // assume 32 digits per ptr.
+        let mut key = String::with_capacity(df.width() * 32);
+        df.get_columns()
+            .iter()
+            .for_each(|s| key.push_str(&format!("{}", s.get_data_ptr())));
+
+        let groupby_column = self.group_column.evaluate(df, state)?;
+        key.push_str(groupby_column.name());
+
+        // 1. get the group tuples
+        // We keep the lock for the entire window expression, we want those to be sequential
+        // The utilize parallelism enough in groupby and join operation
+        let mut groups_lock = state.group_tuples.lock().unwrap();
+        let groups = match groups_lock.get_mut(&key) {
+            Some(groups) => std::mem::take(groups),
+            None => {
+                let mut gb = df.groupby_with_series(vec![groupby_column.clone()], true)?;
+                std::mem::take(gb.get_groups_mut())
+            }
+        };
+
+        // 2. create GroupBy object and apply aggregation
+        let mut gb = GroupBy::new(
+            df,
+            vec![groupby_column.clone()],
+            groups,
+            Some(vec![&self.apply_column]),
+        );
+
+        let out = match &self.function {
+            Expr::Udf { function, .. } => {
+                let mut df = gb.agg_list()?;
+                df.may_apply_at_idx(1, |s| function.call_udf(s.clone()))?;
+                Ok(df)
+            }
+            Expr::Agg(agg) => match agg {
+                AggExpr::Median(_) => gb.median(),
+                AggExpr::Mean(_) => gb.mean(),
+                AggExpr::Max(_) => gb.max(),
+                AggExpr::Min(_) => gb.min(),
+                AggExpr::Sum(_) => gb.sum(),
+                AggExpr::First(_) => gb.first(),
+                AggExpr::Last(_) => gb.last(),
+                AggExpr::Count(_) => gb.count(),
+                AggExpr::NUnique(_) => gb.n_unique(),
+                AggExpr::Quantile { quantile, .. } => gb.quantile(*quantile),
+                AggExpr::List(_) => gb.agg_list(),
+                AggExpr::AggGroups(_) => gb.groups(),
+                AggExpr::Std(_) => gb.std(),
+                AggExpr::Var(_) => gb.var(),
+            },
+            _ => Err(PolarsError::Other(
+                format!("{:?} function not supported", self.function).into(),
+            )),
+        }?;
+        // store the group tuples and drop the lock so other threads may use them
+        groups_lock.insert(key.clone(), std::mem::take(gb.get_groups_mut()));
+        drop(groups_lock);
+
+        // 3. get the join tuples and use them to take the new Series
+        let out_column = out.select_at_idx(1).unwrap();
+        let mut join_tuples_lock = state.join_tuples.lock().unwrap();
+        let opt_join_tuples = match join_tuples_lock.get_mut(&key) {
+            Some(t) => std::mem::take(t),
+            None => {
+                // group key from right column
+                let right = out.select_at_idx(0).unwrap();
+                groupby_column.hash_join_left(right)
+            }
+        };
+
+        let mut iter = opt_join_tuples
+            .iter()
+            .map(|(_left, right)| right.map(|i| i as usize));
+        let mut out = unsafe { out_column.take_opt_iter_unchecked(&mut iter) };
+        join_tuples_lock.insert(key, opt_join_tuples);
+        if let Some(name) = &self.out_name {
+            out.rename(name.as_str());
+        }
+        Ok(out)
+    }
+
+    fn to_field(&self, input_schema: &Schema) -> Result<Field> {
+        self.function.to_field(input_schema, Context::Default)
+    }
+}

--- a/polars/polars-lazy/src/physical_plan/planner.rs
+++ b/polars/polars-lazy/src/physical_plan/planner.rs
@@ -396,20 +396,17 @@ impl DefaultPlanner {
                 order_by: _,
             } => {
                 // TODO! Order by
-                let group_column = aexpr_to_root_names(partition_by, expr_arena)
-                    .pop()
-                    .expect("need a partition_by column for a window function");
-                let out_name;
+                let group_column =
+                    self.create_physical_expr(partition_by, Context::Default, expr_arena)?;
+                let mut out_name = None;
                 let apply_column = aexpr_to_root_names(function, expr_arena)
                     .pop()
                     .expect("need a root column for a window function");
 
                 if let Alias(expr, name) = expr_arena.get(function) {
                     function = *expr;
-                    out_name = name.clone();
-                } else {
-                    out_name = group_column.clone();
-                }
+                    out_name = Some(name.clone());
+                };
                 let function = node_to_exp(function, expr_arena);
 
                 Ok(Arc::new(WindowExpr {

--- a/polars/polars-lazy/src/physical_plan/planner.rs
+++ b/polars/polars-lazy/src/physical_plan/planner.rs
@@ -445,6 +445,11 @@ impl DefaultPlanner {
                     node_to_exp(expression, expr_arena),
                 )))
             }
+            Take { expr, idx } => {
+                let phys_expr = self.create_physical_expr(expr, ctxt, expr_arena)?;
+                let phys_idx = self.create_physical_expr(idx, ctxt, expr_arena)?;
+                Ok(Arc::new(TakeExpr::new(phys_expr, phys_idx)))
+            }
             SortBy { expr, by, reverse } => {
                 let phys_expr = self.create_physical_expr(expr, ctxt, expr_arena)?;
                 let phys_by = self.create_physical_expr(by, ctxt, expr_arena)?;

--- a/polars/polars-lazy/src/prelude.rs
+++ b/polars/polars-lazy/src/prelude.rs
@@ -1,8 +1,5 @@
 pub use polars_core::utils::{Arena, Node};
 
-pub use crate::logical_plan::aexpr::*;
-pub use crate::logical_plan::alp::*;
-pub(crate) use crate::logical_plan::conversion::*;
 pub use crate::{
     dsl::*,
     frame::*,
@@ -16,4 +13,8 @@ pub use crate::{
         planner::DefaultPlanner,
         Executor, PhysicalPlanner,
     },
+};
+pub(crate) use crate::{
+    logical_plan::{aexpr::*, alp::*, conversion::*},
+    physical_plan::expressions::take::TakeExpr,
 };

--- a/polars/polars-lazy/src/prelude.rs
+++ b/polars/polars-lazy/src/prelude.rs
@@ -16,5 +16,5 @@ pub use crate::{
 };
 pub(crate) use crate::{
     logical_plan::{aexpr::*, alp::*, conversion::*},
-    physical_plan::expressions::take::TakeExpr,
+    physical_plan::expressions::{take::TakeExpr, window::WindowExpr},
 };

--- a/py-polars/polars/lazy/__init__.py
+++ b/py-polars/polars/lazy/__init__.py
@@ -873,6 +873,21 @@ class Expr:
 
         return wrap_expr(self._pyexpr.sort_by(by._pyexpr, reverse))
 
+    def take(self, index: "Expr") -> "Expr":
+        """
+        Take values by index.
+
+        Parameters
+        ----------
+        index
+            An expression that leads to a UInt32 dtyped Series.
+
+        Returns
+        -------
+        Values taken by index
+        """
+        return wrap_expr(self._pyexpr.take(index._pyexpr))
+
     def shift(self, periods: int) -> "Expr":
         """
         Shift the values by a given period and fill the parts that will be empty due to this operation

--- a/py-polars/polars/lazy/__init__.py
+++ b/py-polars/polars/lazy/__init__.py
@@ -956,6 +956,14 @@ class Expr:
         """Count unique values"""
         return wrap_expr(self._pyexpr.n_unique())
 
+    def arg_unique(self) -> "Expr":
+        """Get index of first unique value"""
+        return wrap_expr(self._pyexpr.arg_unique())
+
+    def unique(self) -> "Expr":
+        """Get unique values"""
+        return wrap_expr(self._pyexpr.unique())
+
     def first(self) -> "Expr":
         """
         Get first value

--- a/py-polars/polars/lazy/__init__.py
+++ b/py-polars/polars/lazy/__init__.py
@@ -312,6 +312,14 @@ class LazyFrame:
         return wrap_ldf(self._ldf.filter(predicate._pyexpr))
 
     def select(self, exprs: "Union[str, Expr, List[str], List[Expr]]") -> "LazyFrame":
+        """
+        Select columns from this DataFrame
+
+        Parameters
+        ----------
+        exprs
+            Column or columns to select
+        """
         exprs = _selection_to_pyexpr_list(exprs)
         return wrap_ldf(self._ldf.select(exprs))
 

--- a/py-polars/src/lazy/dsl.rs
+++ b/py-polars/src/lazy/dsl.rs
@@ -111,6 +111,12 @@ impl PyExpr {
     pub fn n_unique(&self) -> PyExpr {
         self.clone().inner.n_unique().into()
     }
+    pub fn arg_unique(&self) -> PyExpr {
+        self.clone().inner.arg_unique().into()
+    }
+    pub fn unique(&self) -> PyExpr {
+        self.clone().inner.unique().into()
+    }
     pub fn first(&self) -> PyExpr {
         self.clone().inner.first().into()
     }

--- a/py-polars/src/lazy/dsl.rs
+++ b/py-polars/src/lazy/dsl.rs
@@ -145,6 +145,10 @@ impl PyExpr {
         self.clone().inner.sort(reverse).into()
     }
 
+    pub fn take(&self, idx: PyExpr) -> PyExpr {
+        self.clone().inner.take(idx.inner).into()
+    }
+
     pub fn sort_by(&self, by: PyExpr, reverse: bool) -> PyExpr {
         self.clone().inner.sort_by(by.inner, reverse).into()
     }


### PR DESCRIPTION
This PR improves the lazy DSL (and eager in Python) by adding the following `Expr`:

* `take`
* `unique`
* `arg_unique`

And this enables the lazy dsl in the following Python eager methods: 

* `DataFrame.with_column(s)`
* `DataFrame.select`
* `DataFrame.__getitem__`