### PR TITLE
Remove chunk_id from ChunkedArray

### DIFF
--- a/polars/polars-core/src/chunked_array/builder/categorical.rs
+++ b/polars/polars-core/src/chunked_array/builder/categorical.rs
@@ -152,11 +152,9 @@ impl CategoricalChunkedBuilder {
 
     pub fn finish(mut self) -> ChunkedArray<CategoricalType> {
         let arr = Arc::new(self.array_builder.finish());
-        let len = arr.len();
         ChunkedArray {
             field: Arc::new(self.field),
             chunks: vec![arr],
-            chunk_id: vec![len],
             phantom: PhantomData,
             categorical_map: Some(Arc::new(self.reverse_mapping.finish())),
         }

--- a/polars/polars-core/src/chunked_array/builder/mod.rs
+++ b/polars/polars-core/src/chunked_array/builder/mod.rs
@@ -47,11 +47,9 @@ impl ChunkedBuilder<bool, BooleanType> for BooleanChunkedBuilder {
     fn finish(mut self) -> BooleanChunked {
         let arr = Arc::new(self.array_builder.finish());
 
-        let len = arr.len();
         ChunkedArray {
             field: Arc::new(self.field),
             chunks: vec![arr],
-            chunk_id: vec![len],
             phantom: PhantomData,
             categorical_map: None,
         }
@@ -96,11 +94,9 @@ where
     fn finish(mut self) -> ChunkedArray<T> {
         let arr = Arc::new(self.array_builder.finish());
 
-        let len = arr.len();
         ChunkedArray {
             field: Arc::new(self.field),
             chunks: vec![arr],
-            chunk_id: vec![len],
             phantom: PhantomData,
             categorical_map: None,
         }
@@ -162,11 +158,9 @@ impl Utf8ChunkedBuilder {
 
     pub fn finish(mut self) -> Utf8Chunked {
         let arr = Arc::new(self.builder.finish());
-        let len = arr.len();
         ChunkedArray {
             field: Arc::new(self.field),
             chunks: vec![arr],
-            chunk_id: vec![len],
             phantom: PhantomData,
             categorical_map: None,
         }
@@ -313,7 +307,6 @@ where
         ChunkedArray {
             field,
             chunks: vec![Arc::new(builder.finish())],
-            chunk_id: vec![v.len()],
             phantom: PhantomData,
             categorical_map: None,
         }
@@ -367,11 +360,9 @@ where
 macro_rules! finish_list_builder {
     ($self:ident) => {{
         let arr = Arc::new($self.builder.finish());
-        let len = arr.len();
         ListChunked {
             field: Arc::new($self.field.clone()),
             chunks: vec![arr],
-            chunk_id: vec![len],
             phantom: PhantomData,
             categorical_map: None,
         }

--- a/polars/polars-core/src/chunked_array/comparison.rs
+++ b/polars/polars-core/src/chunked_array/comparison.rs
@@ -73,7 +73,7 @@ where
             }
         }
         // same length
-        else if self.chunk_id == rhs.chunk_id {
+        else if self.chunk_id().zip(rhs.chunk_id()).all(|(l, r)| l == r) {
             // should not fail if arrays are equal
             self.comparison(rhs, comparison::eq)
                 .expect("should not fail.")
@@ -92,7 +92,7 @@ where
             }
         }
         // same length
-        else if self.chunk_id == rhs.chunk_id {
+        else if self.chunk_id().zip(rhs.chunk_id()).all(|(l, r)| l == r) {
             self.comparison(rhs, comparison::neq)
                 .expect("should not fail.")
         } else {
@@ -110,7 +110,7 @@ where
             }
         }
         // same length
-        else if self.chunk_id == rhs.chunk_id {
+        else if self.chunk_id().zip(rhs.chunk_id()).all(|(l, r)| l == r) {
             self.comparison(rhs, comparison::gt)
                 .expect("should not fail.")
         } else {
@@ -128,7 +128,7 @@ where
             }
         }
         // same length
-        else if self.chunk_id == rhs.chunk_id {
+        else if self.chunk_id().zip(rhs.chunk_id()).all(|(l, r)| l == r) {
             self.comparison(rhs, comparison::gt_eq)
                 .expect("should not fail.")
         } else {
@@ -146,7 +146,7 @@ where
             }
         }
         // same length
-        else if self.chunk_id == rhs.chunk_id {
+        else if self.chunk_id().zip(rhs.chunk_id()).all(|(l, r)| l == r) {
             self.comparison(rhs, comparison::lt)
                 .expect("should not fail.")
         } else {
@@ -164,7 +164,7 @@ where
             }
         }
         // same length
-        else if self.chunk_id == rhs.chunk_id {
+        else if self.chunk_id().zip(rhs.chunk_id()).all(|(l, r)| l == r) {
             self.comparison(rhs, comparison::lt_eq)
                 .expect("should not fail.")
         } else {
@@ -322,7 +322,7 @@ impl ChunkCompare<&Utf8Chunked> for Utf8Chunked {
             }
         }
         // same length
-        else if self.chunk_id == rhs.chunk_id {
+        else if self.chunk_id().zip(rhs.chunk_id()).all(|(l, r)| l == r) {
             self.comparison(rhs, eq_utf8).expect("should not fail")
         } else {
             apply_operand_on_chunkedarray_by_iter!(self, rhs, ==)
@@ -339,7 +339,7 @@ impl ChunkCompare<&Utf8Chunked> for Utf8Chunked {
             }
         }
         // same length
-        else if self.chunk_id == rhs.chunk_id {
+        else if self.chunk_id().zip(rhs.chunk_id()).all(|(l, r)| l == r) {
             self.comparison(rhs, neq_utf8).expect("should not fail")
         } else {
             apply_operand_on_chunkedarray_by_iter!(self, rhs, !=)
@@ -356,7 +356,7 @@ impl ChunkCompare<&Utf8Chunked> for Utf8Chunked {
             }
         }
         // same length
-        else if self.chunk_id == rhs.chunk_id {
+        else if self.chunk_id().zip(rhs.chunk_id()).all(|(l, r)| l == r) {
             self.comparison(rhs, gt_utf8).expect("should not fail")
         } else {
             apply_operand_on_chunkedarray_by_iter!(self, rhs, >)
@@ -373,7 +373,7 @@ impl ChunkCompare<&Utf8Chunked> for Utf8Chunked {
             }
         }
         // same length
-        else if self.chunk_id == rhs.chunk_id {
+        else if self.chunk_id().zip(rhs.chunk_id()).all(|(l, r)| l == r) {
             self.comparison(rhs, gt_eq_utf8).expect("should not fail")
         } else {
             apply_operand_on_chunkedarray_by_iter!(self, rhs, >=)
@@ -390,7 +390,7 @@ impl ChunkCompare<&Utf8Chunked> for Utf8Chunked {
             }
         }
         // same length
-        else if self.chunk_id == rhs.chunk_id {
+        else if self.chunk_id().zip(rhs.chunk_id()).all(|(l, r)| l == r) {
             self.comparison(rhs, lt_utf8).expect("should not fail")
         } else {
             apply_operand_on_chunkedarray_by_iter!(self, rhs, <)
@@ -407,7 +407,7 @@ impl ChunkCompare<&Utf8Chunked> for Utf8Chunked {
             }
         }
         // same length
-        else if self.chunk_id == rhs.chunk_id {
+        else if self.chunk_id().zip(rhs.chunk_id()).all(|(l, r)| l == r) {
             self.comparison(rhs, lt_eq_utf8).expect("should not fail")
         } else {
             apply_operand_on_chunkedarray_by_iter!(self, rhs, <=)
@@ -588,7 +588,7 @@ impl BooleanChunked {
 
 macro_rules! impl_bitwise_op  {
     ($self:ident, $rhs:ident, $arrow_method:ident, $op:tt) => {{
-        if $self.chunk_id == $rhs.chunk_id {
+        if $self.chunk_id().zip($rhs.chunk_id()).all(|(l, r)| l == r) {
             let result = $self.bit_operation($rhs, compute::$arrow_method);
             result.unwrap()
         } else {

--- a/polars/polars-core/src/chunked_array/mod.rs
+++ b/polars/polars-core/src/chunked_array/mod.rs
@@ -488,8 +488,9 @@ where
             let mut offset = 0;
             let chunks = chunk_id
                 .map(|len| {
+                    let out = array.slice(offset, len);
                     offset += len;
-                    array.slice(offset, len)
+                    out
                 })
                 .collect();
 

--- a/polars/polars-core/src/chunked_array/mod.rs
+++ b/polars/polars-core/src/chunked_array/mod.rs
@@ -313,8 +313,8 @@ impl<T> ChunkedArray<T> {
             ));
         }
         if self.field.data_type() == other.data_type() {
+            self.chunk_id.push(other.len());
             self.chunks.push(other);
-            self.chunk_id = create_chunk_id(&self.chunks);
             Ok(())
         } else {
             Err(PolarsError::DataTypeMisMatch(
@@ -459,10 +459,11 @@ impl<T> ChunkedArray<T> {
         // replace an empty array
         if self.chunks.len() == 1 && self.is_empty() {
             self.chunks = other.chunks.clone();
+            self.chunk_id = create_chunk_id(&self.chunks);
         } else {
-            self.chunks.extend_from_slice(&other.chunks)
+            self.chunks.extend_from_slice(&other.chunks);
+            self.chunk_id.extend_from_slice(&other.chunk_id);
         }
-        self.chunk_id = create_chunk_id(&self.chunks);
     }
 
     /// Name of the ChunkedArray.

--- a/polars/polars-core/src/chunked_array/object/builder.rs
+++ b/polars/polars-core/src/chunked_array/object/builder.rs
@@ -76,7 +76,6 @@ where
         ChunkedArray {
             field: Arc::new(self.field),
             chunks: vec![arr],
-            chunk_id: vec![len],
             phantom: PhantomData,
             categorical_map: None,
         }
@@ -142,7 +141,6 @@ where
         ObjectChunked {
             field,
             chunks: vec![arr],
-            chunk_id: vec![len],
             phantom: PhantomData,
             categorical_map: None,
         }

--- a/polars/polars-core/src/chunked_array/upstream_traits.rs
+++ b/polars/polars-core/src/chunked_array/upstream_traits.rs
@@ -18,7 +18,6 @@ impl<T> Default for ChunkedArray<T> {
         ChunkedArray {
             field: Arc::new(Field::new("default", DataType::Null)),
             chunks: Default::default(),
-            chunk_id: Default::default(),
             phantom: PhantomData,
             categorical_map: None,
         }

--- a/polars/polars-core/src/frame/mod.rs
+++ b/polars/polars-core/src/frame/mod.rs
@@ -128,7 +128,13 @@ impl DataFrame {
 
     /// Ensure all the chunks in the DataFrame are aligned.
     pub fn rechunk(&mut self) -> &mut Self {
-        if self.columns.iter().map(|s| s.chunk_lengths()).all_equal() {
+        // TODO: remove vec allocation
+        if self
+            .columns
+            .iter()
+            .map(|s| s.chunk_lengths().collect_vec())
+            .all_equal()
+        {
             self
         } else {
             self.as_single_chunk()

--- a/polars/polars-core/src/series/implementations/dates.rs
+++ b/polars/polars-core/src/series/implementations/dates.rs
@@ -10,8 +10,7 @@ use super::private;
 use super::IntoSeries;
 use super::SeriesTrait;
 use super::SeriesWrap;
-use crate::chunked_array::comparison::*;
-use crate::chunked_array::AsSinglePtr;
+use crate::chunked_array::{comparison::*, AsSinglePtr, ChunkIdIter};
 use crate::fmt::FmtList;
 #[cfg(feature = "pivot")]
 use crate::frame::groupby::pivot::*;
@@ -256,7 +255,7 @@ macro_rules! impl_dyn_series {
                 self.0.array_data()
             }
 
-            fn chunk_lengths(&self) -> &Vec<usize> {
+            fn chunk_lengths(&self) -> ChunkIdIter {
                 self.0.chunk_id()
             }
             fn name(&self) -> &str {

--- a/polars/polars-core/src/series/implementations/mod.rs
+++ b/polars/polars-core/src/series/implementations/mod.rs
@@ -15,7 +15,7 @@ use super::SeriesTrait;
 use crate::chunked_array::comparison::*;
 use crate::chunked_array::{
     ops::aggregate::{ChunkAggSeries, VarAggSeries},
-    AsSinglePtr,
+    AsSinglePtr, ChunkIdIter,
 };
 use crate::fmt::FmtList;
 #[cfg(feature = "pivot")]
@@ -202,7 +202,7 @@ macro_rules! impl_dyn_series {
                 self.0.array_data()
             }
 
-            fn chunk_lengths(&self) -> &Vec<usize> {
+            fn chunk_lengths(&self) -> ChunkIdIter {
                 self.0.chunk_id()
             }
             fn name(&self) -> &str {

--- a/polars/polars-core/src/series/implementations/object.rs
+++ b/polars/polars-core/src/series/implementations/object.rs
@@ -1,3 +1,4 @@
+use crate::chunked_array::ChunkIdIter;
 use crate::fmt::FmtList;
 use crate::prelude::*;
 use crate::series::implementations::SeriesWrap;
@@ -37,7 +38,7 @@ where
         ObjectChunked::array_data(&self.0)
     }
 
-    fn chunk_lengths(&self) -> &Vec<usize> {
+    fn chunk_lengths(&self) -> ChunkIdIter {
         ObjectChunked::chunk_id(&self.0)
     }
 

--- a/polars/polars-core/src/series/mod.rs
+++ b/polars/polars-core/src/series/mod.rs
@@ -7,8 +7,7 @@ mod comparison;
 pub mod implementations;
 pub(crate) mod iterator;
 
-use crate::chunked_array::builder::get_list_builder;
-use crate::chunked_array::float::IsNan;
+use crate::chunked_array::{builder::get_list_builder, float::IsNan, ChunkIdIter};
 use crate::series::arithmetic::coerce_lhs_rhs;
 use crate::utils::get_supertype;
 use arrow::array::ArrayData;
@@ -173,7 +172,7 @@ pub trait SeriesTrait: Send + Sync + private::PrivateSeries {
     }
 
     /// Get the lengths of the underlying chunks
-    fn chunk_lengths(&self) -> &Vec<usize> {
+    fn chunk_lengths(&self) -> ChunkIdIter {
         unimplemented!()
     }
     /// Name of series.

--- a/polars/polars-lazy/src/frame.rs
+++ b/polars/polars-lazy/src/frame.rs
@@ -3,7 +3,6 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use ahash::RandomState;
-use itertools::Itertools;
 
 use polars_core::frame::hash_join::JoinType;
 use polars_core::prelude::*;
@@ -497,14 +496,18 @@ impl LazyFrame {
         {
             // only check by names because we may supercast types.
             assert_eq!(
-                prev_schema.fields().iter().map(|f| f.name()).collect_vec(),
+                prev_schema
+                    .fields()
+                    .iter()
+                    .map(|f| f.name())
+                    .collect::<Vec<_>>(),
                 lp_arena
                     .get(lp_top)
                     .schema(lp_arena)
                     .fields()
                     .iter()
                     .map(|f| f.name())
-                    .collect_vec()
+                    .collect::<Vec<_>>()
             );
         };
 

--- a/py-polars/src/series.rs
+++ b/py-polars/src/series.rs
@@ -288,7 +288,7 @@ impl PySeries {
     }
 
     pub fn chunk_lengths(&self) -> Vec<usize> {
-        self.series.chunk_lengths().clone()
+        self.series.chunk_lengths().collect()
     }
 
     pub fn name(&self) -> &str {


### PR DESCRIPTION
Every new append a new chunk_id was created. This lead to a lot of of unneeded Vec allocations. This PR reduces the size of a ChunkedArray, makes appends a lot cheaper. Especially in multiple append calls as this was accidentally `O(n^2)` (for instance in the csv parser). And this speeds up iteration over ListChunked as there is a `Vec::aloc` less.