### PR TITLE
Fix null handling and bug in categorical reverse map

### DIFF
--- a/polars/polars-core/src/frame/groupby/mod.rs
+++ b/polars/polars-core/src/frame/groupby/mod.rs
@@ -1525,4 +1525,19 @@ mod test {
             assert_eq!(a, b);
         }
     }
+
+    #[test]
+    fn test_groupby_null_handling() -> Result<()> {
+        let df = df!(
+            "a" => ["a", "a", "a", "b", "b"],
+            "b" => [Some(1), Some(2), None, None, Some(1)]
+        )?;
+        let out = df.groupby_stable("a")?.mean()?;
+
+        assert_eq!(
+            Vec::from(out.column("b_mean")?.f64()?),
+            &[Some(1.5), Some(1.0)]
+        );
+        Ok(())
+    }
 }

--- a/polars/polars-lazy/src/frame.rs
+++ b/polars/polars-lazy/src/frame.rs
@@ -1849,7 +1849,7 @@ mod test {
 
         assert_eq!(
             out.column("a_mean").unwrap().f64().unwrap().get(0),
-            Some(0.5)
+            Some(1.0)
         );
     }
 


### PR DESCRIPTION
This PR fixes null handling in aggregations of `mean`, `std`, `variance` and `cov` aggregations.