### PR TITLE
Multilevel sort

### DIFF
--- a/polars/Cargo.toml
+++ b/polars/Cargo.toml
@@ -55,9 +55,10 @@ pretty_fmt = ["polars-core/pretty_fmt"]
 # features
 # resample operation on DataFrame
 pivot = ["polars-core/pivot"]
-
 # resample operation on DataFrame
 downsample = ["polars-core/downsample"]
+# sort by multiple columns
+sort_multiple = ["polars-core/sort_multiple"]
 
 # all opt-in datatypes
 dtype-full = [

--- a/polars/polars-core/Cargo.toml
+++ b/polars/polars-core/Cargo.toml
@@ -16,7 +16,7 @@ docs = []
 temporal = ["chrono", "regex"]
 random = ["rand", "rand_distr"]
 default = ["docs", "temporal", "performant"]
-lazy = []
+lazy = ["sort_multiple"]
 
 # commented out until UB is fixed
 #parallel = []

--- a/polars/polars-core/Cargo.toml
+++ b/polars/polars-core/Cargo.toml
@@ -39,6 +39,8 @@ plain_fmt = ["prettytable-rs"]
 pivot = []
 # resample operation on DataFrame
 downsample = ["temporal", "dtype-date64"]
+# sort by multiple columns
+sort_multiple = []
 
 # opt-in datatypes for Series
 dtype-time64-ns = []

--- a/polars/polars-core/src/chunked_array/ops/mod.rs
+++ b/polars/polars-core/src/chunked_array/ops/mod.rs
@@ -582,6 +582,17 @@ pub trait ChunkSort<T> {
 
     /// Retrieve the indexes needed to sort this array.
     fn argsort(&self, reverse: bool) -> UInt32Chunked;
+
+    /// Retrieve the indexes need to sort this and the other arrays.
+    fn argsort_multiple(
+        &self,
+        _other: &[&ChunkedArray<T>],
+        _reverse: bool,
+    ) -> Result<UInt32Chunked> {
+        Err(PolarsError::InvalidOperation(
+            "argsort_multiple not implemented for this dtype".into(),
+        ))
+    }
 }
 
 #[derive(Copy, Clone, Debug)]

--- a/polars/polars-core/src/chunked_array/ops/mod.rs
+++ b/polars/polars-core/src/chunked_array/ops/mod.rs
@@ -584,11 +584,7 @@ pub trait ChunkSort<T> {
     fn argsort(&self, reverse: bool) -> UInt32Chunked;
 
     /// Retrieve the indexes need to sort this and the other arrays.
-    fn argsort_multiple(
-        &self,
-        _other: &[&ChunkedArray<T>],
-        _reverse: bool,
-    ) -> Result<UInt32Chunked> {
+    fn argsort_multiple(&self, _other: &[Series], _reverse: bool) -> Result<UInt32Chunked> {
         Err(PolarsError::InvalidOperation(
             "argsort_multiple not implemented for this dtype".into(),
         ))

--- a/polars/polars-core/src/datatypes.rs
+++ b/polars/polars-core/src/datatypes.rs
@@ -17,6 +17,7 @@ pub use arrow::datatypes::{
     TimestampMicrosecondType, TimestampMillisecondType, TimestampNanosecondType,
     TimestampSecondType, UInt16Type, UInt32Type, UInt64Type, UInt8Type,
 };
+use std::cmp::Ordering;
 use std::fmt::{Display, Formatter};
 
 pub struct Utf8Type {}
@@ -261,7 +262,7 @@ impl Display for DataType {
     }
 }
 
-impl<'a> PartialEq for AnyValue<'a> {
+impl PartialEq for AnyValue<'_> {
     // Everything of Any is slow. Don't use.
     fn eq(&self, other: &Self) -> bool {
         use AnyValue::*;
@@ -288,6 +289,26 @@ impl<'a> PartialEq for AnyValue<'a> {
             // should it?
             (Null, Null) => true,
             _ => false,
+        }
+    }
+}
+
+impl PartialOrd for AnyValue<'_> {
+    /// Only implemented for the same types and physical types!
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        use AnyValue::*;
+        match (self, other) {
+            (UInt8(l), UInt8(r)) => l.partial_cmp(r),
+            (UInt16(l), UInt16(r)) => l.partial_cmp(r),
+            (UInt32(l), UInt32(r)) => l.partial_cmp(r),
+            (UInt64(l), UInt64(r)) => l.partial_cmp(r),
+            (Int8(l), Int8(r)) => l.partial_cmp(r),
+            (Int16(l), Int16(r)) => l.partial_cmp(r),
+            (Int32(l), Int32(r)) => l.partial_cmp(r),
+            (Int64(l), Int64(r)) => l.partial_cmp(r),
+            (Float32(l), Float32(r)) => l.partial_cmp(r),
+            (Float64(l), Float64(r)) => l.partial_cmp(r),
+            _ => None,
         }
     }
 }

--- a/polars/polars-core/src/frame/mod.rs
+++ b/polars/polars-core/src/frame/mod.rs
@@ -767,15 +767,18 @@ impl DataFrame {
                     // we only allow this implementation of the same types
                     // se we determine the supertypes and coerce all series.
                     let mut first = columns.remove(0);
-                    // let first_dtype = Cow::Borrowed(first.dtype());
-                    let dtype = columns.iter().try_fold::<_, _, Result<_>>(None, |acc, s| {
-                        let acc = match (&acc, s.dtype()) {
-                            (_, DataType::Utf8) => acc,
-                            (None, dt) => Some(dt.clone()),
-                            (Some(acc), dt) => Some(get_supertype(acc, dt)?),
-                        };
-                        Ok(acc)
-                    })?;
+                    let dtype = if first.utf8().is_ok() {
+                        Some(DataType::Float64)
+                    } else {
+                        columns.iter().try_fold::<_, _, Result<_>>(None, |acc, s| {
+                            let acc = match (&acc, s.dtype()) {
+                                (_, DataType::Utf8) => acc,
+                                (None, dt) => Some(dt.clone()),
+                                (Some(acc), dt) => Some(get_supertype(acc, dt)?),
+                            };
+                            Ok(acc)
+                        })?
+                    };
 
                     if let Some(dtype) = dtype {
                         columns = columns

--- a/polars/polars-core/src/frame/mod.rs
+++ b/polars/polars-core/src/frame/mod.rs
@@ -14,8 +14,7 @@ use crate::chunked_array::ops::unique::is_unique_helper;
 use crate::frame::select::Selection;
 use crate::prelude::*;
 use crate::utils::{
-    accumulate_dataframes_horizontal, accumulate_dataframes_vertical, get_supertype,
-    CustomIterTools, NoNull,
+    accumulate_dataframes_horizontal, accumulate_dataframes_vertical, get_supertype, NoNull,
 };
 
 mod arithmetic;
@@ -764,7 +763,9 @@ impl DataFrame {
                 #[cfg(feature = "sort_multiple")]
                 {
                     let mut columns = self.select_series(by_column)?;
+
                     // we only allow this implementation of the same types
+                    // se we determine the supertypes and coerce all series.
                     let first = columns.remove(0);
                     let first_dtype = Cow::Borrowed(first.dtype());
                     let dtype = columns
@@ -776,6 +777,7 @@ impl DataFrame {
                         .iter()
                         .map(|s| s.cast_with_datatype(&*dtype))
                         .collect::<Result<Vec<_>>>()?;
+                    let first = first.cast_with_datatype(&*dtype)?;
                     first.argsort_multiple(&columns, reverse)?
                 }
                 #[cfg(not(feature = "sort_multiple"))]

--- a/polars/polars-core/src/frame/select.rs
+++ b/polars/polars-core/src/frame/select.rs
@@ -8,7 +8,7 @@ pub trait Selection<'a, S> {
     fn to_selection_vec(self) -> Vec<&'a str>;
 
     // a single column is selected
-    fn single(&self) -> Option<&'a str> {
+    fn single(&self) -> Option<&str> {
         None
     }
 }
@@ -35,6 +35,14 @@ where
 {
     fn to_selection_vec(self) -> Vec<&'a str> {
         self.as_ref().iter().map(|s| s.as_ref()).collect()
+    }
+
+    fn single(&self) -> Option<&str> {
+        let a = self.as_ref();
+        match a.len() {
+            1 => Some(a[0].as_ref()),
+            _ => None,
+        }
     }
 }
 

--- a/polars/polars-core/src/frame/select.rs
+++ b/polars/polars-core/src/frame/select.rs
@@ -1,11 +1,24 @@
 #[allow(clippy::wrong_self_convention)]
+/// Allow selection by:
+///
+/// &str => df.select("my-column"),
+/// (&str)" => df.select(("col_1", "col_2")),
+/// Vec<&str)" => df.select(vec!["col_a", "col_b"]),
 pub trait Selection<'a, S> {
     fn to_selection_vec(self) -> Vec<&'a str>;
+
+    // a single column is selected
+    fn single(&self) -> Option<&'a str> {
+        None
+    }
 }
 
 impl<'a> Selection<'a, &str> for &'a str {
     fn to_selection_vec(self) -> Vec<&'a str> {
         vec![self]
+    }
+    fn single(&self) -> Option<&'a str> {
+        Some(self)
     }
 }
 

--- a/polars/polars-core/src/series/implementations/dates.rs
+++ b/polars/polars-core/src/series/implementations/dates.rs
@@ -237,13 +237,9 @@ macro_rules! impl_dyn_series {
                 let phys_type = self.0.physical_type();
                 let s = self.cast_with_datatype(&phys_type).unwrap();
 
-                let by = by
-                    .iter()
-                    .map(|s| self.0.unpack_series_matching_type(s))
-                    .collect::<Result<Vec<_>>>()?;
                 self.0
                     .unpack_series_matching_type(&s)?
-                    .argsort_multiple(&by, reverse)
+                    .argsort_multiple(by, reverse)
             }
         }
 

--- a/polars/polars-core/src/series/implementations/dates.rs
+++ b/polars/polars-core/src/series/implementations/dates.rs
@@ -232,6 +232,19 @@ macro_rules! impl_dyn_series {
             fn group_tuples(&self, multithreaded: bool) -> GroupTuples {
                 cast_and_apply!(self, group_tuples, multithreaded)
             }
+            #[cfg(feature = "sort_multiple")]
+            fn argsort_multiple(&self, by: &[Series], reverse: bool) -> Result<UInt32Chunked> {
+                let phys_type = self.0.physical_type();
+                let s = self.cast_with_datatype(&phys_type).unwrap();
+
+                let by = by
+                    .iter()
+                    .map(|s| self.0.unpack_series_matching_type(s))
+                    .collect::<Result<Vec<_>>>()?;
+                self.0
+                    .unpack_series_matching_type(&s)?
+                    .argsort_multiple(&by, reverse)
+            }
         }
 
         impl SeriesTrait for SeriesWrap<$ca> {

--- a/polars/polars-core/src/series/implementations/mod.rs
+++ b/polars/polars-core/src/series/implementations/mod.rs
@@ -182,11 +182,7 @@ macro_rules! impl_dyn_series {
 
             #[cfg(feature = "sort_multiple")]
             fn argsort_multiple(&self, by: &[Series], reverse: bool) -> Result<UInt32Chunked> {
-                let by = by
-                    .iter()
-                    .map(|s| self.0.unpack_series_matching_type(s))
-                    .collect::<Result<Vec<_>>>()?;
-                self.0.argsort_multiple(&by, reverse)
+                self.0.argsort_multiple(by, reverse)
             }
         }
 

--- a/polars/polars-core/src/series/implementations/mod.rs
+++ b/polars/polars-core/src/series/implementations/mod.rs
@@ -179,6 +179,15 @@ macro_rules! impl_dyn_series {
             fn group_tuples(&self, multithreaded: bool) -> GroupTuples {
                 IntoGroupTuples::group_tuples(&self.0, multithreaded)
             }
+
+            #[cfg(feature = "sort_multiple")]
+            fn argsort_multiple(&self, by: &[Series], reverse: bool) -> Result<UInt32Chunked> {
+                let by = by
+                    .iter()
+                    .map(|s| self.0.unpack_series_matching_type(s))
+                    .collect::<Result<Vec<_>>>()?;
+                self.0.argsort_multiple(&by, reverse)
+            }
         }
 
         impl SeriesTrait for SeriesWrap<$ca> {

--- a/polars/polars-core/src/series/mod.rs
+++ b/polars/polars-core/src/series/mod.rs
@@ -144,6 +144,12 @@ pub(crate) mod private {
         fn is_in_same_type(&self, _list_array: &ListChunked) -> Result<BooleanChunked> {
             unimplemented!()
         }
+        #[cfg(feature = "sort_multiple")]
+        fn argsort_multiple(&self, _by: &[Series], _reverse: bool) -> Result<UInt32Chunked> {
+            Err(PolarsError::InvalidOperation(
+                "argsort_multiple is not implemented for this Series".into(),
+            ))
+        }
     }
 }
 

--- a/polars/polars-lazy/src/datafusion/conversion.rs
+++ b/polars/polars-lazy/src/datafusion/conversion.rs
@@ -216,7 +216,16 @@ pub fn to_datafusion_lp(lp: LogicalPlan) -> Result<DLogicalPlan> {
             reverse,
         } => DLogicalPlan::Sort {
             input: Arc::new(to_datafusion_lp(*input)?),
-            expr: vec![col(&by_column).sort(!reverse, true)],
+            expr: by_column
+                .into_iter()
+                .map(|e| {
+                    if reverse {
+                        to_datafusion_expr(e.reverse())
+                    } else {
+                        to_datafusion_expr(e)
+                    }
+                })
+                .collect::<Result<Vec<_>>>()?,
         },
         Join {
             input_left,

--- a/polars/polars-lazy/src/datafusion/conversion.rs
+++ b/polars/polars-lazy/src/datafusion/conversion.rs
@@ -220,9 +220,9 @@ pub fn to_datafusion_lp(lp: LogicalPlan) -> Result<DLogicalPlan> {
                 .into_iter()
                 .map(|e| {
                     if reverse {
-                        to_datafusion_expr(e.reverse())
+                        to_datafusion_expr(e.reverse()).map(|e| e.sort(!reverse, true))
                     } else {
-                        to_datafusion_expr(e)
+                        to_datafusion_expr(e).map(|e| e.sort(!reverse, true))
                     }
                 })
                 .collect::<Result<Vec<_>>>()?,

--- a/polars/polars-lazy/src/frame.rs
+++ b/polars/polars-lazy/src/frame.rs
@@ -332,8 +332,28 @@ impl LazyFrame {
         let opt_state = self.get_opt_state();
         let lp = self
             .get_plan_builder()
-            .sort(by_column.into(), reverse)
+            .sort(vec![col(by_column)], reverse)
             .build();
+        Self::from_logical_plan(lp, opt_state)
+    }
+
+    /// Add a sort operation to the logical plan.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use polars_core::prelude::*;
+    /// use polars_lazy::prelude::*;
+    ///
+    /// /// Sort DataFrame by 'sepal.width' column
+    /// fn example(df: DataFrame) -> LazyFrame {
+    ///       df.lazy()
+    ///         .sort_by_exprs(vec![col("sepal.width")], false)
+    /// }
+    /// ```
+    pub fn sort_by_exprs(self, by_exprs: Vec<Expr>, reverse: bool) -> Self {
+        let opt_state = self.get_opt_state();
+        let lp = self.get_plan_builder().sort(by_exprs, reverse).build();
         Self::from_logical_plan(lp, opt_state)
     }
 

--- a/polars/polars-lazy/src/frame.rs
+++ b/polars/polars-lazy/src/frame.rs
@@ -151,7 +151,7 @@ impl IntoLazy for DataFrame {
 #[derive(Clone)]
 pub struct LazyFrame {
     pub(crate) logical_plan: LogicalPlan,
-    opt_state: OptState,
+    pub(crate) opt_state: OptState,
 }
 
 impl Default for LazyFrame {

--- a/polars/polars-lazy/src/logical_plan/alp.rs
+++ b/polars/polars-lazy/src/logical_plan/alp.rs
@@ -70,7 +70,7 @@ pub enum ALogicalPlan {
     },
     Sort {
         input: Node,
-        by_column: String,
+        by_column: Vec<Node>,
         reverse: bool,
     },
     Explode {

--- a/polars/polars-lazy/src/logical_plan/conversion.rs
+++ b/polars/polars-lazy/src/logical_plan/conversion.rs
@@ -583,10 +583,7 @@ pub(crate) fn node_to_exp(node: Node, expr_arena: &Arena<AExpr>) -> Expr {
 }
 
 fn nodes_to_exprs(nodes: &[Node], expr_arena: &Arena<AExpr>) -> Vec<Expr> {
-    nodes
-        .into_iter()
-        .map(|n| node_to_exp(*n, expr_arena))
-        .collect()
+    nodes.iter().map(|n| node_to_exp(*n, expr_arena)).collect()
 }
 
 pub(crate) fn node_to_lp(

--- a/polars/polars-lazy/src/logical_plan/mod.rs
+++ b/polars/polars-lazy/src/logical_plan/mod.rs
@@ -226,7 +226,7 @@ pub enum LogicalPlan {
     /// Sort the table
     Sort {
         input: Box<LogicalPlan>,
-        by_column: String,
+        by_column: Vec<Expr>,
         reverse: bool,
     },
     /// An explode operation
@@ -370,7 +370,7 @@ impl fmt::Debug for LogicalPlan {
             }
             Sort {
                 input, by_column, ..
-            } => write!(f, "SORT {:?} BY COLUMN {}", input, by_column),
+            } => write!(f, "SORT {:?} BY {:?}", input, by_column),
             Explode { input, columns, .. } => {
                 write!(f, "EXPLODE COLUMN(S) {:?} OF {:?}", columns, input)
             }
@@ -526,7 +526,7 @@ impl LogicalPlan {
             Sort {
                 input, by_column, ..
             } => {
-                let current_node = format!("SORT by {} [{}]", by_column, id);
+                let current_node = format!("SORT BY {:?} [{}]", by_column, id);
                 self.write_dot(acc_str, prev_node, &current_node, id)?;
                 input.dot(acc_str, (branch, id + 1), &current_node)
             }
@@ -1126,7 +1126,7 @@ impl LogicalPlanBuilder {
         .into()
     }
 
-    pub fn sort(self, by_column: String, reverse: bool) -> Self {
+    pub fn sort(self, by_column: Vec<Expr>, reverse: bool) -> Self {
         LogicalPlan::Sort {
             input: Box::new(self.0),
             by_column,

--- a/polars/polars-lazy/src/logical_plan/optimizer/projection_pushdown.rs
+++ b/polars/polars-lazy/src/logical_plan/optimizer/projection_pushdown.rs
@@ -354,14 +354,19 @@ impl ProjectionPushDown {
                 reverse,
             } => {
                 if !acc_projections.is_empty() {
-                    // Make sure that the column used for the sort is projected
-                    let node = expr_arena.add(AExpr::Column(Arc::new(by_column.clone())));
-                    add_expr_to_accumulated(
-                        node,
-                        &mut acc_projections,
-                        &mut projected_names,
-                        expr_arena,
-                    );
+                    // Make sure that the column(s) used for the sort is projected
+                    by_column.iter().for_each(|node| {
+                        aexpr_to_root_nodes(*node, expr_arena)
+                            .iter()
+                            .for_each(|root| {
+                                add_expr_to_accumulated(
+                                    *root,
+                                    &mut acc_projections,
+                                    &mut projected_names,
+                                    expr_arena,
+                                );
+                            })
+                    });
                 }
 
                 self.pushdown_and_assign(

--- a/polars/polars-lazy/src/physical_plan/executors.rs
+++ b/polars/polars-lazy/src/physical_plan/executors.rs
@@ -417,7 +417,7 @@ pub(crate) struct SortExec {
 impl Executor for SortExec {
     fn execute(&mut self, state: &ExecutionState) -> Result<DataFrame> {
         let df = self.input.execute(state)?;
-        df.sort(&self.by_column, self.reverse)
+        df.sort(self.by_column.as_str(), self.reverse)
     }
 }
 

--- a/polars/polars-lazy/src/physical_plan/executors.rs
+++ b/polars/polars-lazy/src/physical_plan/executors.rs
@@ -410,14 +410,34 @@ impl Executor for ExplodeExec {
 
 pub(crate) struct SortExec {
     pub(crate) input: Box<dyn Executor>,
-    pub(crate) by_column: String,
+    pub(crate) by_column: Vec<Arc<dyn PhysicalExpr>>,
     pub(crate) reverse: bool,
 }
 
 impl Executor for SortExec {
     fn execute(&mut self, state: &ExecutionState) -> Result<DataFrame> {
-        let df = self.input.execute(state)?;
-        df.sort(self.by_column.as_str(), self.reverse)
+        let mut df = self.input.execute(state)?;
+
+        let by_columns = self
+            .by_column
+            .iter()
+            .map(|e| e.evaluate(&df, state))
+            .collect::<Result<Vec<_>>>()?;
+        let mut column_names = Vec::with_capacity(by_columns.len());
+        // replace the columns in the DataFrame with the expressions
+        // for col("foo") this is redundant
+        // for col("foo").reverse() this is not
+        for column in by_columns {
+            let name = column.name();
+            column_names.push(name.to_string());
+            // if error, expression create a new named column and we must add it to the DataFrame
+            // if ok, we have replaced the column with the expression eval
+            if let Err(_) = df.apply(name, |_| column.clone()) {
+                df.hstack(&[column])?;
+            }
+        }
+
+        df.sort(&column_names, self.reverse)
     }
 }
 

--- a/polars/polars-lazy/src/physical_plan/executors.rs
+++ b/polars/polars-lazy/src/physical_plan/executors.rs
@@ -432,7 +432,7 @@ impl Executor for SortExec {
             column_names.push(name.to_string());
             // if error, expression create a new named column and we must add it to the DataFrame
             // if ok, we have replaced the column with the expression eval
-            if let Err(_) = df.apply(name, |_| column.clone()) {
+            if df.apply(name, |_| column.clone()).is_err() {
                 df.hstack(&[column])?;
             }
         }

--- a/polars/polars-lazy/src/physical_plan/planner.rs
+++ b/polars/polars-lazy/src/physical_plan/planner.rs
@@ -206,6 +206,8 @@ impl DefaultPlanner {
                 reverse,
             } => {
                 let input = self.create_initial_physical_plan(input, lp_arena, expr_arena)?;
+                let by_column =
+                    self.create_physical_expressions(by_column, Context::Default, expr_arena)?;
                 Ok(Box::new(SortExec {
                     input,
                     by_column,

--- a/py-polars/Cargo.toml
+++ b/py-polars/Cargo.toml
@@ -53,12 +53,12 @@ name = "polars"
 requires-dist = ["numpy", "pyarrow==4.0"]
 
 [profile.release]
-codegen-units = 1
+#codegen-units = 1
 
 # This is ignored here; would be set in .cargo/config.toml.
 # Should not be used when packaging
 # target-cpu = "native"
-lto = "fat"
+#lto = "fat"
 
 #[profile.dev]
 #opt-level = 1

--- a/py-polars/Cargo.toml
+++ b/py-polars/Cargo.toml
@@ -53,12 +53,12 @@ name = "polars"
 requires-dist = ["numpy", "pyarrow==4.0"]
 
 [profile.release]
-#codegen-units = 1
+codegen-units = 1
 
 # This is ignored here; would be set in .cargo/config.toml.
 # Should not be used when packaging
 # target-cpu = "native"
-#lto = "fat"
+lto = "fat"
 
 #[profile.dev]
 #opt-level = 1

--- a/py-polars/polars/frame.py
+++ b/py-polars/polars/frame.py
@@ -58,6 +58,10 @@ def _prepare_other_arg(other: Any) -> Series:
     return other
 
 
+def _is_expr(arg: Any) -> bool:
+    return hasattr(arg, "_pyexpr")
+
+
 class DataFrame:
     def __init__(
         self,
@@ -738,14 +742,17 @@ class DataFrame:
         self._df.replace_at_idx(index, series._s)
 
     def sort(
-        self, by_column: str, in_place: bool = False, reverse: bool = False
+        self,
+        by: "Union[str, Expr, List[Expr]]",
+        in_place: bool = False,
+        reverse: bool = False,
     ) -> Optional["DataFrame"]:
         """
         Sort the DataFrame by column
 
         Parameters
         ----------
-        by_column
+        by
             By which column to sort. Only accepts string.
         in_place
             Perform operation in-place.
@@ -755,13 +762,13 @@ class DataFrame:
         Example
         ---
         ```python
-        >>> pl.DataFrame({
+        >>> df = pl.DataFrame({
             "foo": [1, 2, 3],
             "bar": [6.0, 7.0, 8.0],
             "ham": ['a', 'b', 'c']
             })
 
-        >>> dataframe.sort('foo', reverse=True)
+        >>> df.sort('foo', reverse=True)
         shape: (3, 3)
         ╭─────┬─────┬─────╮
         │ foo ┆ bar ┆ ham │
@@ -775,11 +782,25 @@ class DataFrame:
         │ 1   ┆ 6   ┆ "a" │
         ╰─────┴─────┴─────╯
         ```
+
+        ### Sort by multiple columns.
+
+        For multiple columns we can use expression syntax
+
+        ```python
+        df.sort([col("foo"), col("bar").reverse()])
+        ```
         """
+        if type(by) is list or _is_expr(by):
+            df = self.lazy().sort(by, reverse).collect(no_optimization=True)
+            if in_place:
+                self._df = df._df
+                return
+            return df
         if in_place:
-            self._df.sort_in_place(by_column, reverse)
+            self._df.sort_in_place(by, reverse)
         else:
-            return wrap_df(self._df.sort(by_column, reverse))
+            return wrap_df(self._df.sort(by, reverse))
 
     def frame_equal(self, other: "DataFrame", null_equal: bool = False) -> bool:
         """

--- a/py-polars/polars/lazy/__init__.py
+++ b/py-polars/polars/lazy/__init__.py
@@ -216,7 +216,7 @@ class LazyFrame:
         if type(by_columns) is str:
             return wrap_ldf(self._ldf.sort(by_columns, reverse))
 
-        by_columns = expr_to_lit_or_expr(by_columns)
+        by_columns = expr_to_lit_or_expr(by_columns, str_to_lit=False)
         by_columns = _selection_to_pyexpr_list(by_columns)
         return wrap_ldf(self._ldf.sort_by_exprs(by_columns, reverse))
 
@@ -1447,11 +1447,30 @@ class Expr:
         return ((expr > start) & (expr < end)).alias("is_between")
 
 
-def expr_to_lit_or_expr(expr: "Union[Expr, int, float, str, List[Expr]]") -> "Expr":
+def expr_to_lit_or_expr(
+    expr: "Union[Expr, int, float, str, List[Expr]]", str_to_lit: bool = True
+) -> "Expr":
+    """
+    Helper function that converts args to expressions
+
+    Parameters
+    ----------
+    expr
+        Any argument
+    str_to_lit
+        If True string argument `"foo"` will be converted to `lit("foo")`,
+        If False it will be converted to `col("foo")`
+
+    Returns
+    -------
+
+    """
+    if isinstance(expr, str) and not str_to_lit:
+        return col(expr)
     if isinstance(expr, (int, float, str)):
         return lit(expr)
     if isinstance(expr, list):
-        return [expr_to_lit_or_expr(e) for e in expr]
+        return [expr_to_lit_or_expr(e, str_to_lit=str_to_lit) for e in expr]
     return expr
 
 

--- a/py-polars/src/lazy/dataframe.rs
+++ b/py-polars/src/lazy/dataframe.rs
@@ -155,6 +155,12 @@ impl PyLazyFrame {
         let ldf = self.ldf.clone();
         ldf.sort(by_column, reverse).into()
     }
+
+    pub fn sort_by_exprs(&self, by_column: Vec<PyExpr>, reverse: bool) -> PyLazyFrame {
+        let ldf = self.ldf.clone();
+        let exprs = py_exprs_to_exprs(by_column);
+        ldf.sort_by_exprs(exprs, reverse).into()
+    }
     pub fn cache(&self) -> PyLazyFrame {
         let ldf = self.ldf.clone();
         ldf.cache().into()

--- a/py-polars/tests/test_df.py
+++ b/py-polars/tests/test_df.py
@@ -154,7 +154,7 @@ def test_groupby():
     assert (
         df.groupby("a")["b"]
         .sum()
-        .sort(by_column="a")
+        .sort(by="a")
         .frame_equal(DataFrame({"a": ["a", "b", "c"], "": [4, 11, 6]}))
     )
 
@@ -162,42 +162,42 @@ def test_groupby():
         df.groupby("a")
         .select("b")
         .sum()
-        .sort(by_column="a")
+        .sort(by="a")
         .frame_equal(DataFrame({"a": ["a", "b", "c"], "": [4, 11, 6]}))
     )
     assert (
         df.groupby("a")
         .select("c")
         .sum()
-        .sort(by_column="a")
+        .sort(by="a")
         .frame_equal(DataFrame({"a": ["a", "b", "c"], "": [10, 10, 1]}))
     )
     assert (
         df.groupby("a")
         .select("b")
         .min()
-        .sort(by_column="a")
+        .sort(by="a")
         .frame_equal(DataFrame({"a": ["a", "b", "c"], "": [1, 2, 6]}))
     )
     assert (
         df.groupby("a")
         .select("b")
         .max()
-        .sort(by_column="a")
+        .sort(by="a")
         .frame_equal(DataFrame({"a": ["a", "b", "c"], "": [3, 5, 6]}))
     )
     assert (
         df.groupby("a")
         .select("b")
         .mean()
-        .sort(by_column="a")
+        .sort(by="a")
         .frame_equal(DataFrame({"a": ["a", "b", "c"], "": [2.0, (2 + 4 + 5) / 3, 6.0]}))
     )
     assert (
         df.groupby("a")
         .select("b")
         .last()
-        .sort(by_column="a")
+        .sort(by="a")
         .frame_equal(DataFrame({"a": ["a", "b", "c"], "": [3, 5, 6]}))
     )
     # check if it runs
@@ -522,3 +522,10 @@ def test_lazy_functions():
     expected = 3
     assert np.isclose(out[9], expected)
     assert np.isclose(pl.last(df["b"]), expected)
+
+
+def test_multiple_column_sort():
+    df = pl.DataFrame({"a": ["foo", "bar", "2"], "b": [2, 2, 3], "c": [1.0, 2.0, 3.0]})
+    out = df.sort([col("b"), col("c").reverse()])
+    assert out["c"] == [2, 3, 1]
+    assert out["b"] == [2, 2, 3]

--- a/py-polars/tests/test_series.py
+++ b/py-polars/tests/test_series.py
@@ -290,7 +290,6 @@ def test_describe():
     float_s = pl.Series([1.3, 4.6, 8.9])
     str_s = pl.Series(["abc", "pqr", "xyz"])
     bool_s = pl.Series([True, False, True, True])
-    list_s = pl.Series([[5.0, 6.0], [1.0, 2.0]])
     empty_s = pl.Series(np.empty(0))
 
     assert num_s.describe() == {
@@ -314,6 +313,3 @@ def test_describe():
 
     with pytest.raises(ValueError):
         assert empty_s.describe()
-
-    with pytest.raises(TypeError):
-        assert list_s.describe()


### PR DESCRIPTION
This adds sorting on multiple columns. This can be a combinatorial mess, so we are opinionated. The first column of sorting can be numeric or a `Utf8`. In case of numeric, we coerce other numeric columns to the same numeric (supertype). In case of `Utf8`, we coerce all numerics to `Float64` before doing comparissons. The sorting algorithm is an argsort, that falls back on the secondary columns in case of `equal` ordering of elements, when all secondary columns are depleted ordering remains `equal`.!

Some micro-benchmark comparissons with pandas:

![image](https://user-images.githubusercontent.com/3023000/117270302-5bc6a700-ae59-11eb-9b76-2934940c6619.png)


```python
import polars as pl
import numpy as np
from polars import col, lit
import pandas as pd
import matplotlib.pyplot as plt
import time
import string
import itertools

N = int(2e6)
n = len(string.ascii_letters)

strings = np.repeat(list(string.ascii_letters) * int(N / n), 4)[:N]
a = np.arange(N)

df = pd.DataFrame({
    "10i": np.repeat(a, 10)[:N],
    "2i": np.repeat(a, 2)[:N],
    "4s": strings
})
df
```
<div class="lm-Widget p-Widget jp-RenderedHTMLCommon jp-RenderedHTML jp-mod-trusted jp-OutputArea-output" data-mime-type="text/html"><div>



  | 10i | 2i | 4s
-- | -- | -- | --
0 | 0 | a
0 | 0 | a
0 | 1 | a
0 | 1 | a
0 | 2 | b
... | ... | ...
199999 | 999997 | s
199999 | 999998 | t
199999 | 999998 | t
199999 | 999999 | t
199999 | 999999 | t


<p>2000000 rows × 3 columns</p>
</div></div>

```python
perm = list(itertools.permutations(["10i", "2i", "4s"], 3))
perm
```

```text
[('10i', '2i', '4s'),
 ('10i', '4s', '2i'),
 ('2i', '10i', '4s'),
 ('2i', '4s', '10i'),
 ('4s', '10i', '2i'),
 ('4s', '2i', '10i')]
````

```python
pd_results = {}
for p in perm:
    for i in range(1, 4):
        cols = p[:i]
        
        t0 = time.time()
        df.sort_values(list(cols))
        t = time.time() - t0
        print(cols, t)
        
        pd_results[cols] = t
df = pl.from_pandas(df)
pl_results = {}
for p in perm:
    for i in range(1, 4):
        cols = p[:i]
        
        t0 = time.time()
        df.sort(list(cols))
        t = time.time() - t0
        print(cols, t)
        
        pl_results[cols] = t

labels = [str(s) for s in a[:, 0]]
a = np.array(list(pd_results.items()))
plt.barh(labels, a[:, 1], color="C1", label="pandas sort")
a = np.array(list(pl_results.items()))
plt.barh(labels, a[:, 1], color="C0", label="polars sort")
plt.legend()
````
